### PR TITLE
fix: improve daemon startup error reporting in interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Improved daemon startup error reporting in interactive mode** (#126)
+  - Daemon now starts and verifies health BEFORE entering interactive search TUI
+  - Startup failures are caught early and display clean error messages
+  - Prevents TUI corruption from daemon errors during initialization
+  - Error messages show detailed information including exit code, stderr, and log file location
+  - Added test coverage for daemon startup failure scenarios
+
 - **Fixed missing chunks during search retrieval** (#125)
   - Search adapters now return the actual `chunk_id` stored in the database instead of computing it on-the-fly
   - Prevents "Missing chunks during retrieval" warnings caused by ID mismatches


### PR DESCRIPTION
## Summary

Fixes daemon startup error reporting in interactive search mode (#126). Daemon now starts and verifies health BEFORE entering TUI, ensuring clean error messages instead of TUI corruption.

## Problem

When daemon failed to start during `ember search`, error messages would corrupt the TUI display. The daemon was only started during the first `embed_texts()` call, which happened AFTER the TUI was initialized.

## Solution

Modified `_create_embedder()` to **always** start and verify daemon before returning the client, even in interactive mode. This ensures:

✅ Daemon startup failures caught before TUI initialization  
✅ RuntimeError propagates cleanly through `@handle_cli_errors`  
✅ Error messages display as normal CLI output  
✅ Users see full details: exit code, stderr, log file location

## Changes

### Core Implementation
- **ember/entrypoints/cli.py**: Updated `_create_embedder()` to call `daemon_manager.start()` before TUI initialization
  - Daemon client now has `auto_start=False` (already started)
  - Added reference to issue #126

### Tests
- **tests/integration/test_daemon.py**: Added `test_daemon_startup_failure_raises_before_client_embed()`
  - Verifies RuntimeError raised during `start()` with detailed error message
  - Confirms PID file not created on instant failure

### Documentation
- **CHANGELOG.md**: Documented fix under Unreleased section

## Testing

✅ All 257 tests pass  
✅ Linter passes (ruff)  
✅ New test verifies daemon errors caught before client embedding

## Related Issues

Implements #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>