### PR TITLE
fix: resolve daemon end-to-end test failures (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Helps users resolve index corruption or stale data issues
 
 ### Fixed
+- **Fix daemon end-to-end tests failing with health check timeout** (#185)
+  - Fixed socket path length issue: Unix domain sockets have ~104 char limit on macOS
+  - Test fixtures now use short paths in `/tmp` instead of pytest's long temp paths
+  - Fixed zombie process detection in `is_process_alive()` by reaping child processes
+  - Increased SIGKILL verification timeout from 0.5s to 2.5s with retry loop
+  - Added `auto_start=False` to fallback test to ensure proper fallback behavior
+
 - **Fix race condition in daemon PID file management** (#152)
   - PID file is now written immediately after spawning daemon process
   - Eliminates race where process could die between alive-check and PID write


### PR DESCRIPTION
## Summary
- Fixed socket path length issue: Unix domain sockets have ~104 char limit on macOS, test fixtures now use short paths in `/tmp`
- Fixed zombie process detection in `is_process_alive()` by reaping child processes with `waitpid()`
- Increased SIGKILL verification timeout from 0.5s to 2.5s with retry loop
- Added `auto_start=False` to fallback test to ensure proper fallback behavior testing

## Details

The daemon end-to-end tests were failing with "health check timeout after 20s" because:

1. **Socket path too long**: macOS limits Unix domain socket paths to ~104 chars. Pytest's `tmp_path` generates paths like `/private/var/folders/mc/.../test-daemon.sock` which exceed this limit. The daemon would load the model successfully but fail when binding to the socket.

2. **Zombie process false positive**: After sending SIGTERM/SIGKILL, `os.kill(pid, 0)` was used to check if the process was still alive. However, this succeeds for zombie processes (children that have exited but not been reaped). Added `waitpid(pid, WNOHANG)` before the check to reap any zombies.

3. **SIGKILL timing**: Some systems need more than 0.5s after SIGKILL for the process to fully terminate. Added a retry loop with up to 2.5s wait.

4. **Fallback test**: With the socket path fix, the daemon now starts successfully, so the fallback test needed `auto_start=False` to actually test fallback behavior.

## Test plan
- [x] Both daemon end-to-end tests pass (`test_daemon_start_stop`, `test_daemon_embedding_workflow`)
- [x] Client fallback test passes (`test_client_fallback_on_daemon_failure`)
- [x] All 30 daemon integration tests pass
- [x] All 51 slow tests pass
- [x] All 369 regular tests pass
- [x] Linter passes (`ruff check .`)
- [x] Tests are stable (ran 3x with consistent results)

Fixes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)