### PR TITLE
fix: remove duplicate message in daemon status output (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - No user-facing changes - internal refactoring only
 
 ### Fixed
+- **Removed duplicate message in 'ember daemon status' output** (#73)
+  - Daemon status now shows running state once instead of twice
+  - Message field only displayed for error states (unresponsive, stale, stopped)
+  - Cleaner, more concise status output
 - **Improved error handling in 'ember sync' command** (#66)
   - Fixed duplicate "No changes detected" messages - now shows "(quick check)" vs "(full scan)" to indicate which code path executed
   - Quick check failures now always visible (not just in verbose mode) with clear warning message

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -1021,7 +1021,8 @@ def status() -> None:
     click.echo(f"  PID file: {status['pid_file']}")
     click.echo(f"  Log file: {status['log_file']}")
 
-    if status.get("message"):
+    # Only show message for non-running states (errors/warnings)
+    if status.get("message") and status["status"] != "running":
         click.echo(f"\n{status['message']}")
 
 


### PR DESCRIPTION
## Problem

`ember daemon status` was displaying the running status message twice:

```
✓ Daemon is running (PID 45147)

Details:
  Status: running
  ...

Daemon is running (PID 45147)  ← duplicate
```

## Solution

Modified the status command to only display the `message` field for non-running states (unresponsive, stale, stopped) where the message provides actionable information.

The running state is already clearly shown at the top with the ✓ checkmark, so repeating it at the bottom is redundant.

## Changes

- Updated `cli.py` daemon status command to conditionally display message
- Added check: `if status.get("message") and status["status"] != "running"`
- Message field now reserved for error/warning states

## Impact

- **Cleaner output:** No duplicate messages
- **Better UX:** Message field only shows when it provides new information
- **All tests passing:** 153/153 tests pass

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)