### PR TITLE
Fix: Remove repetitive error message in init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Removed repetitive error message when running `ember init` with existing .ember/ directory
+
 ### Changed
 - Simplified CLAUDE.md to be more concise (~50% reduction)
 - Moved detailed maintainer procedures to MAINTAINER_GUIDE.md

--- a/ember/core/config/init_usecase.py
+++ b/ember/core/config/init_usecase.py
@@ -87,7 +87,7 @@ class InitUseCase:
         if ember_dir.exists():
             if not request.force:
                 raise FileExistsError(
-                    f"Directory {ember_dir} already exists. Use --force to reinitialize."
+                    f"Directory {ember_dir} already exists"
                 )
             was_reinitialized = True
 


### PR DESCRIPTION
Resolves #19

## Problem

When running `ember init` with an existing .ember/ directory, users saw the same message twice:

```
Error: Directory /path/.ember already exists. Use --force to reinitialize.
Use 'ember init --force' to reinitialize
```

This was confusing and redundant.

## Solution

Simplified the `FileExistsError` message in `init_usecase.py` to just state the error:
- **Before:** `"Directory {path} already exists. Use --force to reinitialize."`
- **After:** `"Directory {path} already exists"`

The CLI already provides the helpful instruction on the next line, so no information is lost.

## Result

Now users see a cleaner error message:

```
Error: Directory /path/.ember already exists
Use 'ember init --force' to reinitialize
```

## Testing

✅ All 108 tests pass
✅ Init integration tests verify error handling still works correctly
✅ Checked other commands - no similar issues found

## Notes

Audited other CLI commands (`sync`, `find`, `cat`, `open`) and confirmed they all have appropriate two-line error messages where the first line states the error and the second provides guidance. Only `init` had actual redundancy.