### PR TITLE
fix: eliminate core → adapters dependency violation in CLI utils (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fingerprint comparison happens at start of each indexing operation
 
 ### Changed
+- **CLI utilities no longer import from adapters layer** (#89)
+  - Created `DaemonManager` protocol in `ports/daemon.py` for dependency inversion
+  - Refactored `ensure_daemon_with_progress()` to accept injected `DaemonManager` instead of importing adapters
+  - CLI commands (entrypoints layer) now inject `DaemonLifecycle` adapter implementation
+  - Eliminates core → adapters dependency violation in Clean Architecture
+  - Improves testability and flexibility (can swap daemon implementations without changing core code)
+  - All 207 tests passing - no user-facing changes
 - **Eliminated O(N) table scans with chunk_id column** (#59)
   - Added `chunk_id` column to chunks table for O(1) lookups
   - Created unique index on `chunk_id` for fast queries

--- a/ember/ports/daemon.py
+++ b/ember/ports/daemon.py
@@ -1,0 +1,60 @@
+"""Port interface for daemon management.
+
+Defines protocols for managing daemon lifecycle.
+"""
+
+from typing import Protocol
+
+
+class DaemonManager(Protocol):
+    """Protocol for managing daemon lifecycle.
+
+    This protocol defines the interface for managing a background daemon process
+    that keeps models loaded in memory for fast operations.
+    """
+
+    def is_running(self) -> bool:
+        """Check if daemon is running and healthy.
+
+        Returns:
+            True if daemon is running and responding to health checks
+        """
+        ...
+
+    def ensure_running(self, wait: bool = True) -> bool:
+        """Ensure daemon is running, starting if needed.
+
+        This is the primary method for auto-starting the daemon when needed.
+
+        Args:
+            wait: Wait for daemon to be ready
+
+        Returns:
+            True if daemon is running (or successfully started)
+        """
+        ...
+
+    def start(self, foreground: bool = False) -> bool:
+        """Start the daemon.
+
+        Args:
+            foreground: Run in foreground (for debugging)
+
+        Returns:
+            True if started successfully
+
+        Raises:
+            RuntimeError: If start fails
+        """
+        ...
+
+    def stop(self, timeout: int = 10) -> bool:
+        """Stop the daemon gracefully.
+
+        Args:
+            timeout: Seconds to wait for graceful shutdown
+
+        Returns:
+            True if stopped successfully
+        """
+        ...


### PR DESCRIPTION
## Summary
Fixed Clean Architecture violation where `core/cli_utils.py` imported directly from `adapters/` layer. Core layer should only depend on ports, never adapters.

## Changes
- ✅ Created `DaemonManager` protocol in `ports/daemon.py` for dependency inversion
- ✅ Refactored `ensure_daemon_with_progress()` to accept injected `DaemonManager`
- ✅ Updated CLI commands to inject `DaemonLifecycle` adapter at entrypoints layer
- ✅ Eliminates core → adapters dependency (now core → ports, entrypoints → adapters)
- ✅ Updated CHANGELOG.md

## Benefits
- **Clean Architecture:** Proper dependency inversion (dependencies point inward)
- **Testability:** Can mock daemon without real implementation
- **Flexibility:** Can swap daemon implementations without changing core code
- **Maintainability:** Core code is implementation-agnostic

## Architecture Flow
Before:
```
core/cli_utils.py → adapters/daemon/* (❌ violation)
```

After:
```
core/cli_utils.py → ports/daemon.py (✅ correct)
entrypoints/cli.py → adapters/daemon/* (✅ correct)
```

## Test Results
All 207 tests passing - no behavioral changes

## Closes
Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)