### PR TITLE
fix: raise exception on git index restoration failure (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **GitAdapter now raises exception on index restoration failure** (#140)
+  - `get_worktree_tree_sha()` now raises `RuntimeError` if git index restoration fails
+  - Previously, restoration failures were silently logged as warnings
+  - Error message includes recovery guidance: suggests running `git status` and `git reset`
+  - Prevents silent repository corruption that could cause data loss
+  - Added comprehensive tests for restoration failure scenarios
+
 ### Added
 - **Context manager support for all repository classes** (#138)
   - All SQLite repository classes now implement the context manager protocol (`__enter__`/`__exit__`)


### PR DESCRIPTION
## Summary

- Fix silent git index corruption risk in `get_worktree_tree_sha()`
- Raise `RuntimeError` when index restoration fails instead of just logging
- Add recovery guidance in error messages

## Changes

- `ember/adapters/git_cmd/git_adapter.py`: Change restoration failure handling from warning to exception
- `tests/integration/test_git_adapter.py`: Add 3 new tests for restoration failure scenarios
- `CHANGELOG.md`: Document the fix

## Test Plan

- [x] All existing tests pass (`uv run pytest` - 283 passed)
- [x] New tests verify exception is raised on restoration failure
- [x] New tests verify error message includes recovery guidance
- [x] Linter passes (`uv run ruff check .`)

Fixes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)