### PR TITLE
fix: close stderr on daemon startup failure to prevent fd leak (#139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Error messages show detailed information including exit code, stderr, and log file location
   - Added test coverage for daemon startup failure scenarios
 
+- **Fixed stderr file descriptor leak on daemon startup failure** (#139)
+  - stderr pipe is now closed in all exit paths using try/finally
+  - Prevents file descriptor exhaustion from repeated daemon startup failures
+  - Added test to verify stderr cleanup on instant daemon failure
+
 - **Fixed missing chunks during search retrieval** (#125)
   - Search adapters now return the actual `chunk_id` stored in the database instead of computing it on-the-fly
   - Prevents "Missing chunks during retrieval" warnings caused by ID mismatches


### PR DESCRIPTION
## Summary
- Fixes file descriptor leak when daemon fails to start immediately
- stderr pipe was only closed in the success path, not on failure
- Now uses try/finally to ensure stderr is always closed

## Changes
- Wrap daemon startup error check in try/finally in `lifecycle.py:152-177`
- Add test `test_start_instant_failure_closes_stderr` to verify stderr cleanup
- Update CHANGELOG.md with fix description

Fixes #139

## Test plan
- [x] All existing tests pass (`uv run pytest`)
- [x] New test verifies stderr.close() is called on instant failure
- [x] Linter passes (`uv run ruff check .`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)