### PR TITLE
feat: add MiniLM lightweight embedding adapter (#221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- **Suppressed HuggingFace tokenizer fork warning during `ember search`** (#215)
-  - Set `TOKENIZERS_PARALLELISM=false` before loading the embedding model
-  - Also set the variable when spawning the daemon subprocess for belt-and-suspenders safety
-  - Users can override by explicitly setting `TOKENIZERS_PARALLELISM=true` in their environment
-  - Eliminates the distracting "parallelism has already been used" warning message
-
-- **Fixed daemon status showing "PID None" when PID file is missing** (#214)
-  - When daemon is running but PID file is missing/corrupted, status now recovers PID from daemon
-  - Daemon health check now returns server PID, allowing status recovery
-  - Status message now shows "PID unknown" instead of confusing "PID None" as fallback
-  - Added `get_daemon_pid()` helper function to query daemon PID via health check
-
-- **Fixed daemon startup race condition causing "running (PID None)" status** (#216)
-  - When daemon startup timed out (>20s), the process was left running without a PID file
-  - This caused `ember daemon status` to show "running (PID None)"
-  - Now properly terminates unresponsive daemon processes before cleaning up PID file
-  - Prevents orphan daemon processes from causing confusing status reports
-
 ### Added
+- **MiniLM lightweight embedding adapter for resource-constrained systems** (#221)
+  - New `MiniLMEmbedder` adapter using `sentence-transformers/all-MiniLM-L6-v2` (22M params, 384 dims)
+  - Uses only ~100MB RAM vs ~1.6GB for Jina - ideal for Raspberry Pi, CI, older laptops
+  - ~5x faster inference than larger models
+  - Can be selected via config: `model = "minilm"` in `.ember/config.toml`
+  - Works in direct mode (`mode = "direct"`) - daemon mode support coming in #223
+
 - **Unified sync behavior with visible progress across all commands** (#209)
   - Added `ensure_synced()` helper function as single entry point for sync-before-run
   - `ember search` now shows "Syncing index..." message when auto-syncing (previously silent)
@@ -53,6 +41,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Improves developer experience by reducing visual noise when locating symbols
 
 ### Fixed
+- **Suppressed HuggingFace tokenizer fork warning during `ember search`** (#215)
+  - Set `TOKENIZERS_PARALLELISM=false` before loading the embedding model
+  - Also set the variable when spawning the daemon subprocess for belt-and-suspenders safety
+  - Users can override by explicitly setting `TOKENIZERS_PARALLELISM=true` in their environment
+  - Eliminates the distracting "parallelism has already been used" warning message
+
+- **Fixed daemon status showing "PID None" when PID file is missing** (#214)
+  - When daemon is running but PID file is missing/corrupted, status now recovers PID from daemon
+  - Daemon health check now returns server PID, allowing status recovery
+  - Status message now shows "PID unknown" instead of confusing "PID None" as fallback
+  - Added `get_daemon_pid()` helper function to query daemon PID via health check
+
+- **Fixed daemon startup race condition causing "running (PID None)" status** (#216)
+  - When daemon startup timed out (>20s), the process was left running without a PID file
+  - This caused `ember daemon status` to show "running (PID None)"
+  - Now properly terminates unresponsive daemon processes before cleaning up PID file
+  - Prevents orphan daemon processes from causing confusing status reports
+
 - **Error messages in interactive search TUI now wrap instead of truncating** (#206)
   - Long error messages (e.g., "Search error: SQLite objects created in a thread...") were being cut off at terminal width
   - Error messages now display in a dedicated window with `wrap_lines=True`

--- a/ember/adapters/local_models/minilm_embedder.py
+++ b/ember/adapters/local_models/minilm_embedder.py
@@ -1,0 +1,168 @@
+"""MiniLM embedder adapter for lightweight embedding.
+
+Uses sentence-transformers/all-MiniLM-L6-v2 via sentence-transformers.
+Designed for resource-constrained systems (~100MB RAM, 22M params).
+"""
+
+import hashlib
+from typing import TYPE_CHECKING
+
+# Lazy import - only load when actually needed
+if TYPE_CHECKING:
+    from sentence_transformers import SentenceTransformer
+
+
+class MiniLMEmbedder:
+    """Embedder using all-MiniLM-L6-v2 model.
+
+    Implements the Embedder protocol for lightweight text embedding.
+    Uses sentence-transformers/all-MiniLM-L6-v2 (22M params, 384 dims).
+
+    Features:
+    - 384-dimensional embeddings
+    - 256 token context length
+    - Very fast inference (~5x faster than larger models)
+    - Minimal memory footprint (~100MB)
+    - General-purpose text embeddings (not code-specific)
+    """
+
+    MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+    MODEL_DIM = 384
+    DEFAULT_MAX_SEQ_LENGTH = 256  # MiniLM has shorter context
+    DEFAULT_BATCH_SIZE = 32
+
+    def __init__(
+        self,
+        max_seq_length: int = DEFAULT_MAX_SEQ_LENGTH,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        device: str | None = None,
+    ):
+        """Initialize the MiniLM Embedder.
+
+        Args:
+            max_seq_length: Maximum sequence length for tokenization (1-256).
+            batch_size: Batch size for encoding.
+            device: Device to run on ('cpu', 'cuda', 'mps', or None for auto).
+        """
+        self._max_seq_length = max_seq_length
+        self._batch_size = batch_size
+        self._device = device
+        self._model: SentenceTransformer | None = None
+
+    def _ensure_model_loaded(self) -> "SentenceTransformer":
+        """Lazy-load the model on first use.
+
+        Returns:
+            Loaded SentenceTransformer model.
+
+        Raises:
+            RuntimeError: If model fails to load.
+        """
+        if self._model is None:
+            # Disable tokenizers parallelism before import to prevent fork warning
+            # when daemon spawns a subprocess. The warning occurs because tokenizers
+            # initializes thread pools which don't survive fork() properly.
+            # Using setdefault allows users to override if needed.
+            import os
+
+            os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+
+            # Import here to avoid loading heavy dependencies at module import time
+            from sentence_transformers import SentenceTransformer
+
+            try:
+                # Try to load from local cache first to avoid network calls
+                # This prevents timeouts when HuggingFace is slow/unreachable
+                try:
+                    self._model = SentenceTransformer(
+                        self.MODEL_NAME,
+                        device=self._device,
+                        local_files_only=True,  # Use cached model, no network
+                    )
+                except (OSError, ValueError):
+                    # Model not cached yet, download from HuggingFace
+                    self._model = SentenceTransformer(
+                        self.MODEL_NAME,
+                        device=self._device,
+                    )
+
+                self._model.max_seq_length = self._max_seq_length
+            except Exception as e:
+                raise RuntimeError(f"Failed to load {self.MODEL_NAME}: {e}") from e
+        return self._model
+
+    @property
+    def name(self) -> str:
+        """Model name."""
+        return self.MODEL_NAME
+
+    @property
+    def dim(self) -> int:
+        """Embedding dimension."""
+        return self.MODEL_DIM
+
+    def fingerprint(self) -> str:
+        """Generate deterministic fingerprint for this model configuration.
+
+        Format: {model_name}:v1:sha256({config_json})
+
+        Returns:
+            Stable fingerprint string.
+        """
+        # Include all config that affects embeddings
+        config_parts = [
+            self.MODEL_NAME,
+            str(self.MODEL_DIM),
+            str(self._max_seq_length),
+            "mean_pooling",  # MiniLM uses mean pooling
+            "normalize",  # Normalized embeddings
+        ]
+        config_str = "|".join(config_parts)
+        config_hash = hashlib.sha256(config_str.encode()).hexdigest()[:16]
+        return f"{self.MODEL_NAME}:v1:{config_hash}"
+
+    def ensure_loaded(self) -> None:
+        """Ensure the model is loaded into memory.
+
+        This method can be called proactively to load the model before
+        the first embedding call, making the first embedding faster.
+        If the model is already loaded, this is a no-op.
+
+        Useful for showing explicit loading progress to users.
+        """
+        self._ensure_model_loaded()
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch of texts into vectors.
+
+        Args:
+            texts: List of text strings to embed.
+
+        Returns:
+            List of embedding vectors (one per input text).
+            Each vector is a list of floats of length self.dim.
+
+        Raises:
+            RuntimeError: If model fails to load or embed.
+        """
+        if not texts:
+            return []
+
+        try:
+            model = self._ensure_model_loaded()
+
+            # sentence-transformers handles batching internally
+            # but we can specify batch_size for control
+            embeddings = model.encode(
+                texts,
+                batch_size=self._batch_size,
+                show_progress_bar=False,
+                convert_to_numpy=True,
+                normalize_embeddings=True,  # L2 normalization
+            )
+
+            # Convert numpy arrays to lists
+            return [emb.tolist() for emb in embeddings]
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to embed {len(texts)} texts: {e}") from e

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -113,9 +113,19 @@ def _create_embedder(config, show_progress: bool = True):
         )
     else:
         # Use direct mode (fallback or explicit config)
-        from ember.adapters.local_models.jina_embedder import JinaCodeEmbedder
+        # Select embedder based on config.index.model
+        model_name = config.index.model.lower()
 
-        return JinaCodeEmbedder()
+        if model_name in ("minilm", "all-minilm-l6-v2"):
+            from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+            return MiniLMEmbedder()
+        else:
+            # Default to Jina code embedder for any other value
+            # including "local-default-code-embed", "jina-code-v2", etc.
+            from ember.adapters.local_models.jina_embedder import JinaCodeEmbedder
+
+            return JinaCodeEmbedder()
 
 
 def get_ember_repo_root() -> tuple[Path, Path]:

--- a/tests/unit/adapters/test_minilm_embedder_unit.py
+++ b/tests/unit/adapters/test_minilm_embedder_unit.py
@@ -1,0 +1,323 @@
+"""Unit tests for MiniLMEmbedder (no model loading required)."""
+
+import contextlib
+import os
+from unittest.mock import MagicMock, patch
+
+
+class TestTokenizersParallelismEnvVar:
+    """Tests for TOKENIZERS_PARALLELISM environment variable fix."""
+
+    def test_ensure_model_loaded_sets_tokenizers_parallelism(self) -> None:
+        """Test _ensure_model_loaded sets TOKENIZERS_PARALLELISM before import."""
+        # Clean state - remove any existing value
+        original_value = os.environ.pop("TOKENIZERS_PARALLELISM", None)
+        try:
+            with patch(
+                "ember.adapters.local_models.minilm_embedder.SentenceTransformer",
+                create=True,
+            ) as mock_st:
+                # Set up mock to capture env var at import time
+                env_at_import_time = {}
+
+                def capture_env(*args, **kwargs):
+                    env_at_import_time["TOKENIZERS_PARALLELISM"] = os.environ.get(
+                        "TOKENIZERS_PARALLELISM"
+                    )
+                    return MagicMock()
+
+                mock_st.side_effect = capture_env
+
+                # Import after patching
+                from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+                embedder = MiniLMEmbedder()
+                embedder._model = None  # Force re-initialization
+
+                # Trigger model loading (this will call our mock)
+                with contextlib.suppress(Exception):
+                    embedder._ensure_model_loaded()
+
+                # Verify env var was set before import
+                assert os.environ.get("TOKENIZERS_PARALLELISM") == "false"
+        finally:
+            # Restore original value
+            if original_value is not None:
+                os.environ["TOKENIZERS_PARALLELISM"] = original_value
+            else:
+                os.environ.pop("TOKENIZERS_PARALLELISM", None)
+
+    def test_ensure_model_loaded_does_not_override_user_setting(self) -> None:
+        """Test _ensure_model_loaded doesn't override user's TOKENIZERS_PARALLELISM."""
+        original_value = os.environ.get("TOKENIZERS_PARALLELISM")
+        try:
+            # User has explicitly set TOKENIZERS_PARALLELISM=true
+            os.environ["TOKENIZERS_PARALLELISM"] = "true"
+
+            with patch(
+                "ember.adapters.local_models.minilm_embedder.SentenceTransformer",
+                create=True,
+            ) as mock_st:
+                mock_st.return_value = MagicMock()
+
+                from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+                embedder = MiniLMEmbedder()
+                embedder._model = None  # Force re-initialization
+
+                with contextlib.suppress(Exception):
+                    embedder._ensure_model_loaded()
+
+                # Verify user's setting is preserved (setdefault doesn't override)
+                assert os.environ.get("TOKENIZERS_PARALLELISM") == "true"
+        finally:
+            # Restore original value
+            if original_value is not None:
+                os.environ["TOKENIZERS_PARALLELISM"] = original_value
+            else:
+                os.environ.pop("TOKENIZERS_PARALLELISM", None)
+
+
+class TestEmbedderConfiguration:
+    """Tests for MiniLMEmbedder configuration (no model loading)."""
+
+    def test_default_configuration(self) -> None:
+        """Test embedder uses correct default values."""
+        from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+        embedder = MiniLMEmbedder()
+
+        assert embedder._max_seq_length == 256
+        assert embedder._batch_size == 32
+        assert embedder._device is None
+        assert embedder._model is None
+
+    def test_custom_configuration(self) -> None:
+        """Test embedder accepts custom configuration."""
+        from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+        embedder = MiniLMEmbedder(
+            max_seq_length=128,
+            batch_size=64,
+            device="cpu",
+        )
+
+        assert embedder._max_seq_length == 128
+        assert embedder._batch_size == 64
+        assert embedder._device == "cpu"
+
+    def test_model_constants(self) -> None:
+        """Test model constants are correct."""
+        from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+        assert MiniLMEmbedder.MODEL_NAME == "sentence-transformers/all-MiniLM-L6-v2"
+        assert MiniLMEmbedder.MODEL_DIM == 384
+        assert MiniLMEmbedder.DEFAULT_MAX_SEQ_LENGTH == 256
+        assert MiniLMEmbedder.DEFAULT_BATCH_SIZE == 32
+
+
+class TestEmbedderProperties:
+    """Tests for MiniLMEmbedder protocol properties."""
+
+    def test_name_property(self) -> None:
+        """Test name property returns model name."""
+        from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+        embedder = MiniLMEmbedder()
+        assert embedder.name == "sentence-transformers/all-MiniLM-L6-v2"
+
+    def test_dim_property(self) -> None:
+        """Test dim property returns embedding dimension."""
+        from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+        embedder = MiniLMEmbedder()
+        assert embedder.dim == 384
+
+    def test_fingerprint_format(self) -> None:
+        """Test fingerprint has correct format."""
+        from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+        embedder = MiniLMEmbedder()
+        fingerprint = embedder.fingerprint()
+
+        # Should be model_name:version:hash
+        parts = fingerprint.split(":")
+        assert len(parts) == 3
+        assert parts[0] == "sentence-transformers/all-MiniLM-L6-v2"
+        assert parts[1] == "v1"
+        assert len(parts[2]) == 16  # SHA256 truncated to 16 chars
+
+    def test_fingerprint_changes_with_config(self) -> None:
+        """Test fingerprint changes when config changes."""
+        from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+        embedder1 = MiniLMEmbedder(max_seq_length=256)
+        embedder2 = MiniLMEmbedder(max_seq_length=128)
+
+        assert embedder1.fingerprint() != embedder2.fingerprint()
+
+    def test_fingerprint_is_deterministic(self) -> None:
+        """Test fingerprint is deterministic for same config."""
+        from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+        embedder1 = MiniLMEmbedder()
+        embedder2 = MiniLMEmbedder()
+
+        assert embedder1.fingerprint() == embedder2.fingerprint()
+
+
+class TestEmbedTextsWithMock:
+    """Tests for embed_texts using mocked model."""
+
+    def test_embed_texts_empty_list(self) -> None:
+        """Test embed_texts returns empty list for empty input."""
+        from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+        embedder = MiniLMEmbedder()
+        result = embedder.embed_texts([])
+        assert result == []
+
+    def test_embed_texts_calls_model_encode(self) -> None:
+        """Test embed_texts calls model.encode with correct parameters."""
+        import numpy as np
+
+        with patch(
+            "sentence_transformers.SentenceTransformer"
+        ) as mock_st:
+            mock_model = MagicMock()
+            mock_model.encode.return_value = np.array([[0.1] * 384, [0.2] * 384])
+            mock_st.return_value = mock_model
+
+            from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+            embedder = MiniLMEmbedder(batch_size=16)
+            embedder._model = None  # Force fresh load
+
+            result = embedder.embed_texts(["text1", "text2"])
+
+            mock_model.encode.assert_called_once_with(
+                ["text1", "text2"],
+                batch_size=16,
+                show_progress_bar=False,
+                convert_to_numpy=True,
+                normalize_embeddings=True,
+            )
+            assert len(result) == 2
+            assert len(result[0]) == 384
+
+    def test_embed_texts_error_handling(self) -> None:
+        """Test embed_texts wraps model errors in RuntimeError."""
+        import pytest
+
+        with patch(
+            "sentence_transformers.SentenceTransformer"
+        ) as mock_st:
+            mock_model = MagicMock()
+            mock_model.encode.side_effect = Exception("Model error")
+            mock_st.return_value = mock_model
+
+            from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+            embedder = MiniLMEmbedder()
+            embedder._model = None
+
+            with pytest.raises(RuntimeError, match="Failed to embed 2 texts"):
+                embedder.embed_texts(["text1", "text2"])
+
+
+class TestEnsureLoaded:
+    """Tests for ensure_loaded method."""
+
+    def test_ensure_loaded_loads_model(self) -> None:
+        """Test ensure_loaded triggers model loading."""
+        with patch(
+            "sentence_transformers.SentenceTransformer"
+        ) as mock_st:
+            mock_st.return_value = MagicMock()
+
+            from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+            embedder = MiniLMEmbedder()
+            embedder._model = None
+
+            embedder.ensure_loaded()
+
+            mock_st.assert_called()
+
+    def test_ensure_loaded_idempotent(self) -> None:
+        """Test ensure_loaded only loads model once."""
+        with patch(
+            "sentence_transformers.SentenceTransformer"
+        ) as mock_st:
+            mock_model = MagicMock()
+            mock_st.return_value = mock_model
+
+            from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+            embedder = MiniLMEmbedder()
+            embedder._model = None
+
+            embedder.ensure_loaded()
+            embedder.ensure_loaded()
+            embedder.ensure_loaded()
+
+            # Should only create model once
+            assert mock_st.call_count == 1
+
+
+class TestModelLoading:
+    """Tests for model loading behavior."""
+
+    def test_local_files_only_tried_first(self) -> None:
+        """Test that local_files_only=True is tried first."""
+        with patch(
+            "sentence_transformers.SentenceTransformer"
+        ) as mock_st:
+            mock_st.return_value = MagicMock()
+
+            from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+            embedder = MiniLMEmbedder(device="cpu")
+            embedder._model = None
+            embedder._ensure_model_loaded()
+
+            # First call should have local_files_only=True
+            first_call = mock_st.call_args_list[0]
+            assert first_call.kwargs.get("local_files_only") is True
+
+    def test_fallback_to_download_on_cache_miss(self) -> None:
+        """Test fallback to download when model not cached."""
+        with patch(
+            "sentence_transformers.SentenceTransformer"
+        ) as mock_st:
+            # First call raises OSError (not cached), second succeeds
+            mock_st.side_effect = [OSError("Not found"), MagicMock()]
+
+            from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+            embedder = MiniLMEmbedder()
+            embedder._model = None
+            embedder._ensure_model_loaded()
+
+            # Should have been called twice
+            assert mock_st.call_count == 2
+            # Second call should not have local_files_only
+            second_call = mock_st.call_args_list[1]
+            assert "local_files_only" not in second_call.kwargs
+
+    def test_model_load_failure_raises_runtime_error(self) -> None:
+        """Test that model load failure raises RuntimeError."""
+        import pytest
+
+        with patch(
+            "sentence_transformers.SentenceTransformer"
+        ) as mock_st:
+            mock_st.side_effect = Exception("Download failed")
+
+            from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+            embedder = MiniLMEmbedder()
+            embedder._model = None
+
+            with pytest.raises(RuntimeError, match="Failed to load"):
+                embedder._ensure_model_loaded()


### PR DESCRIPTION
## Summary

Add `MiniLMEmbedder` adapter using `sentence-transformers/all-MiniLM-L6-v2` for resource-constrained systems.

Part of #220 (configurable embedding models)

## Changes

- **New adapter:** `ember/adapters/local_models/minilm_embedder.py`
  - 22M params (7x smaller than Jina), 384 dimensions
  - ~100MB RAM vs ~1.6GB for Jina
  - ~5x faster inference
  - Lazy model loading with local cache support
  - Implements `Embedder` protocol

- **CLI integration:** `ember/entrypoints/cli.py`
  - Select via config: `model = "minilm"` in `.ember/config.toml`
  - Works in direct mode (`mode = "direct"`)

- **Test coverage:** 18 unit tests
  - Configuration and default values
  - Protocol properties (name, dim, fingerprint)
  - Model loading behavior
  - TOKENIZERS_PARALLELISM env var fix

## Configuration

```toml
[index]
model = "minilm"  # Use lightweight model

[model]
mode = "direct"   # Required for now (daemon support coming in #223)
```

## Acceptance Criteria

- [x] `MiniLMEmbedder` implements `Embedder` protocol
- [x] Lazy model loading (same pattern as Jina)
- [x] Fingerprint includes model name and config
- [x] Unit tests pass
- [x] Can be selected via config: `model = "minilm"`

## Test Plan

- [x] All unit tests pass: `uv run pytest tests/unit/adapters/test_minilm_embedder_unit.py -v`
- [x] All integration tests pass: `uv run pytest tests/integration -x`
- [x] Linter passes: `uv run ruff check .`

## Next Steps

- #222 - Add BGE-small adapter
- #223 - Implement model selection logic (daemon mode support)

Implements #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)