### PR TITLE
refactor: extract common CLI error handling to decorator (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Extracted common CLI error handling to reduce boilerplate** (#67)
+  - Created `handle_cli_errors()` decorator for consistent error handling across all commands
+  - Eliminated 40+ lines of duplicated exception handling code
+  - All commands (sync, find, cat, open) now use centralized error handler
+  - Consistent error messages and verbose mode traceback support
+  - No user-facing changes - internal refactoring only
 - **Simplified editor detection logic in 'ember open' command** (#68)
   - Replaced 18-line if/elif chain with data-driven pattern lookup
   - Editor patterns defined once in `EDITOR_PATTERNS` dictionary


### PR DESCRIPTION
## Summary

Eliminates 40+ lines of duplicated exception handling boilerplate by extracting common CLI error handling pattern into a reusable decorator.

## Changes

- **Created `handle_cli_errors()` decorator** in `cli.py`
  - Handles RuntimeError (user-facing errors)
  - Handles general Exception (unexpected errors)
  - Shows traceback in verbose mode
  - Exits with status code 1 on errors

- **Applied decorator to all CLI commands:**
  - `sync` command
  - `find` command
  - `cat` command
  - `open` command

- **Removed duplicate try/except blocks** from all commands
  - Preserved specific error handling (e.g., find_repo_root early exit)
  - Kept internal error handlers (e.g., cache write failures in find)

## Impact

- **Code reduction:** 40+ lines of duplicated code → single 18-line decorator
- **Consistency:** All commands now have identical error handling behavior
- **Maintainability:** Future error handling changes only need to be made once
- **Testing:** All 153 tests passing

## Testing

✅ All existing tests pass
✅ Linter clean (pre-existing issues in other files)
✅ No user-facing changes

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)