### PR TITLE
refactor: extract duplicate editor integration code (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added 35 new tests covering validation edge cases
 
 ### Changed
+- **Extract duplicate editor integration code** (#175)
+  - Created `open_file_in_editor()` helper function for consistent editor handling
+  - Moved `EDITOR_PATTERNS` and `get_editor_command()` to cli_utils module
+  - Unified error handling across `search()` and `open_result()` commands
+  - Both commands now use identical error messages and editor detection logic
+  - Added 6 unit tests covering editor opening scenarios
+
 - **Reduced `DaemonLifecycle.start()` complexity from C=13 to B=6** (#172)
   - Extracted `_wait_for_daemon_ready()` for consolidated health check waiting
   - Extracted `_cleanup_failed_startup()` for PID file cleanup after failures

--- a/ember/core/cli_utils.py
+++ b/ember/core/cli_utils.py
@@ -4,6 +4,9 @@ Shared utilities to reduce duplication across CLI commands.
 """
 
 import json
+import os
+import shutil
+import subprocess
 import sys
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -26,7 +29,87 @@ __all__ = ["RichProgressCallback", "progress_context", "load_cached_results",
            "validate_result_index", "highlight_symbol", "format_result_header",
            "ensure_daemon_with_progress", "lookup_result_from_cache",
            "lookup_result_by_hash", "display_content_with_context",
-           "display_content_with_highlighting"]
+           "display_content_with_highlighting", "open_file_in_editor",
+           "get_editor_command", "EDITOR_PATTERNS"]
+
+
+# Editor command patterns for opening files at specific line numbers
+EDITOR_PATTERNS = {
+    # Editors that use +line syntax (vim, emacs, nano)
+    "vim-style": {
+        "editors": ["vim", "vi", "nvim", "emacs", "emacsclient", "nano"],
+        "build": lambda ed, fp, ln: [ed, f"+{ln}", str(fp)],
+    },
+    # VS Code: --goto file:line
+    "vscode-style": {
+        "editors": ["code", "vscode"],
+        "build": lambda ed, fp, ln: [ed, "--goto", f"{fp}:{ln}"],
+    },
+    # Sublime Text and Atom: file:line
+    "colon-style": {
+        "editors": ["subl", "atom"],
+        "build": lambda ed, fp, ln: [ed, f"{fp}:{ln}"],
+    },
+}
+
+
+def get_editor_command(editor: str, file_path: Path, line_num: int) -> list[str]:
+    """Build editor command with line number support.
+
+    Args:
+        editor: Editor executable name or path.
+        file_path: Path to file to open.
+        line_num: Line number to jump to.
+
+    Returns:
+        Command list for subprocess.run().
+
+    Note:
+        Falls back to vim-style +line syntax for unknown editors.
+    """
+    editor_name = Path(editor).name.lower()
+
+    # Find matching pattern
+    for pattern in EDITOR_PATTERNS.values():
+        if editor_name in pattern["editors"]:
+            return pattern["build"](editor, file_path, line_num)
+
+    # Default: vim-style +line syntax (most widely supported)
+    return [editor, f"+{line_num}", str(file_path)]
+
+
+def open_file_in_editor(file_path: Path, line_num: int) -> None:
+    """Open a file in the user's editor at a specific line.
+
+    Uses $VISUAL, then $EDITOR, then falls back to vim.
+
+    Args:
+        file_path: Absolute path to file to open.
+        line_num: Line number to jump to.
+
+    Raises:
+        click.ClickException: If file not found, editor not found, or editor fails.
+    """
+    # Check file exists
+    if not file_path.exists():
+        raise click.ClickException(f"File not found: {file_path}")
+
+    # Determine editor (priority: $VISUAL > $EDITOR > vim)
+    editor = os.environ.get("VISUAL") or os.environ.get("EDITOR") or "vim"
+
+    # Check editor is available
+    if not shutil.which(editor):
+        raise click.ClickException(
+            f"Editor '{editor}' not found. Set $EDITOR or $VISUAL environment variable"
+        )
+
+    # Build and execute command
+    cmd = get_editor_command(editor, file_path, line_num)
+
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        raise click.ClickException(f"Editor failed: {e}") from e
 
 
 class RichProgressCallback:


### PR DESCRIPTION
## Summary

- Created `open_file_in_editor()` helper function for consistent editor handling
- Moved `EDITOR_PATTERNS` and `get_editor_command()` to cli_utils module
- Unified error handling across `search()` and `open_result()` commands

Implements #175

## Changes

- **ember/core/cli_utils.py**: Added `EDITOR_PATTERNS`, `get_editor_command()`, and new `open_file_in_editor()` helper function
- **ember/entrypoints/cli.py**: Refactored `search()` and `open_result()` to use the new helper, removed duplicate code
- **tests/unit/core/test_cli_utils.py**: Added 6 unit tests for the new helper function

## Acceptance Criteria

- [x] Single `open_file_in_editor()` helper function
- [x] Consistent error handling across both commands
- [x] Consistent error messages for same failure modes
- [x] Unit tests for the helper function

## Test Plan

- [x] All existing tests pass (`uv run pytest`)
- [x] Linter passes (`uv run ruff check .`)
- [x] New tests added for `open_file_in_editor()`:
  - Opens file successfully
  - Raises for nonexistent file
  - Raises for missing editor
  - Raises on editor failure
  - Uses VISUAL over EDITOR
  - Defaults to vim

🤖 Generated with [Claude Code](https://claude.com/claude-code)