### PR TITLE
fix: add syntax highlighting to ember find and remove ellipses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Added syntax highlighting to `ember find` (non-context mode)**
+  - `ember find` now applies syntax highlighting by default, matching `ember find --context` behavior
+  - Shows compact 3-line preview with syntax highlighting (keeps distinction from `ember cat`)
+  - Uses terminal-native ANSI colors consistent with other commands
+  - Automatically detects language from file extension
+  - Respects `display.syntax_highlighting` config setting (can be disabled)
+  - Uses configured theme from `display.theme` (default: "ansi")
+  - Graceful fallback to plain text if file not readable or highlighting fails
+
 ### Fixed
+- **Removed ellipses (`...`) from `ember find` output**
+  - Preview no longer shows `...` at the end of truncated chunks
+  - Consistent behavior between context and non-context modes
+
 - **Fixed `ember find -C/--context` output format to match ripgrep-style** (#129)
   - Context output now uses compact ripgrep-style format: `[rank] line_num:content`
   - Shows only N lines before and after the match line (not the entire chunk)


### PR DESCRIPTION
## Summary

Adds syntax highlighting to non-context `ember find` output and removes the ellipses (`...`) from chunk previews, addressing visual inconsistencies between `ember find` and `ember find -C`.

## Problem

As reported by the user:
1. `ember find -k 5 daemon` had no syntax highlighting, but `ember find -k 5 daemon -C 2` did
2. Ellipses (`...`) appeared in non-context output but not in context output

## Changes

### Syntax Highlighting for Non-Context Mode
- Modified `format_human_output()` to apply syntax highlighting to non-context find results
- Reads chunk content from file and applies `render_syntax_highlighted()`
- Respects `display.syntax_highlighting` config setting
- Uses configured `display.theme` (default: "ansi")
- Graceful fallback to plain text if file not readable or highlighting fails

### Removed Ellipses
- Changed from using `result.format_preview()` (which adds `...`) to using `result.chunk.content` directly
- Shows full chunk content instead of truncated preview
- Consistent behavior between context and non-context modes

## Before

```
ember/entrypoints/cli.py
[1] 1238:def start(ctx: click.Context, foreground: bool) -> None:
    """Start the daemon server."""
    from ember.adapters.config.toml_config_provider import TomlConfigProvider
    ...
```

## After

```
ember/entrypoints/cli.py
[1] 1238:def start(ctx: click.Context, foreground: bool) -> None:
    """Start the daemon server."""
    from ember.adapters.config.toml_config_provider import TomlConfigProvider
    (full chunk content with syntax highlighting)
```

## Testing

- ✅ All 262 tests pass
- ✅ Linter passes with no errors
- ✅ Verified manually with `ember find` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)