### PR TITLE
fix: add logging for chunking failures during indexing (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Add logging for chunking failures during indexing** (#144)
+  - Chunking failures now log a warning with the file path and error message
+  - `IndexResponse` now includes `files_failed` count for tracking chunking failures
+  - Summary log includes failed file count when failures occur
+  - Helps users identify which files are failing and why
+  - Preserves existing chunks on failure to avoid data loss
+
 - **Make path filters mutually exclusive in find and search commands** (#142)
   - `ember find` PATH argument and `--in` filter are now mutually exclusive
   - `ember search` `--path` and `--in` flags are now mutually exclusive


### PR DESCRIPTION
## Summary
- Add warning logging when chunking fails with file path and error message
- Add `files_failed` field to `IndexResponse` for tracking chunking failures
- Update summary log to include failed file count when failures occur

## Details
When chunking fails during indexing, the error message from `chunk_response.error` was previously ignored. This PR:

1. Logs a warning with the file path and error message:
   ```
   WARNING: Failed to chunk path/to/file.py: <error message>. Preserving existing chunks to avoid data loss.
   ```

2. Tracks failed files in `IndexResponse.files_failed` field

3. Includes failed count in the summary log when failures occur:
   ```
   INFO: Indexing complete: 10 files, 5 chunks created, 0 updated, 0 deleted, 5 vectors stored, 2 failed
   ```

This helps users identify which files are failing to chunk and why, making it easier to debug indexing issues.

Implements #144

## Test Plan
- [x] Added integration test `test_chunking_failure_logs_warning_and_tracks_stats`
- [x] Test verifies warning is logged with file path and error message
- [x] Test verifies `files_failed` is tracked in `IndexResponse`
- [x] All existing tests pass
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)