### PR TITLE
refactor: reduce sync CLI command complexity (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Refactored sync CLI command to reduce complexity** (#91)
+  - Reduced cyclomatic complexity from C-level (20) to manageable levels by extracting 3 helper functions
+  - Extracted `_parse_sync_mode()` for CLI option validation and sync mode determination
+  - Extracted `_quick_check_unchanged()` for optimization logic to skip unchanged indexes
+  - Extracted `_format_sync_results()` for result formatting and display
+  - Improved readability and maintainability of sync command
+  - All 257 tests passing - pure refactor, no behavior changes
+
 ### Performance
 - **Implemented SQLite connection pooling to reduce overhead** (#87)
   - All SQLite repository adapters now reuse database connections instead of creating new ones for each operation


### PR DESCRIPTION
## Summary
- Reduced cyclomatic complexity of `sync()` CLI command from C-level (20) to manageable levels
- Extracted 3 helper functions to improve readability and maintainability
- All 257 tests passing - pure refactor, no behavior changes

## Changes Made
1. **Extracted `_parse_sync_mode()`** - Handles CLI option validation and determines sync mode
   - Validates mutually exclusive options (`--rev`, `--staged`, `--worktree`)
   - Returns appropriate sync mode string
   - Raises `click.UsageError` for invalid combinations

2. **Extracted `_quick_check_unchanged()`** - Optimization logic to skip unchanged indexes
   - Checks if worktree tree SHA matches last indexed SHA
   - Allows skipping expensive model initialization when no changes detected
   - Returns boolean indicating whether sync can be skipped

3. **Extracted `_format_sync_results()`** - Result formatting and display
   - Formats and prints indexing results
   - Shows chunks created/updated/deleted, vectors stored, and tree SHA
   - Handles both incremental and full sync display

## Code Quality
- **Before**: Complexity C-level (20) - above recommended threshold of 10
- **After**: All complexity checks pass - maintainable levels
- Verified with `ruff check --select C90`
- All 257 tests passing

## Test Plan
- [x] All existing tests pass (`uv run pytest`)
- [x] Complexity check passes (`uv run ruff check --select C90`)
- [x] Manual testing of sync command behavior
- [x] CHANGELOG.md updated

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)