### PR TITLE
fix: daemon stop now properly handles SIGTERM failures and verifies SIGKILL (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Daemon stop now properly handles SIGTERM failures and verifies SIGKILL** (#90)
+  - SIGTERM failure now falls through to SIGKILL instead of giving up immediately
+  - SIGKILL is now verified to actually kill the process before returning success
+  - Cleanup of PID and socket files only happens after verified process death
+  - Fixes issue where orphaned daemon processes could accumulate
+  - Prevents stale PID files when process survives SIGKILL
+  - Added 4 new tests for SIGTERM/SIGKILL edge cases and race conditions
+
 ### Added
 - **CLI integration tests for all user-facing commands** (#62)
   - Added comprehensive test suite using `click.testing.CliRunner`


### PR DESCRIPTION
## Summary

Fixes #90 - Daemon stop logic now properly handles SIGTERM failures and verifies SIGKILL success.

**Key Changes:**
- SIGTERM failure now falls through to SIGKILL instead of returning False immediately
- SIGKILL is now verified to actually kill the process before returning True
- Cleanup of PID and socket files only happens after verified process death

## Problem

The previous daemon shutdown logic had three critical bugs:

1. **SIGTERM failure caused immediate return** - If SIGTERM failed (e.g., permission denied), the function returned False without attempting SIGKILL
2. **SIGKILL didn't verify death** - After sending SIGKILL, it returned True immediately without checking if the process actually died
3. **Cleanup happened before verification** - PID file was deleted even if the process survived

This meant:
- Orphaned daemon processes could accumulate if SIGTERM failed
- Stale PID files were left behind when process survived SIGKILL
- Users couldn't forcefully stop malfunctioning daemons

## Solution

**Code Changes (ember/adapters/daemon/lifecycle.py:182-246):**

1. **SIGTERM failure fallthrough**: Changed exception handler to check if process is already dead, and if not, fall through to SIGKILL
2. **SIGKILL verification**: After sending SIGKILL, wait 0.5s and verify the process is actually dead before returning True
3. **Verified cleanup**: Only call `cleanup_stale_files()` after confirming the process is dead

**Test Coverage (tests/integration/test_daemon.py):**

Added 4 new tests covering edge cases:
1. `test_stop_sigterm_failure_falls_through_to_sigkill` - SIGTERM fails but SIGKILL succeeds
2. `test_stop_sigkill_verifies_death` - Process survives SIGKILL (zombie scenario)
3. `test_stop_cleanup_only_after_verified_death` - Cleanup called only after verification
4. `test_stop_process_dies_before_sigterm` - Race condition: process dies between check and SIGTERM

## Test Plan

- [x] All 202 existing tests pass
- [x] 4 new tests added specifically for SIGTERM/SIGKILL edge cases
- [x] Verified tests cover all three problems listed in the issue
- [x] Linter passes (`uv run ruff check .`)

## Impact

- **User-facing**: More reliable daemon cleanup, especially for stuck processes
- **Risk**: Low - changes are isolated to daemon stop logic, well-tested
- **Breaking**: None - behavior change is backward compatible (more robust)

🤖 Generated with [Claude Code](https://claude.com/claude-code)