### PR TITLE
refactor: extract error response helper in IndexingUseCase (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Extracted error response helper in IndexingUseCase** (#61)
+  - Created `_create_error_response()` helper method for standardized error responses
+  - Eliminated 60+ lines of duplicated IndexResponse creation code
+  - All 6 exception handlers now use common helper
+  - Improved maintainability - error response structure defined once
+  - No user-facing changes - internal refactoring only
 - **Extracted common CLI error handling to reduce boilerplate** (#67)
   - Created `handle_cli_errors()` decorator for consistent error handling across all commands
   - Eliminated 40+ lines of duplicated exception handling code


### PR DESCRIPTION
## Problem

`IndexingUseCase.execute()` contained 89 lines of nearly identical error response creation code across 6 different exception handlers.

Each handler created an `IndexResponse` with the same zero-counts structure, differing only in the error message.

## Solution

Extracted a `_create_error_response()` helper method that creates standardized error responses.

## Changes

- **Added helper method:**
  ```python
  def _create_error_response(self, error: str) -> IndexResponse:
      """Create a standardized error response with zero counts."""
      return IndexResponse(
          files_indexed=0,
          chunks_created=0,
          chunks_updated=0,
          chunks_deleted=0,
          vectors_stored=0,
          tree_sha="",
          is_incremental=False,
          success=False,
          error=error,
      )
  ```

- **Replaced all 6 exception handlers:**
  - FileNotFoundError
  - PermissionError
  - OSError
  - ValueError
  - RuntimeError
  - Exception (catch-all)

## Impact

- **Code reduction:** 89 lines → ~30 lines (67% reduction)
- **Single source of truth:** Error response structure defined once
- **Better maintainability:** Changes to error response structure only need one edit
- **No behavior change:** Error messages remain identical
- **All tests passing:** 153/153 tests pass

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)