### PR TITLE
test: add comprehensive unit tests for ResultPresenter class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Comprehensive unit tests for ResultPresenter class** (#149)
+  - Increased test coverage from 76% to 100%
+  - Added 11 new tests covering edge cases, error handling, and all code paths
+  - Tests for `_get_context` method with file boundary handling
+  - Tests for syntax highlighting paths in preview and context rendering
+  - Tests for error handling when files are missing or unreadable
+  - Fast tests using mocks (< 0.2s total for 28 tests)
+
 ### Improved
 - **Optimized ChunkRepository.delete() by removing redundant get() call** (#148)
   - Deletes chunks directly using indexed chunk_id column instead of fetching full chunk first


### PR DESCRIPTION
## Summary
- Increased test coverage for `ResultPresenter` from 76% to 100%
- Added 11 new tests covering edge cases, error handling, and all code paths
- Total: 28 tests for the class, all passing in < 0.2s

Implements #149

## Test Coverage Details
- `_get_context` method tests for file boundaries (start/end)
- Syntax highlighting paths in `_render_compact_preview` and `_render_with_context`
- Error handling when files are missing or unreadable
- JSON output with/without context
- Multiple results with context (blank line spacing)

## Test plan
- [x] Run `uv run pytest tests/unit/core/test_result_presenter.py -v` - all 28 tests pass
- [x] Run `uv run pytest` - all 364 tests pass
- [x] Run `uv run ruff check .` - linter passes
- [x] Coverage report shows 100% for result_presenter.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)