### PR TITLE
fix: improve daemon protocol robustness and prevent data loss (#83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Daemon protocol now handles large messages correctly and warns about data loss** (#83)
+  - Increased buffer size from 1024 to 4096 bytes for better performance
+  - Added warning when multiple messages received in single recv() call (potential data loss)
+  - Documented one-message-per-connection protocol contract in function docstring
+  - Added comprehensive tests for large messages (>4KB) and multiple messages
+  - Prevents silent failures and makes debugging easier
 - **Daemon startup race condition no longer creates stale PID files** (#85)
   - Fixed race condition where PID file was written before verifying daemon process survived
   - Now waits 0.1s after spawn and checks if process died instantly before writing PID file


### PR DESCRIPTION
## Summary
Improved daemon protocol message handling to be more robust and prevent silent data loss when multiple messages are received in a single recv() call.

## Changes
- ✅ Increased buffer size from 1024 to 4096 bytes for better performance
- ✅ Added warning when multiple messages received in single recv() call (potential data loss)
- ✅ Documented one-message-per-connection protocol contract in function docstring
- ✅ Added comprehensive tests for large messages (>4KB) and multiple messages
- ✅ Prevents silent failures and makes debugging easier
- ✅ Updated CHANGELOG.md

## Technical Details
The daemon uses a one-message-per-connection model, so multiple messages in one recv() should never happen in practice. However, the code is now defensive and will warn if it does happen, making debugging much easier.

## Test Results
All 26 daemon tests passing (including 2 new protocol tests)

## Closes
Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)