### PR TITLE
refactor: extract file I/O from ResultPresenter to respect clean architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **ResultPresenter refactored to use dependency injection for file I/O** (#170)
+  - Extracted file reading from core presentation layer to respect clean architecture
+  - ResultPresenter now accepts a FileSystem port via constructor injection
+  - Added `read_text_lines()` method to FileSystem protocol and LocalFileSystem adapter
+  - Tests can now easily mock file content without touching the filesystem
+  - Core layer no longer directly performs file I/O operations
+
 ### Added
 - **Comprehensive unit tests for ResultPresenter class** (#149)
   - Increased test coverage from 76% to 100%

--- a/ember/adapters/fs/local.py
+++ b/ember/adapters/fs/local.py
@@ -79,3 +79,20 @@ class LocalFileSystem:
         matches = sorted(root.glob(pattern))
         # Ensure all paths are absolute
         return [p.resolve() for p in matches]
+
+    def read_text_lines(self, path: Path) -> list[str] | None:
+        """Read file and return lines as strings.
+
+        Args:
+            path: Absolute path to file.
+
+        Returns:
+            List of lines (without trailing newlines), or None if file
+            doesn't exist or can't be read.
+        """
+        if not path.exists():
+            return None
+        try:
+            return path.read_text(errors="replace").splitlines()
+        except Exception:
+            return None

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import blake3
 import click
 
+from ember.adapters.fs.local import LocalFileSystem
 from ember.core.cli_utils import (
     format_result_header,
     load_cached_results,
@@ -689,10 +690,11 @@ def find(
             click.echo(f"Warning: Could not cache results: {e}", err=True)
 
     # Display results
+    presenter = ResultPresenter(LocalFileSystem())
     if json_output:
-        click.echo(ResultPresenter.format_json_output(results, context=context, repo_root=repo_root))
+        click.echo(presenter.format_json_output(results, context=context, repo_root=repo_root))
     else:
-        ResultPresenter.format_human_output(results, context=context, repo_root=repo_root, config=config)
+        presenter.format_human_output(results, context=context, repo_root=repo_root, config=config)
 
 
 @cli.command()

--- a/ember/ports/fs.py
+++ b/ember/ports/fs.py
@@ -71,3 +71,15 @@ class FileSystem(Protocol):
             List of matching absolute paths.
         """
         ...
+
+    def read_text_lines(self, path: Path) -> list[str] | None:
+        """Read file and return lines as strings.
+
+        Args:
+            path: Absolute path to file.
+
+        Returns:
+            List of lines (without trailing newlines), or None if file
+            doesn't exist or can't be read.
+        """
+        ...


### PR DESCRIPTION
## Summary

- Refactored `ResultPresenter` to accept `FileSystem` port via constructor injection
- Added `read_text_lines()` method to `FileSystem` protocol and `LocalFileSystem` adapter
- Updated CLI to inject `LocalFileSystem` when creating `ResultPresenter`
- Updated tests to use `MockFileSystem` for easier mocking

## Details

This PR addresses the clean architecture violation in `ResultPresenter` where file I/O operations were performed directly in the core presentation layer. 

**Before:** `ResultPresenter._read_file_lines()` was a static method that directly used `pathlib.Path` to read files from disk.

**After:** `ResultPresenter` accepts a `FileSystem` port via constructor, and delegates file reading to the injected implementation. The core layer now depends only on the `ports/` interface, not on infrastructure.

### Changes

1. **`ember/ports/fs.py`**: Added `read_text_lines()` method to `FileSystem` protocol
2. **`ember/adapters/fs/local.py`**: Implemented `read_text_lines()` in `LocalFileSystem`
3. **`ember/core/presentation/result_presenter.py`**: Converted to instance-based class with `FileSystem` injection
4. **`ember/entrypoints/cli.py`**: Creates `ResultPresenter` with `LocalFileSystem()` instance
5. **`tests/unit/core/test_result_presenter.py`**: Added `MockFileSystem` for easy testing

Closes #170

## Test plan

- [x] All existing tests pass (373 tests)
- [x] Added new tests for mock filesystem injection
- [x] Verified no adapter imports in `core/presentation/result_presenter.py`
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)