### PR TITLE
perf: optimize slow daemon test (20s → 0.2s) (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Optimized slow daemon test (20s → 0.2s)** (#181)
+  - Mocked `time.sleep` in `test_start_failure_during_ready_wait_cleans_pid` to skip actual waits
+  - Test now completes in ~0.2s instead of 20+ seconds (100x speedup)
+  - Full test suite time reduced by ~20 seconds
+
 - **Consolidated duplicate git repository test fixtures** (#178)
   - Created shared helper functions in `tests/conftest.py`: `init_git_repo()`, `git_add_and_commit()`, `create_test_files()`, `create_git_repo()`
   - Replaced ~280 lines of duplicate git setup code across 10 test files

--- a/tests/integration/test_daemon.py
+++ b/tests/integration/test_daemon.py
@@ -473,6 +473,8 @@ class TestDaemonLifecycle:
             patch("subprocess.Popen", return_value=mock_process),
             patch.object(lifecycle, "is_running", return_value=False),
             patch.object(lifecycle, "is_process_alive") as mock_alive,
+            # Mock time.sleep to skip actual waits (avoids 20s timeout delay)
+            patch("ember.adapters.daemon.lifecycle.time.sleep"),
         ):
             # Process dies during ready-wait
             mock_alive.return_value = False


### PR DESCRIPTION
## Summary

- Mocked `time.sleep` in `test_start_failure_during_ready_wait_cleans_pid` to skip the 20-second daemon ready-wait timeout
- Test now completes in ~0.2s instead of 20+ seconds (100x speedup)
- Full test suite time reduced by ~20 seconds

Implements #181

## What was the issue?

The test `test_start_failure_during_ready_wait_cleans_pid` was taking 20.24 seconds because it was waiting through the full daemon ready-wait timeout. The test validates that PID files are cleaned up when a daemon fails during startup, not the actual timeout behavior.

## Solution

Added a `patch("ember.adapters.daemon.lifecycle.time.sleep")` mock to skip the actual sleep calls while still validating the PID cleanup logic.

## Test plan

- [x] Test completes in < 2 seconds (now ~0.18s)
- [x] Still validates PID cleanup on failure
- [x] All other daemon tests pass
- [x] Full test suite passes
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)