### PR TITLE
fix: log warnings when chunks can't be retrieved during search (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Search now logs warnings when chunks can't be retrieved** (#88)
+  - Missing chunks are now logged with count and sample IDs
+  - Helps diagnose index corruption, stale data, or orphaned index entries
+  - Warning includes first 5 missing chunk IDs for debugging
+  - Previously silently dropped missing chunks, making problems invisible
+  - Added test for missing chunk scenario
 - **Daemon stop now properly handles SIGTERM failures and verifies SIGKILL** (#90)
   - SIGTERM failure now falls through to SIGKILL instead of giving up immediately
   - SIGKILL is now verified to actually kill the process before returning success


### PR DESCRIPTION
## Summary

Fixes #88 - Search now logs warnings when chunks can't be retrieved from the repository.

**Key Changes:**
- Added logging to `_retrieve_chunks()` to track missing chunks
- Warning includes count and first 5 missing chunk IDs
- Added comprehensive test using mocks to simulate missing chunks

## Problem

Previously, `SearchUseCase._retrieve_chunks()` silently dropped chunks that couldn't be retrieved from the repository. Users would see fewer results than the search index reported, with no way to diagnose why.

This silent failure made it impossible to detect:
- Database corruption
- Index out of sync with chunk storage
- Race conditions (chunk deleted between search and retrieval)
- Orphaned index entries

## Solution

**Code Changes (ember/core/retrieval/search_usecase.py:147-176):**

1. **Added logging import** at module level
2. **Modified `_retrieve_chunks()`** to track missing chunk IDs
3. **Log warning** when chunks are missing, including:
   - Count of missing chunks
   - First 5 missing chunk IDs (for brevity)
   - Helpful message about potential causes

**Test Coverage (tests/integration/test_search_usecase.py:517-598):**

Added `test_missing_chunks_logged` which:
- Uses mock chunk repository that returns None for some chunks
- Verifies only found chunks are returned
- Verifies warning is logged with correct count and IDs
- Uses pytest's caplog fixture to capture and verify log messages

## Example Log Output

```
WARNING:ember.core.retrieval.search_usecase:Missing 3 chunks during retrieval. This may indicate index corruption or stale data. Missing IDs: ['chunk_3', 'chunk_4', 'chunk_5']
```

## Test Plan

- [x] All 203 existing tests pass
- [x] New test added specifically for missing chunk scenario
- [x] Test verifies logging behavior using caplog
- [x] Test verifies only found chunks are returned

## Impact

- **User-facing**: Better observability - users can now diagnose missing chunks
- **Risk**: Low - changes are isolated to logging only, no behavior change
- **Breaking**: None - backward compatible (logs are warnings, not errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)