### PR TITLE
fix: add missing methods to ChunkRepository port interface (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Added missing methods to ChunkRepository port interface** (#82)
+  - Added `delete_by_path()` and `delete_all_for_path()` to ChunkRepository protocol
+  - Eliminates architectural violation where core layer called undocumented adapter methods
+  - Port interface now matches adapter implementation completely
+  - Improves maintainability and ensures future adapters implement required methods
+  - No user-facing changes - internal architecture cleanup
+
 ### Fixed
 - **find_ember_root() now respects git repository boundaries** (#100)
   - Prevents confusion between global daemon directory (~/.ember) and repository directories

--- a/ember/ports/repositories.py
+++ b/ember/ports/repositories.py
@@ -83,6 +83,36 @@ class ChunkRepository(Protocol):
         """
         ...
 
+    def delete_by_path(self, path: Path, tree_sha: str) -> int:
+        """Delete all chunks for a given file path and tree SHA.
+
+        This is more efficient than calling delete() for each chunk.
+        Used for handling deleted files during incremental sync.
+
+        Args:
+            path: File path relative to repository root.
+            tree_sha: Tree SHA to delete chunks for.
+
+        Returns:
+            Number of chunks deleted.
+        """
+        ...
+
+    def delete_all_for_path(self, path: Path) -> int:
+        """Delete all chunks for a given file path across all tree SHAs.
+
+        This is used when re-indexing a file to remove all old chunks
+        before adding new ones, preventing duplicate accumulation across
+        multiple syncs.
+
+        Args:
+            path: File path relative to repository root.
+
+        Returns:
+            Number of chunks deleted.
+        """
+        ...
+
 
 class MetaRepository(Protocol):
     """Repository for storing metadata (state, config, etc.)."""


### PR DESCRIPTION
## Summary

Fixes #82 - Adds `delete_by_path()` and `delete_all_for_path()` methods to the ChunkRepository port interface, eliminating an architectural violation where core layer code called undocumented adapter-specific methods.

**Problem:** `IndexingUseCase` called `delete_by_path()` and `delete_all_for_path()` on `ChunkRepository`, but these methods were not defined in the port protocol. This violates Clean Architecture where core should only depend on documented port interfaces.

**Solution:** Added both missing methods to the `ChunkRepository` protocol in `ember/ports/repositories.py` with complete type hints and documentation.

## Changes

- **Port interface:** Added two methods to `ChunkRepository` protocol
  - `delete_by_path(path: Path, tree_sha: str) -> int`
  - `delete_all_for_path(path: Path) -> int`
  - Type signatures match adapter implementation exactly
  - Full documentation with parameters and return values
  
- **Documentation:** Updated CHANGELOG.md

## Impact

✅ **Before:** Core layer depended on undocumented adapter methods (architectural violation)
✅ **After:** Port interface fully documents all required methods
✅ **Compatibility:** All 210 existing tests pass, no behavioral changes

## Testing

```bash
# All tests pass
uv run pytest  # 210 passed

# Linting passes
uv run ruff check ember/ports/repositories.py
# All checks passed!
```

## Architecture Compliance

This change restores proper dependency inversion:
- Core layer (`IndexingUseCase`) ✓ depends on port interface (`ChunkRepository` protocol)
- Port interface ✓ fully documents all required methods  
- Adapter layer (`SQLiteChunkRepository`) ✓ implements all port methods

Future adapter implementations will now know all required methods from the port definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)