### PR TITLE
fix: add logging when TOML config parsing fails (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Add logging when TOML config parsing fails** (#145)
+  - Config parsing failures now log a warning with the error details
+  - Missing config file (expected) does not log a warning
+  - Invalid TOML syntax logs a clear message to help users debug config issues
+  - Graceful fallback to defaults still works, but users are now informed
+
 - **Improve "No changes detected" feedback clarity** (#143)
   - Sync feedback now correctly distinguishes between full and incremental scans
   - Previously always showed "(full scan)" even for incremental scans

--- a/ember/adapters/config/toml_config_provider.py
+++ b/ember/adapters/config/toml_config_provider.py
@@ -3,10 +3,13 @@
 Loads configuration from .ember/config.toml with graceful fallback to defaults.
 """
 
+import logging
 from pathlib import Path
 
 from ember.domain.config import EmberConfig
 from ember.shared.config_io import load_config
+
+logger = logging.getLogger(__name__)
 
 
 class TomlConfigProvider:
@@ -36,7 +39,9 @@ class TomlConfigProvider:
         # Try to load config, fall back to defaults on error
         try:
             return load_config(config_path)
-        except (FileNotFoundError, ValueError):
-            # Log warning but don't fail - use defaults
-            # In the future, we could use a logger here
+        except (FileNotFoundError, ValueError) as e:
+            logger.warning(
+                "Failed to parse config.toml: %s. Using default configuration.",
+                e,
+            )
             return EmberConfig.default()

--- a/tests/unit/test_config_provider.py
+++ b/tests/unit/test_config_provider.py
@@ -91,6 +91,47 @@ def test_load_config_invalid_toml_returns_defaults():
         assert config.index.line_window == 120
 
 
+def test_load_config_invalid_toml_logs_warning(caplog):
+    """Test that invalid TOML logs a warning message."""
+    import logging
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ember_dir = Path(tmpdir) / ".ember"
+        ember_dir.mkdir()
+
+        # Write invalid TOML
+        config_path = ember_dir / "config.toml"
+        config_path.write_text("this is [[ not valid toml")
+
+        # Load with logging captured
+        with caplog.at_level(logging.WARNING):
+            provider = TomlConfigProvider()
+            provider.load(ember_dir)
+
+        # Verify warning was logged
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == "WARNING"
+        assert "config.toml" in caplog.text
+        assert "Invalid TOML" in caplog.text or "parse" in caplog.text.lower()
+
+
+def test_load_config_missing_file_no_warning(caplog):
+    """Test that missing config file does NOT log a warning."""
+    import logging
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ember_dir = Path(tmpdir) / ".ember"
+        ember_dir.mkdir()
+
+        # No config file created - this is expected behavior
+        with caplog.at_level(logging.WARNING):
+            provider = TomlConfigProvider()
+            provider.load(ember_dir)
+
+        # No warnings should be logged for missing file
+        assert len(caplog.records) == 0
+
+
 def test_load_config_partial_config():
     """Test loading a partial config (only some sections defined)."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- Config parsing failures now log a warning with error details
- Missing config file (expected) does not log a warning
- Invalid TOML syntax logs a clear message to help users debug config issues
- Graceful fallback to defaults still works, but users are now informed

## Changes
- Added logging import and logger to `ember/adapters/config/toml_config_provider.py`
- Updated exception handler to log warning with error message
- Added 2 unit tests for logging behavior

## Test plan
- [x] All 348 existing tests pass
- [x] Added 2 new unit tests for logging behavior
- [x] Linter passes

Implements #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)