### PR TITLE
Fix: Index only code files (resolves #1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,10 @@ When the user says "continue" or similar, follow this pattern:
 
 ## 📍 CURRENT STATE
 
-**Phase:** v0.1.0 RELEASED ✅
-**Last Session:** 2025-10-15 (Session 15 - Release)
-**Last Completed:** v0.1.0 MVP release tagged and documented
-**Active Work:** None - ready for v0.2 planning or user feedback
+**Phase:** v0.1.1 Development (Post-MVP)
+**Last Session:** 2025-10-17 (Session 16 - Issue #1 Fix)
+**Last Completed:** File extension filtering (issue #1) - code files only
+**Active Work:** Creating PR for file filtering feature
 **Blockers:** None
 
 ---

--- a/README.md
+++ b/README.md
@@ -253,10 +253,22 @@ max_file_mb = 5  # Skip files larger than this
 >
 > See [docs/AUDIT.md](docs/AUDIT.md) for details on this limitation.
 
-**Respects (v0.1):**
-- `.gitignore` (automatically applied - files tracked by git are indexed)
-- `.emberignore` (optional, same format as .gitignore)
-- **Git tracking**: Only files in `git ls-files` are indexed
+**File Indexing (v0.1):**
+- **Code files only**: Only source code files are indexed (see supported extensions below)
+- **Git tracking**: Only files tracked by git are candidates for indexing
+- `.gitignore`: Automatically respected (untracked files are skipped)
+- `.emberignore`: Optional, same format as .gitignore
+
+**Indexed file extensions:**
+`.py`, `.pyi`, `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`, `.go`, `.rs`, `.java`, `.kt`, `.scala`, `.c`, `.cpp`, `.cc`, `.cxx`, `.h`, `.hpp`, `.hh`, `.hxx`, `.cs`, `.rb`, `.php`, `.swift`, `.sh`, `.bash`, `.zsh`, `.vue`, `.svelte`, `.sql`, `.proto`, `.graphql`
+
+**Skipped files (not indexed):**
+- Documentation: `.md`, `.txt`, `.rst`, `.adoc`
+- Data/Config: `.json`, `.yaml`, `.yml`, `.toml`, `.xml`, `.csv`
+- Binary files: `.png`, `.jpg`, `.jpeg`, `.gif`, `.pdf`, `.zip`, etc.
+- Build artifacts: `.pyc`, `.class`, `.o`, `.so`, `.dll`, `.exe`
+- Lock files: `.lock`, `.sum`
+- Other non-code files
 
 ---
 
@@ -443,7 +455,7 @@ A: No. Everything runs locally. The embedding model downloads once from HuggingF
 A: Not yet, but this is planned. The architecture supports swapping models via the `Embedder` protocol.
 
 **Q: What about binary files / images / PDFs?**
-A: Ember currently only indexes text-based source code. Binary files are skipped.
+A: Ember only indexes source code files with recognized code extensions (see Configuration section). Binary files, documentation, and data files are automatically skipped during indexing.
 
 **Q: How do I exclude sensitive files?**
 A: In v0.1, use `.gitignore` or `.emberignore` to exclude files. Note that `.ember/config.toml` settings (including `ignore` patterns) are not yet active in v0.1.

--- a/ember/core/indexing/index_usecase.py
+++ b/ember/core/indexing/index_usecase.py
@@ -26,6 +26,37 @@ from ember.ports.repositories import (
 )
 from ember.ports.vcs import VCS
 
+# Code file extensions to index (whitelist approach)
+# Only source code files are indexed - data, config, docs, and binary files are skipped
+CODE_FILE_EXTENSIONS = frozenset({
+    # Python
+    ".py", ".pyi",
+    # JavaScript/TypeScript
+    ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs",
+    # Go
+    ".go",
+    # Rust
+    ".rs",
+    # Java/JVM
+    ".java", ".kt", ".scala",
+    # C/C++
+    ".c", ".cpp", ".cc", ".cxx", ".h", ".hpp", ".hh", ".hxx",
+    # C#
+    ".cs",
+    # Ruby
+    ".rb",
+    # PHP
+    ".php",
+    # Swift
+    ".swift",
+    # Shell
+    ".sh", ".bash", ".zsh",
+    # Web frameworks
+    ".vue", ".svelte",
+    # Other
+    ".sql", ".proto", ".graphql",
+})
+
 
 @dataclass
 class IndexRequest:
@@ -257,6 +288,9 @@ class IndexingUseCase:
             files = [repo_root / f for f in relative_files]
             is_incremental = True
 
+        # Filter to only include code files (skip docs, data, binary files)
+        files = [f for f in files if self._is_code_file(f)]
+
         # Apply path filters if provided
         if path_filters:
             # Simple filtering for now (exact match or contains)
@@ -450,6 +484,18 @@ class IndexingUseCase:
             chunks.append(chunk)
 
         return chunks
+
+    def _is_code_file(self, file_path: Path) -> bool:
+        """Check if file is a code file that should be indexed.
+
+        Args:
+            file_path: Path to file.
+
+        Returns:
+            True if file should be indexed, False otherwise.
+        """
+        suffix = file_path.suffix.lower()
+        return suffix in CODE_FILE_EXTENSIONS
 
     def _detect_language(self, file_path: Path) -> str:
         """Detect language from file extension.


### PR DESCRIPTION
## Summary
- Fixes issue #1: Ember now only indexes source code files
- Added whitelist of 30+ code file extensions
- Automatically skips documentation (.md, .txt), data files (.json, .yaml), and binary files (.png, .pdf)

## Changes
- **Core**: Added `CODE_FILE_EXTENSIONS` constant and `_is_code_file()` filter method
- **Filtering**: Applied in `IndexingUseCase._get_files_to_index()` before processing
- **Documentation**: Updated README.md with explicit list of indexed/skipped extensions
- **State tracking**: Updated CLAUDE.md to reflect v0.1.1 development

## Testing
✅ All 103 tests passing  
✅ Manual verification: Ember repo (67 .py files indexed, 30+ non-code files skipped)  
✅ No .md, .json, .toml, .png files indexed  

## Indexed Extensions
Python, JS/TS, Go, Rust, Java/JVM, C/C++, C#, Ruby, PHP, Swift, Shell, Web frameworks, SQL, Proto, GraphQL

## Behavior
**Before**: All git-tracked files attempted (caused errors on binaries)  
**After**: Only recognized code files indexed, others silently skipped

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)