### PR TITLE
refactor: simplify editor detection with data-driven patterns (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Simplified editor detection logic in 'ember open' command** (#68)
+  - Replaced 18-line if/elif chain with data-driven pattern lookup
+  - Editor patterns defined once in `EDITOR_PATTERNS` dictionary
+  - New editors can be added by updating the dictionary (no code changes)
+  - Reduced code duplication (vim/emacs/nano now share pattern, subl/atom share pattern)
+  - Improved maintainability and extensibility
+  - No user-facing changes - internal refactoring only
+
 ### Fixed
 - **Unreachable error handler in 'ember open' command** (#63)
   - Fixed unreachable `FileNotFoundError` exception handler


### PR DESCRIPTION
## Problem

The `open_result` command had 6 nearly identical if/elif blocks for editor detection (18 lines total), with duplicate logic and no way to extend without code modification.

**Issues:**
1. vim/emacs blocks were identical but separate (DRY violation)
2. subl/atom blocks were identical but separate
3. Default case duplicated vim logic
4. No data-driven editor configuration
5. Hard to extend (required code change for new editors)

## Solution

Replaced the if/elif chain with a data-driven pattern lookup using a dictionary:

```python
EDITOR_PATTERNS = {
    "vim-style": {
        "editors": ["vim", "vi", "nvim", "emacs", "emacsclient", "nano"],
        "build": lambda ed, fp, ln: [ed, f"+{ln}", str(fp)],
    },
    "vscode-style": {
        "editors": ["code", "vscode"],
        "build": lambda ed, fp, ln: [ed, "--goto", f"{fp}:{ln}"],
    },
    "colon-style": {
        "editors": ["subl", "atom"],
        "build": lambda ed, fp, ln: [ed, f"{fp}:{ln}"],
    },
}
```

## Changes

- ✅ Added `EDITOR_PATTERNS` dictionary with 3 pattern categories
- ✅ Added `get_editor_command()` helper function
- ✅ Replaced 18-line if/elif chain with single function call
- ✅ Consolidated duplicate patterns (vim/emacs share, subl/atom share)
- ✅ Updated CHANGELOG.md

## Benefits

- **DRY compliance** - Each pattern defined once
- **Extensibility** - New editors can be added by updating dictionary
- **Maintainability** - Easier to test and modify
- **Clarity** - Pattern-based organization is more readable
- **Code reduction** - 18 lines → 3 lines in command code

## Verification

- ✅ All tests pass (153 passed) ✓
- ✅ All existing editors work identically ✓
- ✅ No user-facing changes ✓
- ✅ Code is more maintainable ✓

## Impact

**Internal refactoring only** - improves code quality with no user-facing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)