### PR TITLE
fix: remove adapter import from core layer (init_usecase)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Removed architecture violation: adapter import in core layer** (#180)
+  - `InitUseCase` now uses dependency injection for database initialization
+  - Created `DatabaseInitializer` port interface in `ember/ports/database.py`
+  - Created `SqliteDatabaseInitializer` adapter implementation
+  - Core layer (`ember/core/`) no longer imports from adapters layer
+  - Clean architecture dependency rule is now fully restored
+
 - **Reduced `cat` command complexity from C=16 to C=5** (#171)
   - Extracted `lookup_result_from_cache()` helper for numeric index lookups
   - Extracted `lookup_result_by_hash()` helper for hash-based chunk lookups

--- a/ember/adapters/sqlite/__init__.py
+++ b/ember/adapters/sqlite/__init__.py
@@ -1,6 +1,12 @@
 """SQLite adapters for ember storage."""
 
 from .file_repository import SQLiteFileRepository
+from .initializer import SqliteDatabaseInitializer
 from .schema import check_schema_version, init_database
 
-__all__ = ["SQLiteFileRepository", "init_database", "check_schema_version"]
+__all__ = [
+    "SQLiteFileRepository",
+    "SqliteDatabaseInitializer",
+    "init_database",
+    "check_schema_version",
+]

--- a/ember/adapters/sqlite/initializer.py
+++ b/ember/adapters/sqlite/initializer.py
@@ -1,0 +1,28 @@
+"""SQLite database initializer adapter.
+
+Implements the DatabaseInitializer port using SQLite.
+"""
+
+from pathlib import Path
+
+from ember.adapters.sqlite.schema import init_database as sqlite_init_database
+
+
+class SqliteDatabaseInitializer:
+    """SQLite implementation of DatabaseInitializer port.
+
+    Wraps the existing init_database function to satisfy the port interface.
+    """
+
+    def init_database(self, db_path: Path) -> None:
+        """Initialize a new SQLite database with complete schema.
+
+        Creates all tables, indexes, and default metadata entries.
+
+        Args:
+            db_path: Path to the SQLite database file.
+
+        Raises:
+            sqlite3.Error: If database creation fails.
+        """
+        sqlite_init_database(db_path)

--- a/ember/core/config/init_usecase.py
+++ b/ember/core/config/init_usecase.py
@@ -7,7 +7,7 @@ necessary files: config.toml, index.db, and state.json.
 from dataclasses import dataclass
 from pathlib import Path
 
-from ember.adapters.sqlite.schema import init_database
+from ember.ports.database import DatabaseInitializer
 from ember.shared.config_io import create_default_config_file
 from ember.shared.state_io import create_initial_state
 
@@ -51,12 +51,14 @@ class InitUseCase:
     It's the first command users run when setting up ember in a codebase.
     """
 
-    def __init__(self, version: str = "0.1.0"):
+    def __init__(self, db_initializer: DatabaseInitializer, version: str = "0.1.0"):
         """Initialize the use case.
 
         Args:
+            db_initializer: Database initializer for creating the index database.
             version: Ember version string (for state.json)
         """
+        self._db_initializer = db_initializer
         self.version = version
 
     def execute(self, request: InitRequest) -> InitResponse:
@@ -95,8 +97,8 @@ class InitUseCase:
         # Create config.toml with defaults
         create_default_config_file(config_path)
 
-        # Initialize SQLite database with schema
-        init_database(db_path)
+        # Initialize database with schema
+        self._db_initializer.init_database(db_path)
 
         # Create initial state.json
         create_initial_state(state_path, version=self.version)

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -344,13 +344,15 @@ def init(ctx: click.Context, force: bool) -> None:
     If in a git repository, initializes at the git root.
     """
     # Lazy import - only load when init is actually called
+    from ember.adapters.sqlite.initializer import SqliteDatabaseInitializer
     from ember.core.config.init_usecase import InitRequest, InitUseCase
     from ember.core.repo_utils import find_repo_root_for_init
 
     repo_root = find_repo_root_for_init()
 
-    # Create use case and execute
-    use_case = InitUseCase(version="1.1.0")
+    # Create use case with injected dependencies
+    db_initializer = SqliteDatabaseInitializer()
+    use_case = InitUseCase(db_initializer=db_initializer, version="1.1.0")
     request = InitRequest(repo_root=repo_root, force=force)
 
     try:

--- a/ember/ports/database.py
+++ b/ember/ports/database.py
@@ -1,0 +1,29 @@
+"""Database port interface for database initialization.
+
+Defines abstract interface for database schema initialization.
+Implementations should be in adapters/ layer.
+"""
+
+from pathlib import Path
+from typing import Protocol
+
+
+class DatabaseInitializer(Protocol):
+    """Protocol for database initialization operations.
+
+    This port abstracts the database initialization logic, allowing
+    the core layer to remain independent of specific database implementations.
+    """
+
+    def init_database(self, db_path: Path) -> None:
+        """Initialize a new database with complete schema.
+
+        Creates all tables, indexes, and default metadata entries.
+
+        Args:
+            db_path: Path to the database file (e.g., .ember/index.db)
+
+        Raises:
+            Exception: If database creation fails.
+        """
+        ...

--- a/tests/integration/test_config_workflow.py
+++ b/tests/integration/test_config_workflow.py
@@ -7,6 +7,7 @@ import tempfile
 from pathlib import Path
 
 from ember.adapters.config.toml_config_provider import TomlConfigProvider
+from ember.adapters.sqlite.initializer import SqliteDatabaseInitializer
 from ember.core.config.init_usecase import InitRequest, InitUseCase
 from ember.shared.config_io import load_config
 
@@ -18,7 +19,8 @@ def test_init_creates_valid_config():
         repo_root.mkdir()
 
         # Initialize ember
-        use_case = InitUseCase(version="0.1.0")
+        db_initializer = SqliteDatabaseInitializer()
+        use_case = InitUseCase(db_initializer=db_initializer, version="0.1.0")
         request = InitRequest(repo_root=repo_root, force=False)
         response = use_case.execute(request)
 
@@ -38,7 +40,8 @@ def test_config_provider_loads_init_config():
         repo_root.mkdir()
 
         # Initialize ember
-        use_case = InitUseCase(version="0.1.0")
+        db_initializer = SqliteDatabaseInitializer()
+        use_case = InitUseCase(db_initializer=db_initializer, version="0.1.0")
         request = InitRequest(repo_root=repo_root, force=False)
         response = use_case.execute(request)
 
@@ -59,7 +62,8 @@ def test_modified_config_is_loaded():
         repo_root.mkdir()
 
         # Initialize ember
-        use_case = InitUseCase(version="0.1.0")
+        db_initializer = SqliteDatabaseInitializer()
+        use_case = InitUseCase(db_initializer=db_initializer, version="0.1.0")
         request = InitRequest(repo_root=repo_root, force=False)
         response = use_case.execute(request)
 

--- a/tests/integration/test_subdirectory_support.py
+++ b/tests/integration/test_subdirectory_support.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from ember.adapters.sqlite.initializer import SqliteDatabaseInitializer
+
 
 @pytest.fixture
 def test_repo_with_subdirs(tmp_path):
@@ -56,7 +58,8 @@ def test_init_from_subdirectory_finds_git_root(test_repo_with_subdirs):
     assert repo_root == repo
 
     # Now actually initialize
-    use_case = InitUseCase(version="0.2.0")
+    db_initializer = SqliteDatabaseInitializer()
+    use_case = InitUseCase(db_initializer=db_initializer, version="0.2.0")
     request = InitRequest(repo_root=repo_root, force=False)
     response = use_case.execute(request)
 
@@ -74,7 +77,8 @@ def test_find_ember_root_from_subdirectory(test_repo_with_subdirs):
     # Initialize ember at repo root
     from ember.core.config.init_usecase import InitRequest, InitUseCase
 
-    use_case = InitUseCase(version="0.2.0")
+    db_initializer = SqliteDatabaseInitializer()
+    use_case = InitUseCase(db_initializer=db_initializer, version="0.2.0")
     request = InitRequest(repo_root=repo, force=False)
     use_case.execute(request)
 
@@ -117,7 +121,8 @@ def test_path_scoped_search_from_subdirectory(test_repo_with_subdirs):
     # Initialize and sync
     from ember.core.config.init_usecase import InitRequest, InitUseCase
 
-    use_case = InitUseCase(version="0.2.0")
+    db_initializer = SqliteDatabaseInitializer()
+    use_case = InitUseCase(db_initializer=db_initializer, version="0.2.0")
     request = InitRequest(repo_root=repo, force=False)
     use_case.execute(request)
 


### PR DESCRIPTION
## Summary

- Created `DatabaseInitializer` port interface for database initialization abstraction
- Implemented `SqliteDatabaseInitializer` adapter to satisfy the port
- Updated `InitUseCase` to receive database initializer via dependency injection
- Fixed architecture violation where core layer was importing from adapters

Fixes #180

## Changes

- **New files:**
  - `ember/ports/database.py` - Port interface for database initialization
  - `ember/adapters/sqlite/initializer.py` - SQLite implementation of the port

- **Modified files:**
  - `ember/core/config/init_usecase.py` - Now receives `DatabaseInitializer` via constructor
  - `ember/entrypoints/cli.py` - Wires the dependency injection
  - Updated all tests that use `InitUseCase` to inject the dependency

## Test plan

- [x] All 382 tests pass
- [x] Linter passes (`ruff check .`)
- [x] No imports from `ember.adapters` in `ember/core/` (verified with grep)
- [x] Architecture constraint: core only depends on ports, never adapters

🤖 Generated with [Claude Code](https://claude.com/claude-code)