### PR TITLE
fix: improve error handling in sync command (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - No user-facing changes - internal refactoring only
 
 ### Fixed
+- **Improved error handling in 'ember sync' command** (#66)
+  - Fixed duplicate "No changes detected" messages - now shows "(quick check)" vs "(full scan)" to indicate which code path executed
+  - Quick check failures now always visible (not just in verbose mode) with clear warning message
+  - Added validation for mutually exclusive sync options (--rev, --staged, --worktree)
+  - Users now get immediate error when conflicting options are specified instead of silent last-one-wins behavior
+  - Better observability: users can tell if quick check ran or full indexing occurred
 - **Unreachable error handler in 'ember open' command** (#63)
   - Fixed unreachable `FileNotFoundError` exception handler
   - Now checks if editor exists using `shutil.which()` before running subprocess

--- a/tests/integration/test_sync_error_handling.py
+++ b/tests/integration/test_sync_error_handling.py
@@ -1,0 +1,126 @@
+"""Integration tests for sync command error handling (Issue #66)."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from ember.entrypoints.cli import sync
+
+
+@pytest.fixture
+def sync_test_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a test git repo for sync error handling tests."""
+    repo = tmp_path / "test-repo"
+    repo.mkdir()
+
+    # Initialize git repo
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, timeout=5)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        timeout=5,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        timeout=5,
+    )
+
+    # Create .gitignore to ignore .ember directory
+    gitignore = repo / ".gitignore"
+    gitignore.write_text(".ember/\n")
+
+    # Create initial file
+    test_file = repo / "test.py"
+    test_file.write_text("def foo(): pass\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True, timeout=5)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        timeout=5,
+    )
+
+    # Initialize ember
+    monkeypatch.chdir(repo)
+    from ember.entrypoints.cli import init
+
+    runner = CliRunner()
+    result = runner.invoke(init, [], obj={}, catch_exceptions=False)
+    assert result.exit_code == 0
+
+    return repo
+
+
+@pytest.mark.slow
+def test_quick_check_message_differs_from_full_scan(
+    sync_test_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that quick check and full scan show different messages."""
+    monkeypatch.chdir(sync_test_repo)
+    runner = CliRunner()
+
+    # First sync - will index
+    result1 = runner.invoke(sync, [], obj={}, catch_exceptions=False)
+    assert result1.exit_code == 0
+
+    # Second sync with no changes - should use quick check
+    result2 = runner.invoke(sync, [], obj={}, catch_exceptions=False)
+    assert result2.exit_code == 0
+    assert "✓ No changes detected (quick check)" in result2.stdout
+
+    # Force reindex - should skip quick check and do full reindex
+    result3 = runner.invoke(sync, ["--reindex"], obj={}, catch_exceptions=False)
+    assert result3.exit_code == 0
+    # With --reindex, it will actually reindex the files
+    assert "full sync" in result3.stdout or "incremental sync" in result3.stdout
+
+
+@pytest.mark.slow
+def test_mutually_exclusive_options_rejected(
+    sync_test_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that mutually exclusive sync options are rejected."""
+    monkeypatch.chdir(sync_test_repo)
+    runner = CliRunner()
+
+    # --rev and --staged should be mutually exclusive
+    result = runner.invoke(sync, ["--rev", "HEAD", "--staged"], obj={})
+    assert result.exit_code == 1
+    assert "mutually exclusive" in result.stderr
+
+    # --worktree and --staged should be mutually exclusive
+    result = runner.invoke(sync, ["--worktree", "--staged"], obj={})
+    assert result.exit_code == 1
+    assert "mutually exclusive" in result.stderr
+
+    # --rev and --worktree should be mutually exclusive
+    result = runner.invoke(sync, ["--rev", "HEAD", "--worktree"], obj={})
+    assert result.exit_code == 1
+    assert "mutually exclusive" in result.stderr
+
+
+@pytest.mark.slow
+def test_single_sync_mode_options_work(
+    sync_test_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that single sync mode options work correctly."""
+    monkeypatch.chdir(sync_test_repo)
+    runner = CliRunner()
+
+    # Each option should work on its own
+    result = runner.invoke(sync, ["--worktree"], obj={}, catch_exceptions=False)
+    assert result.exit_code == 0
+
+    result = runner.invoke(sync, ["--staged"], obj={}, catch_exceptions=False)
+    assert result.exit_code == 0
+
+    result = runner.invoke(sync, ["--rev", "HEAD"], obj={}, catch_exceptions=False)
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary

Fixes #66 - Improves error handling in the `ember sync` command to eliminate confusion and provide better observability.

## Changes

### 1. Differentiate success messages
- **Quick check path**: "✓ No changes detected (quick check)"  
- **Full scan path**: "✓ No changes detected (full scan)"
- Users can now tell which code path executed instead of seeing identical messages

### 2. Always show quick check failures
- Previously only visible with `--verbose` flag
- Now always shows: `Warning: Quick check failed, performing full sync: {error}`
- Provides transparency when quick optimization fails and full sync is needed

### 3. Validate mutually exclusive options
- Added validation for `--rev`, `--staged`, and `--worktree` options
- Clear error message: `Error: --rev, --staged, and --worktree are mutually exclusive`
- Prevents confusing silent "last-one-wins" behavior

### 4. Bug fix
- Fixed incorrect method call in quick check logic
- Changed `meta_repo.get_last_indexed_tree_sha()` → `meta_repo.get("last_tree_sha")`
- `SQLiteMetaRepository` uses generic key-value `get()` method

## Test Plan

- ✅ Added comprehensive integration tests in `tests/integration/test_sync_error_handling.py`
- ✅ Test scenarios cover all three fixes:
  1. Quick check vs full scan message differentiation
  2. Mutually exclusive options validation  
  3. Single sync mode options work correctly
- ✅ All 153 existing tests pass
- ✅ New tests include `.gitignore` setup to prevent `.ember/` files from affecting tree SHA calculations

## Success Criteria (from #66)

- [x] Different messages for quick check vs full scan
- [x] Quick check failures always visible (not just in verbose)
- [x] Mutually exclusive options validated
- [x] Tests added for all three scenarios
- [x] User knows which code path executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)