### PR TITLE
refactor: add validation to domain entities (Query, Chunk, Config)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Input validation for domain entities** (#173)
+  - Query validates `topk > 0` and non-empty text on construction
+  - Chunk validates `start_line` and `end_line` are >= 1 and `start_line <= end_line`
+  - IndexConfig validates `line_window > 0`, `line_stride > 0`, `overlap_lines >= 0`, and `overlap_lines < line_window`
+  - SearchConfig validates `topk > 0`
+  - RedactionConfig validates `max_file_mb > 0`
+  - ModelConfig validates `daemon_timeout > 0` and `daemon_startup_timeout > 0`
+  - Invalid configuration values now fail fast with clear error messages
+  - Added 35 new tests covering validation edge cases
+
 ### Changed
 - **Removed architecture violation: adapter import in core layer** (#180)
   - `InitUseCase` now uses dependency injection for database initialization

--- a/ember/domain/entities.py
+++ b/ember/domain/entities.py
@@ -30,6 +30,9 @@ class Chunk:
         file_hash: blake3 hash of entire file (for change detection).
         tree_sha: Git tree SHA when chunk was indexed.
         rev: Git revision (commit SHA) when indexed, or "worktree".
+
+    Raises:
+        ValueError: If line numbers are invalid (< 1 or start > end).
     """
 
     id: str
@@ -44,6 +47,15 @@ class Chunk:
     file_hash: str
     tree_sha: str
     rev: str
+
+    def __post_init__(self) -> None:
+        """Validate chunk data after initialization."""
+        if self.start_line < 1 or self.end_line < 1:
+            raise ValueError("Line numbers must be >= 1")
+        if self.start_line > self.end_line:
+            raise ValueError(
+                f"start_line ({self.start_line}) > end_line ({self.end_line})"
+            )
 
     @staticmethod
     def compute_content_hash(content: str) -> str:
@@ -110,6 +122,9 @@ class Query:
         path_filter: Optional glob pattern to filter by file path.
         lang_filter: Optional language code to filter by.
         json_output: Whether to output JSON instead of human-readable text.
+
+    Raises:
+        ValueError: If text is empty or topk is not positive.
     """
 
     text: str
@@ -117,6 +132,13 @@ class Query:
     path_filter: str | None = None
     lang_filter: str | None = None
     json_output: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate query data after initialization."""
+        if not self.text or not self.text.strip():
+            raise ValueError("Query text cannot be empty")
+        if self.topk <= 0:
+            raise ValueError(f"topk must be positive, got {self.topk}")
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,14 +72,17 @@ def sample_chunks() -> list[Chunk]:
     """
     chunks = []
     for i in range(5):
+        # Start lines at 1 (1-indexed) to satisfy validation
+        start_line = (i * 10) + 1
+        end_line = start_line + 10
         chunk = Chunk(
             id=f"chunk_{i}",
             project_id="test_project",
             path=Path(f"src/file_{i}.py"),
             lang="py",
             symbol=f"function_{i}",
-            start_line=i * 10,
-            end_line=(i * 10) + 10,
+            start_line=start_line,
+            end_line=end_line,
             content=f"def function_{i}():\n    pass",
             content_hash=Chunk.compute_content_hash(f"def function_{i}():\n    pass"),
             file_hash=f"hash_{i}",

--- a/tests/unit/domain/test_config.py
+++ b/tests/unit/domain/test_config.py
@@ -1,0 +1,202 @@
+"""Tests for domain config classes validation."""
+
+import pytest
+
+from ember.domain.config import (
+    DisplayConfig,
+    IndexConfig,
+    ModelConfig,
+    RedactionConfig,
+    SearchConfig,
+)
+
+# =============================================================================
+# IndexConfig validation tests
+# =============================================================================
+
+
+class TestIndexConfigValidation:
+    """Tests for IndexConfig entity validation."""
+
+    def test_index_config_valid_defaults(self):
+        """Test creating IndexConfig with valid defaults."""
+        config = IndexConfig()
+        assert config.line_window == 120
+        assert config.line_stride == 100
+        assert config.overlap_lines == 15
+
+    def test_index_config_valid_custom_values(self):
+        """Test creating IndexConfig with valid custom values."""
+        config = IndexConfig(line_window=200, line_stride=150, overlap_lines=20)
+        assert config.line_window == 200
+        assert config.line_stride == 150
+        assert config.overlap_lines == 20
+
+    def test_index_config_line_window_zero_raises_error(self):
+        """Test that line_window=0 raises ValueError."""
+        with pytest.raises(ValueError, match="line_window must be positive"):
+            IndexConfig(line_window=0)
+
+    def test_index_config_line_window_negative_raises_error(self):
+        """Test that negative line_window raises ValueError."""
+        with pytest.raises(ValueError, match="line_window must be positive"):
+            IndexConfig(line_window=-10)
+
+    def test_index_config_line_stride_zero_raises_error(self):
+        """Test that line_stride=0 raises ValueError."""
+        with pytest.raises(ValueError, match="line_stride must be positive"):
+            IndexConfig(line_stride=0)
+
+    def test_index_config_line_stride_negative_raises_error(self):
+        """Test that negative line_stride raises ValueError."""
+        with pytest.raises(ValueError, match="line_stride must be positive"):
+            IndexConfig(line_stride=-5)
+
+    def test_index_config_overlap_lines_negative_raises_error(self):
+        """Test that negative overlap_lines raises ValueError."""
+        with pytest.raises(ValueError, match="overlap_lines cannot be negative"):
+            IndexConfig(overlap_lines=-1)
+
+    def test_index_config_overlap_lines_zero_valid(self):
+        """Test that overlap_lines=0 is valid (no overlap)."""
+        config = IndexConfig(overlap_lines=0)
+        assert config.overlap_lines == 0
+
+    def test_index_config_overlap_greater_than_window_raises_error(self):
+        """Test that overlap_lines >= line_window raises ValueError."""
+        with pytest.raises(ValueError, match="overlap_lines.*must be less than.*line_window"):
+            IndexConfig(line_window=100, overlap_lines=100)
+
+        with pytest.raises(ValueError, match="overlap_lines.*must be less than.*line_window"):
+            IndexConfig(line_window=100, overlap_lines=150)
+
+
+# =============================================================================
+# SearchConfig validation tests
+# =============================================================================
+
+
+class TestSearchConfigValidation:
+    """Tests for SearchConfig entity validation."""
+
+    def test_search_config_valid_defaults(self):
+        """Test creating SearchConfig with valid defaults."""
+        config = SearchConfig()
+        assert config.topk == 20
+        assert config.rerank is False
+
+    def test_search_config_valid_custom_values(self):
+        """Test creating SearchConfig with valid custom values."""
+        config = SearchConfig(topk=50, rerank=True)
+        assert config.topk == 50
+        assert config.rerank is True
+
+    def test_search_config_topk_zero_raises_error(self):
+        """Test that topk=0 raises ValueError."""
+        with pytest.raises(ValueError, match="topk must be positive"):
+            SearchConfig(topk=0)
+
+    def test_search_config_topk_negative_raises_error(self):
+        """Test that negative topk raises ValueError."""
+        with pytest.raises(ValueError, match="topk must be positive"):
+            SearchConfig(topk=-5)
+
+    def test_search_config_topk_one_valid(self):
+        """Test that topk=1 is valid."""
+        config = SearchConfig(topk=1)
+        assert config.topk == 1
+
+
+# =============================================================================
+# RedactionConfig validation tests
+# =============================================================================
+
+
+class TestRedactionConfigValidation:
+    """Tests for RedactionConfig entity validation."""
+
+    def test_redaction_config_valid_defaults(self):
+        """Test creating RedactionConfig with valid defaults."""
+        config = RedactionConfig()
+        assert config.max_file_mb == 5
+
+    def test_redaction_config_valid_custom_values(self):
+        """Test creating RedactionConfig with valid custom values."""
+        config = RedactionConfig(max_file_mb=10)
+        assert config.max_file_mb == 10
+
+    def test_redaction_config_max_file_mb_zero_raises_error(self):
+        """Test that max_file_mb=0 raises ValueError."""
+        with pytest.raises(ValueError, match="max_file_mb must be positive"):
+            RedactionConfig(max_file_mb=0)
+
+    def test_redaction_config_max_file_mb_negative_raises_error(self):
+        """Test that negative max_file_mb raises ValueError."""
+        with pytest.raises(ValueError, match="max_file_mb must be positive"):
+            RedactionConfig(max_file_mb=-1)
+
+
+# =============================================================================
+# ModelConfig validation tests
+# =============================================================================
+
+
+class TestModelConfigValidation:
+    """Tests for ModelConfig entity validation."""
+
+    def test_model_config_valid_defaults(self):
+        """Test creating ModelConfig with valid defaults."""
+        config = ModelConfig()
+        assert config.daemon_timeout == 900
+        assert config.daemon_startup_timeout == 5
+
+    def test_model_config_valid_custom_values(self):
+        """Test creating ModelConfig with valid custom values."""
+        config = ModelConfig(daemon_timeout=600, daemon_startup_timeout=10)
+        assert config.daemon_timeout == 600
+        assert config.daemon_startup_timeout == 10
+
+    def test_model_config_daemon_timeout_zero_raises_error(self):
+        """Test that daemon_timeout=0 raises ValueError."""
+        with pytest.raises(ValueError, match="daemon_timeout must be positive"):
+            ModelConfig(daemon_timeout=0)
+
+    def test_model_config_daemon_timeout_negative_raises_error(self):
+        """Test that negative daemon_timeout raises ValueError."""
+        with pytest.raises(ValueError, match="daemon_timeout must be positive"):
+            ModelConfig(daemon_timeout=-100)
+
+    def test_model_config_daemon_startup_timeout_zero_raises_error(self):
+        """Test that daemon_startup_timeout=0 raises ValueError."""
+        with pytest.raises(ValueError, match="daemon_startup_timeout must be positive"):
+            ModelConfig(daemon_startup_timeout=0)
+
+    def test_model_config_daemon_startup_timeout_negative_raises_error(self):
+        """Test that negative daemon_startup_timeout raises ValueError."""
+        with pytest.raises(ValueError, match="daemon_startup_timeout must be positive"):
+            ModelConfig(daemon_startup_timeout=-1)
+
+
+# =============================================================================
+# DisplayConfig validation tests (no validation needed, just literal types)
+# =============================================================================
+
+
+class TestDisplayConfigValidation:
+    """Tests for DisplayConfig entity validation."""
+
+    def test_display_config_valid_defaults(self):
+        """Test creating DisplayConfig with valid defaults."""
+        config = DisplayConfig()
+        assert config.syntax_highlighting is True
+        assert config.color_scheme == "auto"
+        assert config.theme == "ansi"
+
+    def test_display_config_valid_custom_values(self):
+        """Test creating DisplayConfig with valid custom values."""
+        config = DisplayConfig(
+            syntax_highlighting=False, color_scheme="always", theme="monokai"
+        )
+        assert config.syntax_highlighting is False
+        assert config.color_scheme == "always"
+        assert config.theme == "monokai"


### PR DESCRIPTION
## Summary
- Add `__post_init__` validation to domain entities to fail fast on invalid configuration values
- Query: validates `topk > 0` and non-empty text
- Chunk: validates line numbers `>= 1` and `start_line <= end_line`
- IndexConfig: validates `line_window > 0`, `line_stride > 0`, `overlap_lines >= 0`, and `overlap_lines < line_window`
- SearchConfig: validates `topk > 0`
- RedactionConfig: validates `max_file_mb > 0`
- ModelConfig: validates `daemon_timeout > 0` and `daemon_startup_timeout > 0`

Implements #173

## Test plan
- [x] All 421 tests pass
- [x] 35 new validation tests added
- [x] Linter passes (`uv run ruff check .`)
- [x] Fixed sample_chunks fixture to use valid 1-indexed line numbers
- [x] No architecture violations introduced

## Acceptance Criteria (from issue)
- [x] Query validates topk > 0 and text not empty
- [x] Chunk validates start_line <= end_line and both >= 1
- [x] Config classes validate positive values and logical constraints
- [x] Tests added for validation edge cases
- [x] Clear error messages when validation fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)