### PR TITLE
feat: implement auto-sync on search (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Auto-sync on search**: `ember find` now automatically syncs the index before searching (#26)
+  - Detects stale index by comparing current git tree SHA vs last indexed SHA
+  - Runs incremental sync automatically if changes detected (typically <2s overhead)
+  - Shows clear progress: "Detected changes, syncing index... ✓ Synced N file(s) in X.Xs"
+  - Ensures users never get stale search results
+  - Added `--no-sync` flag to skip auto-sync for power users who want maximum speed
+  - Silent in JSON mode (messages go to stderr, not stdout)
+  - Added 4 new integration tests for auto-sync behavior
 - **Functional config system**: `.ember/config.toml` settings are now loaded and respected (#25)
   - `search.topk`: Default number of search results (overridable with `-k` flag)
   - `index.line_window`: Lines per chunk for line-based chunking
@@ -27,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved detailed maintainer procedures to MAINTAINER_GUIDE.md
 - Reorganized documentation structure for better discoverability
 - Updated README to document functional config settings
-- Updated README to reflect 116 passing tests (up from 103)
+- Updated README to reflect 120 passing tests (up from 103)
 
 ### Fixed
 - Removed repetitive error message when running `ember init` with existing .ember/ directory

--- a/tests/integration/test_auto_sync.py
+++ b/tests/integration/test_auto_sync.py
@@ -1,0 +1,211 @@
+"""Integration tests for auto-sync on search functionality."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def auto_sync_repo(tmp_path: Path) -> Path:
+    """Create a test git repo for auto-sync testing."""
+    repo = tmp_path / "test-repo"
+    repo.mkdir()
+
+    # Initialize git repo
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+    # Create initial file
+    test_file = repo / "test.py"
+    test_file.write_text("def foo(): pass\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+    # Initialize ember
+    import os
+
+    cwd = os.getcwd()
+    os.chdir(repo)
+    try:
+        from ember.entrypoints.cli import init, sync
+        from click.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(init, [], obj={}, catch_exceptions=False)
+        assert result.exit_code == 0
+
+        # Initial sync
+        result = runner.invoke(sync, [], obj={}, catch_exceptions=False)
+        assert result.exit_code == 0
+    finally:
+        os.chdir(cwd)
+
+    return repo
+
+
+def test_auto_sync_on_stale_index(auto_sync_repo: Path) -> None:
+    """Test that find auto-syncs when index is stale."""
+    import os
+    from click.testing import CliRunner
+
+    from ember.entrypoints.cli import find
+
+    # Modify file to make index stale
+    test_file = auto_sync_repo / "test.py"
+    test_file.write_text("def foo(): pass\ndef bar(): pass\n")
+    subprocess.run(
+        ["git", "add", "."], cwd=auto_sync_repo, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "add bar"],
+        cwd=auto_sync_repo,
+        check=True,
+        capture_output=True,
+    )
+
+    # Run find - should auto-sync
+    cwd = os.getcwd()
+    os.chdir(auto_sync_repo)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(
+            find, ["function"], obj={}, catch_exceptions=False
+        )
+    finally:
+        os.chdir(cwd)
+
+    assert result.exit_code == 0
+    # Should see sync message in stderr
+    assert "Detected changes, syncing index" in result.stderr or "Synced" in result.stderr
+    # Should find the new function
+    assert "bar" in result.stdout
+
+
+def test_auto_sync_skipped_with_no_sync_flag(auto_sync_repo: Path) -> None:
+    """Test that --no-sync flag skips auto-sync."""
+    import os
+    from click.testing import CliRunner
+
+    from ember.entrypoints.cli import find
+
+    # Modify file to make index stale
+    test_file = auto_sync_repo / "test.py"
+    test_file.write_text("def foo(): pass\ndef baz(): pass\n")
+    subprocess.run(
+        ["git", "add", "."], cwd=auto_sync_repo, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "add baz"],
+        cwd=auto_sync_repo,
+        check=True,
+        capture_output=True,
+    )
+
+    # Run find with --no-sync - should NOT auto-sync
+    cwd = os.getcwd()
+    os.chdir(auto_sync_repo)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(
+            find, ["function", "--no-sync"], obj={}, catch_exceptions=False
+        )
+    finally:
+        os.chdir(cwd)
+
+    assert result.exit_code == 0
+    # Should NOT see sync message
+    assert "Syncing" not in result.stderr
+    assert "Detected changes" not in result.stderr
+    # Should NOT find the new function (stale results)
+    assert "baz" not in result.stdout
+
+
+def test_auto_sync_noop_when_up_to_date(auto_sync_repo: Path) -> None:
+    """Test that auto-sync is a no-op when index is up to date."""
+    import os
+    from click.testing import CliRunner
+
+    from ember.entrypoints.cli import find
+
+    # Run find twice - second time should not sync
+    cwd = os.getcwd()
+    os.chdir(auto_sync_repo)
+    try:
+        runner = CliRunner()
+
+        # First find
+        result1 = runner.invoke(
+            find, ["function"], obj={}, catch_exceptions=False
+        )
+        assert result1.exit_code == 0
+
+        # Second find - index is up to date, should not sync
+        result2 = runner.invoke(
+            find, ["function"], obj={}, catch_exceptions=False
+        )
+        assert result2.exit_code == 0
+        # Should not see sync messages when already up to date
+        # (No "Synced X files" message, just search results)
+        assert "Synced" not in result2.stderr
+    finally:
+        os.chdir(cwd)
+
+
+def test_auto_sync_with_json_output(auto_sync_repo: Path) -> None:
+    """Test that auto-sync works with --json output."""
+    import os
+    from click.testing import CliRunner
+
+    from ember.entrypoints.cli import find
+
+    # Modify file
+    test_file = auto_sync_repo / "test.py"
+    test_file.write_text("def foo(): pass\ndef qux(): pass\n")
+    subprocess.run(
+        ["git", "add", "."], cwd=auto_sync_repo, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "add qux"],
+        cwd=auto_sync_repo,
+        check=True,
+        capture_output=True,
+    )
+
+    # Run find with --json
+    cwd = os.getcwd()
+    os.chdir(auto_sync_repo)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(
+            find, ["function", "--json"], obj={}, catch_exceptions=False
+        )
+    finally:
+        os.chdir(cwd)
+
+    assert result.exit_code == 0
+    # Sync messages should go to stderr, not stdout
+    assert "Synced" not in result.stdout
+    # stdout should be valid JSON
+    import json
+
+    data = json.loads(result.stdout)
+    assert isinstance(data, list)
+    # Should find the new function
+    assert any("qux" in str(item) for item in data)


### PR DESCRIPTION
## Summary

Implements zero-friction search workflow by automatically syncing the index when changes are detected. Users never need to manually run `ember sync` before searching.

**Key Features:**
- ✅ Auto-detects stale index by comparing git tree SHAs
- ✅ Runs incremental sync before search if changes detected  
- ✅ Shows clear progress: "Detected changes, syncing... ✓ Synced N files in Xs"
- ✅ Added `--no-sync` flag for power users who want speed
- ✅ Silent in JSON mode (messages to stderr, not stdout)

## Implementation Details

**Staleness Detection:**
- Compares current `worktree_tree_sha` vs `last_tree_sha` from metadata
- If different, index is stale and needs sync

**Auto-Sync:**
- Reuses existing `IndexingUseCase` with incremental mode
- Typical overhead: <2s for incremental sync
- Graceful error handling - continues search even if sync fails

**User Control:**
- Default: Always sync (zero-friction, always current)
- `--no-sync`: Skip sync check (faster, may return stale results)

## Testing

**New Tests:** 4 integration tests (`tests/integration/test_auto_sync.py`)
- ✅ Auto-sync on stale index
- ✅ `--no-sync` flag skips sync
- ✅ No-op when index is already up to date
- ✅ Works correctly with `--json` output

**Test Results:** All 120 tests passing

## Success Criteria (from #26)

- ✅ User never gets stale results (unless using `--no-sync`)
- ✅ <2s overhead for typical incremental sync
- ✅ Clear feedback about what's happening
- ✅ Tests verify auto-sync behavior

## Example Usage

```bash
# Make changes to a file
echo "def new_func(): pass" >> code.py
git add code.py && git commit -m "add func"

# Search - automatically syncs first
ember find "function"
# Output:
# Detected changes, syncing index...
# ✓ Synced 1 file(s) in 1.8s
# code.py
# [1] 1:def new_func(): pass

# Power user mode - skip sync for speed
ember find "function" --no-sync
# (no sync message, returns immediately)
```

## Files Changed

- `ember/entrypoints/cli.py`: Added auto-sync logic and `--no-sync` flag to `find` command
- `tests/integration/test_auto_sync.py`: New test file with 4 integration tests
- `CHANGELOG.md`: Documented the new feature

Closes #26

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)