### PR TITLE
fix: eliminate race condition in daemon PID file management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Helps users resolve index corruption or stale data issues
 
 ### Fixed
+- **Fix race condition in daemon PID file management** (#152)
+  - PID file is now written immediately after spawning daemon process
+  - Eliminates race where process could die between alive-check and PID write
+  - PID file properly cleaned up in all error paths (instant failure, write failure)
+  - If PID file write fails, spawned process is terminated to prevent orphans
+  - Added 2 unit tests for PID file handling
+
 - **Add logging when TOML config parsing fails** (#145)
   - Config parsing failures now log a warning with the error details
   - Missing config file (expected) does not log a warning


### PR DESCRIPTION
## Summary

- Write PID file immediately after spawning daemon process to prevent race condition
- If PID write fails, terminate spawned process to prevent orphan daemon
- Clean up PID file in all error paths

Fixes #152

## Problem

In `DaemonLifecycle.start()`, the PID file was written AFTER checking if the process died. If the process died between the check and PID write, a stale PID file remained which required manual cleanup (`rm .ember/daemon.pid`).

## Solution

Write PID file immediately after spawn, then clean it up if the process fails:
1. Spawn process
2. Write PID file immediately
3. If write fails, terminate process to avoid orphan
4. Check if process died - if so, clean up PID file

## Test plan

- [x] All 369 tests pass
- [x] Linter passes
- [x] Added 2 new tests:
  - `test_start_pid_write_failure_terminates_process` - verifies process is terminated if PID write fails
  - `test_start_pid_written_before_poll_check` - verifies PID is written before alive-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)