### PR TITLE
fix: suppress HuggingFace tokenizer fork warning (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Suppressed HuggingFace tokenizer fork warning during `ember search`** (#215)
+  - Set `TOKENIZERS_PARALLELISM=false` before loading the embedding model
+  - Also set the variable when spawning the daemon subprocess for belt-and-suspenders safety
+  - Users can override by explicitly setting `TOKENIZERS_PARALLELISM=true` in their environment
+  - Eliminates the distracting "parallelism has already been used" warning message
+
 - **Fixed daemon status showing "PID None" when PID file is missing** (#214)
   - When daemon is running but PID file is missing/corrupted, status now recovers PID from daemon
   - Daemon health check now returns server PID, allowing status recovery

--- a/ember/adapters/daemon/lifecycle.py
+++ b/ember/adapters/daemon/lifecycle.py
@@ -175,12 +175,20 @@ class DaemonLifecycle:
             The spawned process
         """
         logger.info("Starting daemon in background...")
+
+        # Set TOKENIZERS_PARALLELISM=false to prevent HuggingFace tokenizer
+        # fork warning. The warning occurs because tokenizers initializes
+        # thread pools that don't survive fork() properly.
+        env = os.environ.copy()
+        env.setdefault("TOKENIZERS_PARALLELISM", "false")
+
         return subprocess.Popen(
             cmd,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,  # Capture stderr to report startup failures
             stdin=subprocess.DEVNULL,
             start_new_session=True,  # Detach from parent
+            env=env,
         )
 
     def _write_pid_file(self, process: subprocess.Popen) -> None:

--- a/ember/adapters/local_models/jina_embedder.py
+++ b/ember/adapters/local_models/jina_embedder.py
@@ -59,6 +59,14 @@ class JinaCodeEmbedder:
             RuntimeError: If model fails to load.
         """
         if self._model is None:
+            # Disable tokenizers parallelism before import to prevent fork warning
+            # when daemon spawns a subprocess. The warning occurs because tokenizers
+            # initializes thread pools which don't survive fork() properly.
+            # Using setdefault allows users to override if needed.
+            import os
+
+            os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+
             # Import here to avoid loading heavy dependencies at module import time
             from sentence_transformers import SentenceTransformer
 

--- a/tests/unit/adapters/test_daemon_lifecycle.py
+++ b/tests/unit/adapters/test_daemon_lifecycle.py
@@ -1,0 +1,101 @@
+"""Unit tests for daemon lifecycle module."""
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ember.adapters.daemon.lifecycle import DaemonLifecycle
+
+
+class TestTokenizersParallelismEnvVar:
+    """Tests for TOKENIZERS_PARALLELISM environment variable fix (#215)."""
+
+    @pytest.fixture
+    def lifecycle(self, tmp_path: Path) -> DaemonLifecycle:
+        """Create a DaemonLifecycle instance for testing."""
+        return DaemonLifecycle(
+            socket_path=tmp_path / "test.sock",
+            pid_file=tmp_path / "test.pid",
+            log_file=tmp_path / "test.log",
+        )
+
+    def test_spawn_sets_tokenizers_parallelism_false(
+        self, lifecycle: DaemonLifecycle
+    ) -> None:
+        """Test _spawn_background_process sets TOKENIZERS_PARALLELISM=false."""
+        with patch("subprocess.Popen") as mock_popen:
+            mock_process = MagicMock()
+            mock_process.pid = 12345
+            mock_popen.return_value = mock_process
+
+            lifecycle._spawn_background_process(["python", "-c", "pass"])
+
+            # Verify Popen was called with env parameter
+            call_kwargs = mock_popen.call_args[1]
+            assert "env" in call_kwargs
+            assert call_kwargs["env"]["TOKENIZERS_PARALLELISM"] == "false"
+
+    def test_spawn_preserves_existing_env_vars(
+        self, lifecycle: DaemonLifecycle
+    ) -> None:
+        """Test _spawn_background_process preserves existing environment."""
+        with patch("subprocess.Popen") as mock_popen:
+            mock_process = MagicMock()
+            mock_process.pid = 12345
+            mock_popen.return_value = mock_process
+
+            # Set up a test environment variable
+            original_path = os.environ.get("PATH", "")
+            lifecycle._spawn_background_process(["python", "-c", "pass"])
+
+            # Verify PATH is preserved
+            call_kwargs = mock_popen.call_args[1]
+            assert call_kwargs["env"]["PATH"] == original_path
+
+    def test_spawn_does_not_override_user_tokenizers_parallelism(
+        self, lifecycle: DaemonLifecycle
+    ) -> None:
+        """Test user's TOKENIZERS_PARALLELISM is not overridden."""
+        with patch("subprocess.Popen") as mock_popen:
+            mock_process = MagicMock()
+            mock_process.pid = 12345
+            mock_popen.return_value = mock_process
+
+            # User has explicitly set TOKENIZERS_PARALLELISM=true
+            with patch.dict(os.environ, {"TOKENIZERS_PARALLELISM": "true"}):
+                lifecycle._spawn_background_process(["python", "-c", "pass"])
+
+                # Verify user's setting is preserved (setdefault doesn't override)
+                call_kwargs = mock_popen.call_args[1]
+                assert call_kwargs["env"]["TOKENIZERS_PARALLELISM"] == "true"
+
+
+class TestDaemonLifecycleInit:
+    """Tests for DaemonLifecycle initialization."""
+
+    def test_default_paths_use_home_ember_dir(self) -> None:
+        """Test default paths are under ~/.ember/."""
+        lifecycle = DaemonLifecycle()
+
+        ember_dir = Path.home() / ".ember"
+        assert lifecycle.socket_path == ember_dir / "daemon.sock"
+        assert lifecycle.pid_file == ember_dir / "daemon.pid"
+        assert lifecycle.log_file == ember_dir / "daemon.log"
+
+    def test_custom_paths_are_used(self, tmp_path: Path) -> None:
+        """Test custom paths override defaults."""
+        custom_socket = tmp_path / "custom.sock"
+        custom_pid = tmp_path / "custom.pid"
+        custom_log = tmp_path / "custom.log"
+
+        lifecycle = DaemonLifecycle(
+            socket_path=custom_socket,
+            pid_file=custom_pid,
+            log_file=custom_log,
+        )
+
+        assert lifecycle.socket_path == custom_socket
+        assert lifecycle.pid_file == custom_pid
+        assert lifecycle.log_file == custom_log

--- a/tests/unit/adapters/test_jina_embedder_unit.py
+++ b/tests/unit/adapters/test_jina_embedder_unit.py
@@ -1,0 +1,107 @@
+"""Unit tests for JinaCodeEmbedder (no model loading required)."""
+
+import contextlib
+import os
+from unittest.mock import MagicMock, patch
+
+
+class TestTokenizersParallelismEnvVar:
+    """Tests for TOKENIZERS_PARALLELISM environment variable fix (#215)."""
+
+    def test_ensure_model_loaded_sets_tokenizers_parallelism(self) -> None:
+        """Test _ensure_model_loaded sets TOKENIZERS_PARALLELISM before import."""
+        # Clean state - remove any existing value
+        original_value = os.environ.pop("TOKENIZERS_PARALLELISM", None)
+        try:
+            with patch(
+                "ember.adapters.local_models.jina_embedder.SentenceTransformer",
+                create=True,
+            ) as mock_st:
+                # Set up mock to capture env var at import time
+                env_at_import_time = {}
+
+                def capture_env(*args, **kwargs):
+                    env_at_import_time["TOKENIZERS_PARALLELISM"] = os.environ.get(
+                        "TOKENIZERS_PARALLELISM"
+                    )
+                    return MagicMock()
+
+                mock_st.side_effect = capture_env
+
+                # Import after patching
+                from ember.adapters.local_models.jina_embedder import JinaCodeEmbedder
+
+                embedder = JinaCodeEmbedder()
+                embedder._model = None  # Force re-initialization
+
+                # Trigger model loading (this will call our mock)
+                with contextlib.suppress(Exception):
+                    embedder._ensure_model_loaded()
+
+                # Verify env var was set before import
+                assert os.environ.get("TOKENIZERS_PARALLELISM") == "false"
+        finally:
+            # Restore original value
+            if original_value is not None:
+                os.environ["TOKENIZERS_PARALLELISM"] = original_value
+            else:
+                os.environ.pop("TOKENIZERS_PARALLELISM", None)
+
+    def test_ensure_model_loaded_does_not_override_user_setting(self) -> None:
+        """Test _ensure_model_loaded doesn't override user's TOKENIZERS_PARALLELISM."""
+        original_value = os.environ.get("TOKENIZERS_PARALLELISM")
+        try:
+            # User has explicitly set TOKENIZERS_PARALLELISM=true
+            os.environ["TOKENIZERS_PARALLELISM"] = "true"
+
+            with patch(
+                "ember.adapters.local_models.jina_embedder.SentenceTransformer",
+                create=True,
+            ) as mock_st:
+                mock_st.return_value = MagicMock()
+
+                from ember.adapters.local_models.jina_embedder import JinaCodeEmbedder
+
+                embedder = JinaCodeEmbedder()
+                embedder._model = None  # Force re-initialization
+
+                with contextlib.suppress(Exception):
+                    embedder._ensure_model_loaded()
+
+                # Verify user's setting is preserved (setdefault doesn't override)
+                assert os.environ.get("TOKENIZERS_PARALLELISM") == "true"
+        finally:
+            # Restore original value
+            if original_value is not None:
+                os.environ["TOKENIZERS_PARALLELISM"] = original_value
+            else:
+                os.environ.pop("TOKENIZERS_PARALLELISM", None)
+
+
+class TestEmbedderConfiguration:
+    """Tests for JinaCodeEmbedder configuration (no model loading)."""
+
+    def test_default_configuration(self) -> None:
+        """Test embedder uses correct default values."""
+        from ember.adapters.local_models.jina_embedder import JinaCodeEmbedder
+
+        embedder = JinaCodeEmbedder()
+
+        assert embedder._max_seq_length == 512
+        assert embedder._batch_size == 32
+        assert embedder._device is None
+        assert embedder._model is None
+
+    def test_custom_configuration(self) -> None:
+        """Test embedder accepts custom configuration."""
+        from ember.adapters.local_models.jina_embedder import JinaCodeEmbedder
+
+        embedder = JinaCodeEmbedder(
+            max_seq_length=1024,
+            batch_size=64,
+            device="cpu",
+        )
+
+        assert embedder._max_seq_length == 1024
+        assert embedder._batch_size == 64
+        assert embedder._device == "cpu"


### PR DESCRIPTION
## Summary

- Set `TOKENIZERS_PARALLELISM=false` in jina_embedder.py before importing SentenceTransformer
- Also set it in lifecycle.py when spawning daemon subprocess for belt-and-suspenders safety
- Both use `setdefault` to respect user's explicit environment variable setting

Fixes #215

## Test plan

- [x] New unit tests in `test_daemon_lifecycle.py` verify env var is set during spawn
- [x] New unit tests in `test_jina_embedder_unit.py` verify env var is set before import
- [x] Tests verify user's explicit setting is not overridden
- [x] All 600 tests pass
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)