### PR TITLE
fix: terminate unresponsive daemon process on startup timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Fixed daemon startup race condition causing "running (PID None)" status** (#216)
+  - When daemon startup timed out (>20s), the process was left running without a PID file
+  - This caused `ember daemon status` to show "running (PID None)"
+  - Now properly terminates unresponsive daemon processes before cleaning up PID file
+  - Prevents orphan daemon processes from causing confusing status reports
+
 ### Added
 - **Unified sync behavior with visible progress across all commands** (#209)
   - Added `ensure_synced()` helper function as single entry point for sync-before-run


### PR DESCRIPTION
## Summary
- Fixes daemon startup race condition where process was left running without PID file
- Now properly terminates unresponsive daemon processes before cleaning up
- Prevents "running (PID None)" status messages

Fixes #216

## Changes
- Modified `_handle_startup_timeout()` in `lifecycle.py` to terminate process before cleanup
- Added test `test_start_timeout_kills_unresponsive_process` 
- Updated CHANGELOG.md

## Root Cause
When daemon startup timed out (>20s waiting for health checks), the code was:
1. Deleting the PID file
2. Raising RuntimeError
3. **Not killing the process**

This left the daemon running in the background without a PID file, so subsequent `ember daemon status` showed "running (PID None)".

## Test plan
- [x] Unit tests pass (`uv run pytest`)
- [x] New test verifies SIGTERM is sent on timeout
- [x] Linter passes (`uv run ruff check .`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)