### PR TITLE
refactor: reduce DaemonLifecycle.start() complexity from C=13 to B=6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added 35 new tests covering validation edge cases
 
 ### Changed
+- **Reduced `DaemonLifecycle.start()` complexity from C=13 to B=6** (#172)
+  - Extracted `_wait_for_daemon_ready()` for consolidated health check waiting
+  - Extracted `_cleanup_failed_startup()` for PID file cleanup after failures
+  - Extracted `_read_stderr_output()` for safe stderr reading with logging
+  - Extracted `_start_foreground()` for foreground daemon execution
+  - Extracted `_spawn_background_process()` for background process creation
+  - Extracted `_write_pid_file()` for PID file writing with process termination on failure
+  - Extracted `_check_instant_failure()` for early process failure detection
+  - Extracted `_handle_startup_timeout()` for timeout error handling
+  - Main `start()` function reduced to simple orchestration of helper methods
+
 - **Removed architecture violation: adapter import in core layer** (#180)
   - `InitUseCase` now uses dependency injection for database initialization
   - Created `DatabaseInitializer` port interface in `ember/ports/database.py`

--- a/ember/adapters/daemon/lifecycle.py
+++ b/ember/adapters/daemon/lifecycle.py
@@ -109,6 +109,140 @@ class DaemonLifecycle:
             logger.info(f"Removing stale socket: {self.socket_path}")
             self.socket_path.unlink()
 
+    def _cleanup_failed_startup(self) -> None:
+        """Clean up PID file after a failed startup attempt."""
+        self.pid_file.unlink(missing_ok=True)
+
+    def _wait_for_daemon_ready(self, max_wait_secs: float = 20.0) -> bool:
+        """Wait for daemon to become ready.
+
+        Args:
+            max_wait_secs: Maximum seconds to wait for daemon to be ready
+
+        Returns:
+            True if daemon is ready, False if timeout
+        """
+        check_interval = 0.5
+        num_checks = int(max_wait_secs / check_interval)
+
+        for i in range(num_checks):
+            time.sleep(check_interval)
+            if self.is_running():
+                elapsed = (i + 1) * check_interval
+                logger.info(f"Daemon is ready (took {elapsed:.1f}s)")
+                return True
+
+        return False
+
+    def _read_stderr_output(self, process: subprocess.Popen) -> str:
+        """Read stderr output from a process for error reporting.
+
+        Args:
+            process: The subprocess to read stderr from
+
+        Returns:
+            Decoded stderr output, or empty string if unavailable
+        """
+        if not process.stderr:
+            return ""
+        try:
+            stderr_bytes = process.stderr.read()
+            return stderr_bytes.decode("utf-8", errors="replace").strip()
+        except Exception:
+            logger.debug("Failed to read stderr from process")
+            return ""
+
+    def _start_foreground(self, cmd: list[str]) -> bool:
+        """Start daemon in foreground mode (blocking).
+
+        Args:
+            cmd: Command to execute
+
+        Returns:
+            True if started successfully
+        """
+        logger.info("Starting daemon in foreground...")
+        subprocess.run(cmd, check=True)
+        return True
+
+    def _spawn_background_process(self, cmd: list[str]) -> subprocess.Popen:
+        """Spawn daemon as a background process.
+
+        Args:
+            cmd: Command to execute
+
+        Returns:
+            The spawned process
+        """
+        logger.info("Starting daemon in background...")
+        return subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,  # Capture stderr to report startup failures
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,  # Detach from parent
+        )
+
+    def _write_pid_file(self, process: subprocess.Popen) -> None:
+        """Write PID file for the spawned process.
+
+        Args:
+            process: The spawned process
+
+        Raises:
+            RuntimeError: If PID file cannot be written
+        """
+        try:
+            self.pid_file.write_text(str(process.pid))
+            logger.info(f"Daemon started with PID {process.pid}")
+        except Exception as e:
+            # Failed to write PID file - terminate process to avoid orphan
+            process.terminate()
+            raise RuntimeError(f"Failed to write PID file: {e}") from e
+
+    def _check_instant_failure(self, process: subprocess.Popen) -> None:
+        """Check if the process failed immediately after spawn.
+
+        Args:
+            process: The spawned process
+
+        Raises:
+            RuntimeError: If process exited immediately with an error
+        """
+        time.sleep(0.1)  # Brief wait for instant failures
+        exit_code = process.poll()
+        if exit_code is not None:
+            self._cleanup_failed_startup()
+            stderr_output = self._read_stderr_output(process)
+
+            error_msg = f"Daemon failed to start (exit code: {exit_code})"
+            if stderr_output:
+                error_msg += f"\nStderr: {stderr_output}"
+            error_msg += f"\nCheck daemon logs at: {self.log_file}"
+            raise RuntimeError(error_msg)
+
+    def _handle_startup_timeout(self, process: subprocess.Popen) -> None:
+        """Handle the case where daemon didn't become ready in time.
+
+        Args:
+            process: The spawned process
+
+        Raises:
+            RuntimeError: With appropriate message based on process state
+        """
+        self._cleanup_failed_startup()
+        if self.is_process_alive(process.pid):
+            raise RuntimeError(
+                "Daemon process started but not responding to health checks after 20s. "
+                "This may indicate model loading issues. Check daemon logs at: "
+                f"{self.log_file}"
+            )
+        else:
+            raise RuntimeError(
+                f"Daemon process {process.pid} exited unexpectedly during startup. "
+                f"Check daemon logs at: {self.log_file}"
+            )
+
     def start(self, foreground: bool = False) -> bool:
         """Start the daemon.
 
@@ -121,15 +255,12 @@ class DaemonLifecycle:
         Raises:
             RuntimeError: If start fails
         """
-        # Check if already running
         if self.is_running():
             logger.info("Daemon already running")
             return True
 
-        # Clean up stale files
         self.cleanup_stale_files()
 
-        # Build command
         cmd = [
             sys.executable,
             "-m",
@@ -144,92 +275,27 @@ class DaemonLifecycle:
 
         try:
             if foreground:
-                # Run in foreground (blocks)
-                logger.info("Starting daemon in foreground...")
-                subprocess.run(cmd, check=True)
+                return self._start_foreground(cmd)
+
+            process = self._spawn_background_process(cmd)
+            self._write_pid_file(process)
+
+            try:
+                self._check_instant_failure(process)
+            finally:
+                if process.stderr:
+                    process.stderr.close()
+
+            if self._wait_for_daemon_ready():
                 return True
-            else:
-                # Run in background (detached)
-                logger.info("Starting daemon in background...")
 
-                # Spawn detached process - capture stderr initially for debugging
-                process = subprocess.Popen(
-                    cmd,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.PIPE,  # Capture stderr to report startup failures
-                    stdin=subprocess.DEVNULL,
-                    start_new_session=True,  # Detach from parent
-                )
-
-                # Write PID file immediately after spawn to avoid race condition
-                # (process dying between check and write leaves stale PID)
-                try:
-                    self.pid_file.write_text(str(process.pid))
-                    logger.info(f"Daemon started with PID {process.pid}")
-                except Exception as e:
-                    # Failed to write PID file - terminate process to avoid orphan
-                    process.terminate()
-                    raise RuntimeError(f"Failed to write PID file: {e}") from e
-
-                try:
-                    # Check if process died instantly
-                    time.sleep(0.1)  # Brief wait for instant failures
-                    exit_code = process.poll()
-                    if exit_code is not None:
-                        # Process already exited - clean up PID file
-                        self.pid_file.unlink(missing_ok=True)
-
-                        # Try to get stderr for error message
-                        stderr_output = ""
-                        try:
-                            stderr_bytes = (
-                                process.stderr.read() if process.stderr else b""
-                            )
-                            stderr_output = stderr_bytes.decode(
-                                "utf-8", errors="replace"
-                            ).strip()
-                        except Exception:
-                            pass
-
-                        error_msg = f"Daemon failed to start (exit code: {exit_code})"
-                        if stderr_output:
-                            error_msg += f"\nStderr: {stderr_output}"
-                        error_msg += f"\nCheck daemon logs at: {self.log_file}"
-                        raise RuntimeError(error_msg)
-                finally:
-                    # Always close stderr to prevent file descriptor leak
-                    if process.stderr:
-                        process.stderr.close()
-
-                # Wait for daemon to be ready (up to 20 seconds to allow model loading)
-                # Model loading typically takes 3-5 seconds, but can be longer on first download
-                for i in range(40):  # 40 * 0.5s = 20s
-                    time.sleep(0.5)
-                    if self.is_running():
-                        elapsed = (i + 1) * 0.5
-                        logger.info(f"Daemon is ready (took {elapsed:.1f}s)")
-                        return True
-
-                # Daemon started but health check timed out
-                # Check if process is still alive
-                if self.is_process_alive(process.pid):
-                    # Clean up PID file for failed startup
-                    self.pid_file.unlink(missing_ok=True)
-                    raise RuntimeError(
-                        "Daemon process started but not responding to health checks after 20s. "
-                        "This may indicate model loading issues. Check daemon logs at: "
-                        f"{self.log_file}"
-                    )
-                else:
-                    # Clean up PID file for failed startup
-                    self.pid_file.unlink(missing_ok=True)
-                    raise RuntimeError(
-                        f"Daemon process {process.pid} exited unexpectedly during startup. "
-                        f"Check daemon logs at: {self.log_file}"
-                    )
+            self._handle_startup_timeout(process)
 
         except Exception as e:
             raise RuntimeError(f"Failed to start daemon: {e}") from e
+
+        # This return is unreachable but satisfies type checker
+        return False
 
     def stop(self, timeout: int = 10) -> bool:
         """Stop the daemon gracefully.


### PR DESCRIPTION
## Summary

- Reduced cyclomatic complexity of `DaemonLifecycle.start()` from C=13 to B=6
- Extracted 8 focused helper methods for better readability and testability:
  - `_wait_for_daemon_ready()`: Consolidated health check waiting loop
  - `_cleanup_failed_startup()`: Single implementation for PID file cleanup
  - `_read_stderr_output()`: Safe stderr reading with debug logging
  - `_start_foreground()`: Foreground daemon execution
  - `_spawn_background_process()`: Background process creation
  - `_write_pid_file()`: PID file writing with process termination on failure
  - `_check_instant_failure()`: Early process failure detection
  - `_handle_startup_timeout()`: Timeout error handling
- Main `start()` method now orchestrates helper methods with clear control flow

Implements #172

## Acceptance Criteria

- [x] Complexity reduced to B (7-10) or lower - **Achieved B=6**
- [x] Single health check implementation - `_wait_for_daemon_ready()`
- [x] Single PID cleanup implementation - `_cleanup_failed_startup()`
- [x] All exception paths logged appropriately - `_read_stderr_output()` logs debug on failure

## Test Plan

- [x] All existing daemon tests pass (30 tests)
- [x] Linter passes (`ruff check`)
- [x] Verified complexity with radon: `start()` is now B=6

🤖 Generated with [Claude Code](https://claude.com/claude-code)