### PR TITLE
perf: cache database connections in SqliteVecAdapter (#147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Improved
+- **SqliteVecAdapter now caches database connections for better search performance** (#147)
+  - Connection is reused across operations instead of creating new ones per call
+  - sqlite-vec extension loaded once instead of per operation
+  - Reduces overhead for high-frequency search operations
+  - Now follows same connection management pattern as other repository classes
+
 - **Missing chunks warning now includes recovery guidance** (#146)
   - Warning message now suggests running `ember sync --force` to rebuild the index
   - Directs users to report an issue if the problem persists


### PR DESCRIPTION
## Summary

- Add connection caching to SqliteVecAdapter (previously created new connection per operation)
- sqlite-vec extension now loaded once instead of per operation
- Follow same connection management pattern as other repository classes
- Properly implement `close()` method and context manager support

Implements #147

## Changes

- `_get_connection()` now caches and reuses connection
- `close()` properly closes connection instead of being no-op
- Removed `conn.close()` calls from `_ensure_vec_table()`, `_sync_vectors()`, and `query()`
- Updated tests to verify connection caching behavior

## Test plan

- [x] Updated context manager tests for new behavior
- [x] Added `test_connection_reuse` to verify connections are cached
- [x] All 350 tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)