### PR TITLE
refactor: reduce CLI cat function complexity from C=16 to C=5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Reduced `cat` command complexity from C=16 to C=5** (#171)
+  - Extracted `lookup_result_from_cache()` helper for numeric index lookups
+  - Extracted `lookup_result_by_hash()` helper for hash-based chunk lookups
+  - Extracted `display_content_with_context()` helper for context line display
+  - Extracted `display_content_with_highlighting()` helper for syntax highlighting
+  - Main `cat` function reduced from 130 lines to ~50 lines
+  - All helpers are individually testable with 11 new unit tests
+
 - **ResultPresenter refactored to use dependency injection for file I/O** (#170)
   - Extracted file reading from core presentation layer to respect clean architecture
   - ResultPresenter now accepts a FileSystem port via constructor injection

--- a/tests/unit/core/test_cli_utils.py
+++ b/tests/unit/core/test_cli_utils.py
@@ -1,0 +1,185 @@
+"""Unit tests for CLI utility functions.
+
+Tests for the helper functions extracted from the CLI cat command.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from ember.core.cli_utils import (
+    display_content_with_context,
+    display_content_with_highlighting,
+    lookup_result_by_hash,
+    lookup_result_from_cache,
+)
+
+
+class TestLookupResultFromCache:
+    """Tests for lookup_result_from_cache function."""
+
+    def test_returns_result_for_valid_index(self, tmp_path: Path) -> None:
+        """Should return the result at the given index."""
+        cache_path = tmp_path / ".last_search.json"
+        cache_data = {
+            "query": "test",
+            "results": [
+                {"path": "file1.py", "start_line": 1, "content": "content1"},
+                {"path": "file2.py", "start_line": 10, "content": "content2"},
+            ],
+        }
+        cache_path.write_text(json.dumps(cache_data))
+
+        result = lookup_result_from_cache("2", cache_path)
+
+        assert result["path"] == "file2.py"
+        assert result["start_line"] == 10
+
+    def test_exits_for_missing_cache(self, tmp_path: Path) -> None:
+        """Should exit with error when cache doesn't exist."""
+        cache_path = tmp_path / ".last_search.json"
+
+        with pytest.raises(SystemExit):
+            lookup_result_from_cache("1", cache_path)
+
+    def test_exits_for_index_out_of_range(self, tmp_path: Path) -> None:
+        """Should exit with error when index is out of range."""
+        cache_path = tmp_path / ".last_search.json"
+        cache_data = {
+            "query": "test",
+            "results": [{"path": "file1.py", "content": "content1"}],
+        }
+        cache_path.write_text(json.dumps(cache_data))
+
+        with pytest.raises(SystemExit):
+            lookup_result_from_cache("5", cache_path)
+
+
+class TestLookupResultByHash:
+    """Tests for lookup_result_by_hash function."""
+
+    def test_returns_result_for_unique_match(self) -> None:
+        """Should return result when exactly one chunk matches."""
+        mock_chunk = MagicMock()
+        mock_chunk.path = Path("file.py")
+        mock_chunk.start_line = 10
+        mock_chunk.end_line = 20
+        mock_chunk.content = "test content"
+        mock_chunk.lang = "python"
+        mock_chunk.symbol = "test_func"
+
+        mock_repo = MagicMock()
+        mock_repo.find_by_id_prefix.return_value = [mock_chunk]
+
+        result = lookup_result_by_hash("abc123", mock_repo)
+
+        assert result["path"] == "file.py"
+        assert result["start_line"] == 10
+        assert result["end_line"] == 20
+        assert result["content"] == "test content"
+        assert result["lang"] == "python"
+        assert result["symbol"] == "test_func"
+
+    def test_exits_for_no_matches(self) -> None:
+        """Should exit with error when no chunks match."""
+        mock_repo = MagicMock()
+        mock_repo.find_by_id_prefix.return_value = []
+
+        with pytest.raises(SystemExit):
+            lookup_result_by_hash("abc123", mock_repo)
+
+    def test_exits_for_multiple_matches(self) -> None:
+        """Should exit with error when multiple chunks match."""
+        mock_chunk1 = MagicMock()
+        mock_chunk1.id = "abc123456"
+        mock_chunk2 = MagicMock()
+        mock_chunk2.id = "abc123789"
+
+        mock_repo = MagicMock()
+        mock_repo.find_by_id_prefix.return_value = [mock_chunk1, mock_chunk2]
+
+        with pytest.raises(SystemExit):
+            lookup_result_by_hash("abc123", mock_repo)
+
+
+class TestDisplayContentWithContext:
+    """Tests for display_content_with_context function."""
+
+    def test_displays_context_lines(self, tmp_path: Path) -> None:
+        """Should display content with surrounding context lines."""
+        # Create a test file
+        test_file = tmp_path / "test.py"
+        test_file.write_text("line1\nline2\nline3\nline4\nline5\nline6\nline7\n")
+
+        result = {
+            "path": "test.py",
+            "start_line": 3,
+            "end_line": 4,
+            "content": "line3\nline4",
+        }
+
+        # Should return True on success
+        success = display_content_with_context(result, context=2, repo_root=tmp_path)
+        assert success is True
+
+    def test_returns_false_for_missing_file(self, tmp_path: Path) -> None:
+        """Should return False when file doesn't exist."""
+        result = {
+            "path": "nonexistent.py",
+            "start_line": 1,
+            "end_line": 5,
+            "content": "test",
+        }
+
+        success = display_content_with_context(result, context=2, repo_root=tmp_path)
+        assert success is False
+
+
+class TestDisplayContentWithHighlighting:
+    """Tests for display_content_with_highlighting function."""
+
+    def test_displays_plain_content_when_highlighting_disabled(self) -> None:
+        """Should display plain content when syntax highlighting is off."""
+        result = {
+            "path": "test.py",
+            "start_line": 1,
+            "content": "def foo(): pass",
+        }
+
+        mock_config = MagicMock()
+        mock_config.display.syntax_highlighting = False
+
+        # Should not raise any errors
+        display_content_with_highlighting(result, mock_config)
+
+    def test_applies_syntax_highlighting_when_enabled(self) -> None:
+        """Should apply syntax highlighting when enabled."""
+        result = {
+            "path": "test.py",
+            "start_line": 1,
+            "content": "def foo(): pass",
+        }
+
+        mock_config = MagicMock()
+        mock_config.display.syntax_highlighting = True
+        mock_config.display.theme = "monokai"
+
+        # Should not raise any errors
+        display_content_with_highlighting(result, mock_config)
+
+    def test_falls_back_to_plain_on_highlighting_error(self) -> None:
+        """Should fall back to plain text if highlighting fails."""
+        result = {
+            "path": "test.unknown_extension",
+            "start_line": 1,
+            "content": "some content",
+        }
+
+        mock_config = MagicMock()
+        mock_config.display.syntax_highlighting = True
+        mock_config.display.theme = "invalid_theme_that_should_fail"
+
+        # Should not raise any errors (falls back to plain text)
+        display_content_with_highlighting(result, mock_config)


### PR DESCRIPTION
## Summary
- Extracts helper functions from the 130-line cat command to improve testability and maintainability
- Reduces cyclomatic complexity from 16 (very high) to approximately 5 (low)

## Changes
- **`lookup_result_from_cache()`**: Looks up result by numeric index from cached search results
- **`lookup_result_by_hash()`**: Looks up result by chunk ID hash prefix with proper error handling
- **`display_content_with_context()`**: Displays chunk content with surrounding context lines
- **`display_content_with_highlighting()`**: Displays chunk with optional syntax highlighting

The main `cat` function is now ~50 lines with clear separation between lookup and display concerns.

## Implements #171

## Acceptance Criteria
- [x] `cat` function complexity reduced to B (7-10) or lower
- [x] Helper functions are individually testable
- [x] Context rendering logic reused from existing code patterns
- [x] Clear separation between lookup and display concerns

## Test Coverage
- All 382 tests pass (11 new unit tests added for helper functions)
- New tests in `tests/unit/core/test_cli_utils.py`:
  - `TestLookupResultFromCache` (3 tests)
  - `TestLookupResultByHash` (3 tests)
  - `TestDisplayContentWithContext` (2 tests)
  - `TestDisplayContentWithHighlighting` (3 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)