### PR TITLE
fix: prevent find_ember_root() from crossing git boundaries (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **find_ember_root() now respects git repository boundaries** (#100)
+  - Prevents confusion between global daemon directory (~/.ember) and repository directories
+  - Search now stops at git repository root, preventing false "Not a git repository" errors
+  - Fixes issue where daemon running (with ~/.ember) would cause commands to fail in uninitialized repos
+  - Added git boundary check to prevent crossing into parent directories beyond git root
+  - Added comprehensive tests for git boundary checking and nested repository scenarios
+  - Ensures ember only searches for .ember within the current git repository
 - **Daemon protocol now handles large messages correctly and warns about data loss** (#83)
   - Increased buffer size from 1024 to 4096 bytes for better performance
   - Added warning when multiple messages received in single recv() call (potential data loss)


### PR DESCRIPTION
## Summary

Fixes #100 - `find_ember_root()` no longer crosses git repository boundaries when searching for `.ember/`, preventing confusion between global daemon directory (`~/.ember`) and repository-specific ember directories.

**Problem:** When the daemon was running (creating `~/.ember/` for socket/PID files), commands like `ember sync` or `ember search` in uninitialized git repos would find the parent `~/.ember` directory and fail with "Not a git repository: /Users/username" errors.

**Solution:** Added git boundary checking to `find_ember_root()` so it stops searching at the git repository root and never crosses into parent directories.

## Changes

- **Core logic:** Modified `find_ember_root()` to respect git repository boundaries
  - Calls `find_git_root()` to determine boundary
  - Stops search at git root instead of continuing to filesystem root
  - Only affects behavior when inside a git repository
  
- **Tests:** Added 3 comprehensive integration tests
  - `test_find_ember_root_respects_git_boundary` - verifies no crossing of git boundaries
  - `test_find_ember_root_works_within_git_repo` - verifies normal operation still works
  - `test_find_ember_root_nested_git_repos` - verifies monorepo/submodule scenarios
  
- **Documentation:** Updated CHANGELOG.md with fix details

## Impact

✅ **Before:** Users with daemon running saw confusing errors in uninitialized git repos
✅ **After:** Clear behavior - ember respects git boundaries like git does
✅ **Compatibility:** All 210 existing tests pass, no breaking changes

## Testing

```bash
# All tests pass
uv run pytest  # 210 passed

# New tests specifically pass
uv run pytest tests/integration/test_subdirectory_support.py -v
# 9 passed including 3 new boundary tests

# Linting passes
uv run ruff check ember/core/repo_utils.py tests/integration/test_subdirectory_support.py
# All checks passed!
```

## Test Plan

- [x] All existing tests pass (210/210)
- [x] New tests for git boundary checking pass
- [x] Linting passes for modified files
- [x] Manual testing: daemon running + uninitialized repo works correctly
- [x] CHANGELOG.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)