### PR TITLE
perf(cli): implement lazy loading for 25x faster startup

### DIFF
--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -10,24 +10,6 @@ import blake3
 import click
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn
 
-from ember.adapters.local_models.jina_embedder import JinaCodeEmbedder
-from ember.adapters.fs.local import LocalFileSystem
-from ember.adapters.fts.sqlite_fts import SQLiteFTS
-from ember.adapters.git_cmd.git_adapter import GitAdapter
-from ember.adapters.parsers.line_chunker import LineChunker
-from ember.adapters.parsers.tree_sitter_chunker import TreeSitterChunker
-from ember.adapters.sqlite.chunk_repository import SQLiteChunkRepository
-from ember.adapters.sqlite.file_repository import SQLiteFileRepository
-from ember.adapters.sqlite.meta_repository import SQLiteMetaRepository
-from ember.adapters.sqlite.vector_repository import SQLiteVectorRepository
-from ember.adapters.vss.simple_vector_search import SimpleVectorSearch
-from ember.core.chunking.chunk_usecase import ChunkFileUseCase
-from ember.core.config.init_usecase import InitRequest, InitUseCase
-from ember.core.indexing.index_usecase import IndexingUseCase, IndexRequest
-from ember.core.retrieval.search_usecase import SearchUseCase
-from ember.domain.entities import Query
-from ember.ports.progress import ProgressCallback
-
 
 class RichProgressCallback:
     """Rich-based progress callback for visual progress reporting.
@@ -105,6 +87,9 @@ def init(ctx: click.Context, force: bool) -> None:
 
     Creates .ember/ directory with configuration and database.
     """
+    # Lazy import - only load when init is actually called
+    from ember.core.config.init_usecase import InitRequest, InitUseCase
+
     repo_root = Path.cwd().resolve()
 
     # Create use case and execute
@@ -187,6 +172,19 @@ def sync(
         sync_mode = "worktree"
 
     try:
+        # Lazy imports - only load heavy dependencies when sync is actually called
+        from ember.adapters.local_models.jina_embedder import JinaCodeEmbedder
+        from ember.adapters.fs.local import LocalFileSystem
+        from ember.adapters.git_cmd.git_adapter import GitAdapter
+        from ember.adapters.parsers.line_chunker import LineChunker
+        from ember.adapters.parsers.tree_sitter_chunker import TreeSitterChunker
+        from ember.adapters.sqlite.chunk_repository import SQLiteChunkRepository
+        from ember.adapters.sqlite.file_repository import SQLiteFileRepository
+        from ember.adapters.sqlite.meta_repository import SQLiteMetaRepository
+        from ember.adapters.sqlite.vector_repository import SQLiteVectorRepository
+        from ember.core.chunking.chunk_usecase import ChunkFileUseCase
+        from ember.core.indexing.index_usecase import IndexingUseCase, IndexRequest
+
         # Initialize dependencies
         vcs = GitAdapter(repo_root)
         fs = LocalFileSystem()
@@ -329,6 +327,14 @@ def find(
         sys.exit(1)
 
     try:
+        # Lazy imports - only load heavy dependencies when find is actually called
+        from ember.adapters.local_models.jina_embedder import JinaCodeEmbedder
+        from ember.adapters.fts.sqlite_fts import SQLiteFTS
+        from ember.adapters.sqlite.chunk_repository import SQLiteChunkRepository
+        from ember.adapters.vss.simple_vector_search import SimpleVectorSearch
+        from ember.core.retrieval.search_usecase import SearchUseCase
+        from ember.domain.entities import Query
+
         # Initialize dependencies
         text_search = SQLiteFTS(db_path)
         vector_search = SimpleVectorSearch(db_path)

--- a/profile_startup.py
+++ b/profile_startup.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Profile CLI startup time to identify bottlenecks."""
+
+import time
+import sys
+
+def time_import(module_name: str) -> float:
+    """Time how long it takes to import a module."""
+    start = time.perf_counter()
+    __import__(module_name)
+    duration = time.perf_counter() - start
+    return duration
+
+print("Profiling ember CLI startup...")
+print("=" * 60)
+
+# Time individual heavy imports
+modules_to_test = [
+    "click",
+    "rich.progress",
+    "blake3",
+    "ember.adapters.local_models.jina_embedder",
+    "ember.adapters.parsers.tree_sitter_chunker",
+    "ember.adapters.sqlite.chunk_repository",
+    "ember.entrypoints.cli",
+]
+
+results = []
+for module in modules_to_test:
+    try:
+        duration = time_import(module)
+        results.append((module, duration))
+        print(f"{module:50} {duration*1000:>8.1f} ms")
+    except ImportError as e:
+        print(f"{module:50} FAILED: {e}")
+
+print("=" * 60)
+print(f"{'TOTAL':50} {sum(d for _, d in results)*1000:>8.1f} ms")
+
+# Now time the full CLI import
+print("\nFull CLI module import:")
+start = time.perf_counter()
+from ember.entrypoints import cli
+duration = time.perf_counter() - start
+print(f"{'ember.entrypoints.cli':50} {duration*1000:>8.1f} ms")


### PR DESCRIPTION
Fixes #5

## Problem
CLI startup took ~1.76s even for simple commands like `--help` because all heavy dependencies (PyTorch embeddings, tree-sitter, etc.) were imported at module load time.

## Solution
Moved heavy imports inside command functions that actually use them:
- `JinaCodeEmbedder` (1.4s load time) now only loads for `sync` and `find` commands
- `TreeSitterChunker` only loads for `sync` command  
- Other adapters and use cases load on-demand per command

## Results
| Command | Before | After | Improvement |
|---------|--------|-------|-------------|
| `ember --help` | 1.76s | 0.069s | **25x faster** |
| `ember --version` | ~1.75s | 0.060s | **29x faster** |
| `ember find --help` | ~1.75s | 0.063s | **28x faster** |

Overall startup time reduced by **96%** for lightweight commands.

## Testing
✅ All 103 tests pass  
✅ Verified `--help`, `--version`, and command help are fast  
✅ Heavy commands (`sync`, `find`) still work correctly with lazy loading  
✅ No functionality changes - purely performance optimization

## Technical Details
The main culprit was `JinaCodeEmbedder` taking 1.4s to load PyTorch models. By deferring this import until actually needed (only in `sync` and `find` commands), we avoid this cost for informational commands.

Added `profile_startup.py` to measure import times for future debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)