### PR TITLE
fix: prevent data loss when chunking fails during re-indexing (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated README with clarified test running instructions
 
 ### Fixed
+- **Data loss risk in indexing**: Fixed potential chunk deletion when re-indexing fails (#33)
+  - Moved chunk deletion to occur AFTER validating chunking succeeds
+  - When chunking fails, existing chunks are now preserved instead of deleted
+  - Prevents silent data loss when files fail to parse or chunk
+  - Added regression test to verify existing chunks preserved on chunking failure
 - **Model loading now uses local cache**: Fixed HuggingFace connection timeouts
   - Added `local_files_only=True` to force using cached model files
   - Prevents network calls to HuggingFace when model is already cached


### PR DESCRIPTION
## Problem

**CRITICAL:** The `_index_file` method deleted all chunks for a file BEFORE validating that chunking succeeded. If chunking failed, chunks were deleted but not replaced, resulting in data loss.

**Before:** 
```python
# Line 388: DELETE FIRST (risky!)
self.chunk_repo.delete_all_for_path(path=rel_path)

# Lines 398-403: Try to chunk file
chunk_response = self.chunk_usecase.execute(chunk_request)

# Lines 405-407: VALIDATION TOO LATE
if not chunk_response.success:
    return {"chunks_created": 0, ...}  # File now has NO chunks!
```

**Impact:**
- If chunking failed (syntax error, encoding issue, etc.), file became unindexed
- No way to recover chunks without re-indexing entire repo
- Silent data loss - user doesn't know file was dropped

## Solution

Moved chunk deletion to occur AFTER chunking validation:

```python
# Read and chunk file first
chunk_response = self.chunk_usecase.execute(chunk_request)

# VALIDATE FIRST
if not chunk_response.success:
    # Skip files that fail to chunk - preserve existing chunks to avoid data loss
    return {"chunks_created": 0, "chunks_updated": 0, "vectors_stored": 0}

# THEN DELETE (safe)
self.chunk_repo.delete_all_for_path(path=rel_path)
```

## Testing

Added regression test `test_chunking_failure_preserves_existing_chunks`:
- Indexes a file successfully
- Mocks chunker to fail on re-indexing
- Verifies original chunks are preserved (not deleted)

All 91 fast tests pass.

## Changes

- `ember/core/indexing/index_usecase.py:382-409` - Moved delete operation after validation
- `tests/integration/test_indexing_usecase.py:372-432` - Added regression test
- `CHANGELOG.md` - Documented fix

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)