### PR TITLE
fix: progress bar stays in fixed position during indexing (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Now filters during SQL queries (both FTS5 and sqlite-vec), guaranteeing full topk results from filtered paths
   - Significantly improves performance by filtering earlier in the pipeline
   - Adds regression test to ensure path filtering returns full topk results
+- **Progress bar stays in fixed position during indexing** (#44)
+  - Progress bar no longer jumps horizontally as filenames change
+  - Filename now appears after the progress percentage in a separate column
+  - Makes progress display smooth and easier to read
+  - Format: `⠋ Indexing files ━━━━━━━━━━━━━━━━━━━━ 50% src/adapters/file.py`
 
 ### Added
 - **Subdirectory support** - Run ember from anywhere in your repository (#43)

--- a/ember/core/cli_utils.py
+++ b/ember/core/cli_utils.py
@@ -32,18 +32,17 @@ class RichProgressCallback:
     def on_start(self, total: int, description: str) -> None:
         """Create progress bar when operation starts."""
         # Use transient=True to auto-hide when complete
-        self.task_id = self.progress.add_task(description, total=total)
+        # Initialize with empty current_file field
+        self.task_id = self.progress.add_task(description, total=total, current_file="")
 
     def on_progress(self, current: int, item_description: str | None = None) -> None:
         """Update progress bar with current item."""
         if self.task_id is not None:
-            # Update the task description to show current file
-            if item_description:
-                self.progress.update(
-                    self.task_id, completed=current, description=f"[cyan]{item_description}"
-                )
-            else:
-                self.progress.update(self.task_id, completed=current)
+            # Update progress and current file using task fields
+            # This keeps the progress bar position stable
+            self.progress.update(
+                self.task_id, completed=current, current_file=item_description or ""
+            )
 
     def on_complete(self) -> None:
         """Mark progress as complete and hide it."""
@@ -79,6 +78,7 @@ def progress_context(
             TextColumn("[progress.description]{task.description}"),
             BarColumn(),
             TaskProgressColumn(),
+            TextColumn("[cyan]{task.fields[current_file]}"),
             transient=True,
         ) as progress:
             yield RichProgressCallback(progress)


### PR DESCRIPTION
## Summary

Fixes the progress bar jumping issue during indexing. The progress bar now stays in a fixed horizontal position while the filename updates in a separate column.

## Problem

Previously, the progress bar jumped left and right as filenames changed because the filename was part of the description that appeared before the bar:

```
⠋ src/adapters/file.py ━━━━━━━━━━━━━━━━━━━━ 50%
⠙ ember/core/indexing/index_usecase.py ━━━━━━━━━━━━━━━━━━━━ 51%  # Bar shifted right!
⠹ main.py ━━━━━━━━━━━━━━━━━━━━ 52%  # Bar shifted left!
```

## Solution

Used Rich's `task.fields` feature to move the filename to a separate column after the progress percentage:

```
⠋ Indexing files ━━━━━━━━━━━━━━━━━━━━ 50% src/adapters/file.py
⠙ Indexing files ━━━━━━━━━━━━━━━━━━━━ 51% ember/core/indexing/index_usecase.py
⠹ Indexing files ━━━━━━━━━━━━━━━━━━━━ 52% main.py
```

## Changes

- Updated `RichProgressCallback.on_start()` to initialize `current_file` field
- Updated `RichProgressCallback.on_progress()` to update filename via task fields
- Added `TextColumn` for `current_file` to progress bar configuration
- Static description stays before the bar, dynamic filename after

## Testing

- [x] All 153 tests pass
- [x] Manual UAT confirmed working perfectly
- [x] Progress bar stays stable with files of varying path lengths

## Impact

Quick visual win for v1.0.0 - makes the indexing experience feel smoother and more polished.

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)