### PR TITLE
fix(indexing): prevent deletion of unchanged file chunks during incremental sync

### DIFF
--- a/ember/core/indexing/index_usecase.py
+++ b/ember/core/indexing/index_usecase.py
@@ -210,11 +210,6 @@ class IndexingUseCase:
             if progress and files_to_index:
                 progress.on_complete()
 
-            # Clean up old tree SHA chunks (keeps only current tree_sha)
-            # This ensures we don't accumulate stale chunks across syncs
-            stale_deleted = self.chunk_repo.delete_old_tree_shas(tree_sha)
-            chunks_deleted += stale_deleted
-
             # Update metadata with new tree SHA
             self.meta_repo.set("last_tree_sha", tree_sha)
             self.meta_repo.set("last_sync_mode", request.sync_mode)


### PR DESCRIPTION
Fixes #9

## Problem
When staging a file, running `ember sync` incorrectly deleted all existing chunks from the database, resulting in complete loss of the codebase index.

### Reproduction
1. Initialize and sync a codebase with multiple files
2. Stage a new file without committing: `git add newfile.py`
3. Run `ember sync`
4. **Result**: All chunks from existing files are deleted

## Root Cause
During incremental sync, `delete_old_tree_shas()` in `ember/core/indexing/index_usecase.py:215` was deleting **ALL** chunks that didn't match the current tree SHA. 

The issue: when only changed files are re-indexed with the new tree SHA, unchanged files' chunks (which still have the old tree SHA) are incorrectly deleted.

## Solution
Removed the blanket `delete_old_tree_shas()` call. Per-file cleanup in `_index_file()` (lines 382-384) already handles removing old chunks when files are re-indexed, making the global cleanup unnecessary and harmful.

## Testing
- ✅ All 103 existing tests pass
- ✅ Manual verification with reproduction steps: staging a file no longer deletes existing chunks
- ✅ Incremental sync now correctly preserves chunks from unchanged files

## Impact
- **Severity**: Critical bug fix - prevents data loss
- **Breaking Changes**: None
- **Performance**: Slightly improved (fewer deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)