### PR TITLE
fix: filter path-scoped search during SQL query instead of after (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Path-scoped search now filters during SQL query instead of after retrieval** (#52)
+  - Previously, path filtering happened after retrieving results, which could return fewer results than requested
+  - Example: `ember find "query" tests/ -k 5` might only return 2 results if only 2 of the top-5 global results were in `tests/`
+  - Now filters during SQL queries (both FTS5 and sqlite-vec), guaranteeing full topk results from filtered paths
+  - Significantly improves performance by filtering earlier in the pipeline
+  - Adds regression test to ensure path filtering returns full topk results
+
 ### Added
 - **Subdirectory support** - Run ember from anywhere in your repository (#43)
   - All commands now work from any subdirectory, like git

--- a/ember/adapters/fts/sqlite_fts.py
+++ b/ember/adapters/fts/sqlite_fts.py
@@ -44,12 +44,15 @@ class SQLiteFTS:
         # No-op: FTS5 table is automatically synced via triggers
         pass
 
-    def query(self, q: str, topk: int = 100) -> list[tuple[str, float]]:
+    def query(
+        self, q: str, topk: int = 100, path_filter: str | None = None
+    ) -> list[tuple[str, float]]:
         """Query the FTS5 index using SQLite full-text search.
 
         Args:
             q: Query string (supports FTS5 query syntax like AND, OR, NEAR, quotes).
             topk: Maximum number of results to return.
+            path_filter: Optional glob pattern to filter results by path.
 
         Returns:
             List of (chunk_id, score) tuples, sorted by relevance (descending).
@@ -62,22 +65,42 @@ class SQLiteFTS:
             # Query FTS5 table and join with chunks to get chunk metadata
             # FTS5's rank is negative (closer to 0 = better), so we negate it
             # to get a positive score where higher = more relevant
-            cursor.execute(
-                """
-                SELECT
-                    c.project_id,
-                    c.path,
-                    c.start_line,
-                    c.end_line,
-                    -rank AS score
-                FROM chunk_text
-                JOIN chunks c ON chunk_text.rowid = c.id
-                WHERE chunk_text MATCH ?
-                ORDER BY rank
-                LIMIT ?
-                """,
-                (q, topk),
-            )
+            # Add path filtering if specified
+            if path_filter:
+                cursor.execute(
+                    """
+                    SELECT
+                        c.project_id,
+                        c.path,
+                        c.start_line,
+                        c.end_line,
+                        -rank AS score
+                    FROM chunk_text
+                    JOIN chunks c ON chunk_text.rowid = c.id
+                    WHERE chunk_text MATCH ?
+                      AND c.path GLOB ?
+                    ORDER BY rank
+                    LIMIT ?
+                    """,
+                    (q, path_filter, topk),
+                )
+            else:
+                cursor.execute(
+                    """
+                    SELECT
+                        c.project_id,
+                        c.path,
+                        c.start_line,
+                        c.end_line,
+                        -rank AS score
+                    FROM chunk_text
+                    JOIN chunks c ON chunk_text.rowid = c.id
+                    WHERE chunk_text MATCH ?
+                    ORDER BY rank
+                    LIMIT ?
+                    """,
+                    (q, topk),
+                )
 
             rows = cursor.fetchall()
             results = []

--- a/ember/adapters/vss/sqlite_vec_adapter.py
+++ b/ember/adapters/vss/sqlite_vec_adapter.py
@@ -190,6 +190,7 @@ class SqliteVecAdapter:
         self,
         vector: list[float],
         topk: int = 100,
+        path_filter: str | None = None,
     ) -> list[tuple[str, float]]:
         """Query for nearest neighbors using sqlite-vec.
 
@@ -198,6 +199,7 @@ class SqliteVecAdapter:
         Args:
             vector: Query embedding vector.
             topk: Maximum number of results to return.
+            path_filter: Optional glob pattern to filter results by path.
 
         Returns:
             List of (chunk_id, similarity) tuples, sorted by similarity (descending).
@@ -215,23 +217,44 @@ class SqliteVecAdapter:
 
             # Query vec0 table for nearest neighbors
             # sqlite-vec returns distance, we need to convert to similarity
-            cursor.execute(
-                """
-                SELECT
-                    m.project_id,
-                    m.path,
-                    m.start_line,
-                    m.end_line,
-                    v.distance
-                FROM vec_chunks v
-                JOIN vec_chunk_mapping m ON v.rowid = m.vec_rowid
-                WHERE v.embedding MATCH ?
-                  AND k = ?
-                ORDER BY v.distance
-                LIMIT ?
-                """,
-                (serialized_vector, topk, topk),
-            )
+            # Add path filtering if specified
+            if path_filter:
+                cursor.execute(
+                    """
+                    SELECT
+                        m.project_id,
+                        m.path,
+                        m.start_line,
+                        m.end_line,
+                        v.distance
+                    FROM vec_chunks v
+                    JOIN vec_chunk_mapping m ON v.rowid = m.vec_rowid
+                    WHERE v.embedding MATCH ?
+                      AND k = ?
+                      AND m.path GLOB ?
+                    ORDER BY v.distance
+                    LIMIT ?
+                    """,
+                    (serialized_vector, topk, path_filter, topk),
+                )
+            else:
+                cursor.execute(
+                    """
+                    SELECT
+                        m.project_id,
+                        m.path,
+                        m.start_line,
+                        m.end_line,
+                        v.distance
+                    FROM vec_chunks v
+                    JOIN vec_chunk_mapping m ON v.rowid = m.vec_rowid
+                    WHERE v.embedding MATCH ?
+                      AND k = ?
+                    ORDER BY v.distance
+                    LIMIT ?
+                    """,
+                    (serialized_vector, topk, topk),
+                )
 
             rows = cursor.fetchall()
             results = []

--- a/ember/ports/search.py
+++ b/ember/ports/search.py
@@ -19,12 +19,15 @@ class TextSearch(Protocol):
         """
         ...
 
-    def query(self, q: str, topk: int = 100) -> list[tuple[str, float]]:
+    def query(
+        self, q: str, topk: int = 100, path_filter: str | None = None
+    ) -> list[tuple[str, float]]:
         """Query the text search index.
 
         Args:
             q: Query string (may use FTS query syntax).
             topk: Maximum number of results to return.
+            path_filter: Optional glob pattern to filter results by path.
 
         Returns:
             List of (chunk_id, score) tuples, sorted by relevance (descending).
@@ -48,12 +51,14 @@ class VectorSearch(Protocol):
         self,
         vector: list[float],
         topk: int = 100,
+        path_filter: str | None = None,
     ) -> list[tuple[str, float]]:
         """Query for nearest neighbors.
 
         Args:
             vector: Query embedding vector.
             topk: Maximum number of results to return.
+            path_filter: Optional glob pattern to filter results by path.
 
         Returns:
             List of (chunk_id, distance) tuples, sorted by distance (ascending).


### PR DESCRIPTION
## Summary  
Fixes path-scoped search to filter during SQL queries instead of after retrieval, ensuring users always get the requested number of results from the filtered path.

## Problem
Path filtering happened AFTER retrieving top-k results globally:
```bash
cd tests/
ember find "daemon initialization" -k 5 .
# Expected: 5 results from tests/
# Actual: Only 3 results (because only 3 of the global top-5 were in tests/)
```

This made path-scoped search unreliable and confusing.

## Solution
Move path filtering into SQL WHERE clauses:
- FTS5: `WHERE chunk_text MATCH ? AND c.path GLOB ?`
- sqlite-vec: `WHERE v.embedding MATCH ? AND m.path GLOB ?`

Now we retrieve top-k FROM the filtered set, not filter after retrieval.

## Changes

### Protocol Updates
- `TextSearch.query()` - added `path_filter: str | None` parameter
- `VectorSearch.query()` - added `path_filter: str | None` parameter

### Adapter Updates
- `SQLiteFTS.query()` - added path filtering to WHERE clause when path_filter specified
- `SqliteVecAdapter.query()` - added path filtering to WHERE clause when path_filter specified

### SearchUseCase Updates
- Pass `path_filter` to both text_search and vector_search queries
- Simplified `_apply_filters()` to only handle `lang_filter` (path filtering now in SQL)

### Testing
- Added regression test `test_path_filter_returns_full_topk()`
- Creates 10 chunks in `src/`, 10 in `tests/`
- Searches with path filter and verifies full topk returned
- All 149 tests passing

## Example
**Before:**
```bash
cd tests/
ember find "daemon" -k 5 .
# Returns 2 results (only 2 of global top-5 were in tests/)
```

**After:**
```bash
cd tests/
ember find "daemon" -k 5 .
# Returns 5 results (all from tests/)
```

## Performance Impact
**Better performance** - filtering during SQL query is more efficient than:
1. Retrieving 100+ results globally
2. Fusing with RRF
3. Filtering down to path

Now we only retrieve/fuse results from the filtered path.

## Testing
```bash
# All tests pass
uv run pytest  # 149 passed

# New test verifies path filtering correctness
uv run pytest tests/integration/test_search_usecase.py::test_path_filter_returns_full_topk -v
```

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>