### PR TITLE
fix: eliminate daemon startup race condition (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Daemon startup race condition no longer creates stale PID files** (#85)
+  - Fixed race condition where PID file was written before verifying daemon process survived
+  - Now waits 0.1s after spawn and checks if process died instantly before writing PID file
+  - Captures and reports stderr output when daemon fails to start (e.g., model loading errors)
+  - Cleans up PID file if daemon exits during ready-wait loop
+  - Prevents false success reports when daemon actually crashed
+  - Added 2 new integration tests for daemon startup failure scenarios
 - **Search now logs warnings when chunks can't be retrieved** (#88)
   - Missing chunks are now logged with count and sample IDs
   - Helps diagnose index corruption, stale data, or orphaned index entries


### PR DESCRIPTION
## Summary
Fixed race condition where PID file was written before verifying the daemon process survived startup. This prevented stale PID files and false success reports when the daemon actually crashed.

## Changes
- ✅ Check if process died instantly (0.1s wait) before writing PID file
- ✅ Capture stderr during startup to report meaningful error messages  
- ✅ Clean up PID file if daemon exits during ready-wait loop
- ✅ Added 2 integration tests for startup failure scenarios
- ✅ Updated CHANGELOG.md

## Test Results
All 205 tests passing (excluding slow tests)

## Closes
Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)