### PR TITLE
refactor: extract common repo_root initialization pattern in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Helps users understand what type of scan was performed
 
 ### Changed
+- **Extracted common repo_root initialization pattern in CLI** (#151)
+  - Added `get_ember_repo_root()` helper function to reduce code duplication
+  - Consolidated 5 command implementations (sync, find, search, cat, open, status)
+  - Consistent error handling and messaging across all commands
+  - Added 3 unit tests for the helper function
+
 - **Refactored render_syntax_highlighted for reduced complexity and maintainability** (#137)
   - Extracted `AnsiCodes` class with named constants for ANSI escape sequences (replaces magic strings)
   - Extracted `EXTENSION_TO_LEXER` mapping as module-level constant for file extension detection


### PR DESCRIPTION
## Summary

- Added `get_ember_repo_root()` helper function to reduce code duplication across CLI commands
- Consolidated try/except pattern that was repeated in 5 commands (sync, find, search, cat, open, status)
- Ensures consistent error handling and messaging across all commands

Implements #151

## Changes

- `ember/entrypoints/cli.py`: Added helper function and refactored 5 commands
- `tests/integration/test_cli_commands.py`: Added 3 unit tests for the helper

## Test plan

- [x] All 367 tests pass
- [x] Linter passes
- [x] New tests cover helper function behavior
- [x] Manual verification: commands still work from subdirectories

🤖 Generated with [Claude Code](https://claude.com/claude-code)