### PR TITLE
feat: add recovery guidance to missing chunks warning (#146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Improved
+- **Missing chunks warning now includes recovery guidance** (#146)
+  - Warning message now suggests running `ember sync --force` to rebuild the index
+  - Directs users to report an issue if the problem persists
+  - Helps users resolve index corruption or stale data issues
+
 ### Fixed
 - **Add logging when TOML config parsing fails** (#145)
   - Config parsing failures now log a warning with the error details

--- a/ember/core/retrieval/search_usecase.py
+++ b/ember/core/retrieval/search_usecase.py
@@ -163,12 +163,14 @@ class SearchUseCase:
             else:
                 missing_ids.append(chunk_id)
 
-        # Log warning if chunks are missing
+        # Log warning if chunks are missing with recovery guidance
         if missing_ids:
             sample_ids = missing_ids[:5]  # Show first 5 for brevity
             logger.warning(
                 f"Missing {len(missing_ids)} chunks during retrieval. "
                 f"This may indicate index corruption or stale data. "
+                f"Try running 'ember sync --force' to rebuild the index. "
+                f"If the problem persists, please report an issue. "
                 f"Missing IDs: {sample_ids}"
                 + ("..." if len(missing_ids) > 5 else "")
             )

--- a/tests/integration/test_search_usecase.py
+++ b/tests/integration/test_search_usecase.py
@@ -597,3 +597,7 @@ def test_missing_chunks_logged(db_path: Path, caplog: pytest.LogCaptureFixture) 
     assert "chunk_4" in log_record.message
     assert "chunk_5" in log_record.message
     assert "index corruption or stale data" in log_record.message
+
+    # Should include recovery guidance (issue #146)
+    assert "ember sync --force" in log_record.message
+    assert "report an issue" in log_record.message.lower()


### PR DESCRIPTION
## Summary

- Add actionable recovery instructions to the missing chunks warning
- Users now see guidance to run `ember sync --force` to rebuild the index
- Directs users to report an issue if the problem persists

Implements #146

## Test plan

- [x] Existing test `test_missing_chunks_logged` updated to verify recovery guidance
- [x] All 348 tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)