### PR TITLE
feat: add BGE-small embedding adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **BGE-small retrieval-optimized embedding adapter** (#222)
+  - New `BGESmallEmbedder` adapter using `BAAI/bge-small-en-v1.5` (33M params, 384 dims)
+  - Uses only ~130MB RAM - good balance between accuracy and resource usage
+  - Optimized for retrieval tasks, strong MTEB leaderboard performance
+  - 512 token context length (vs 256 for MiniLM)
+  - Can be selected via config: `model = "bge-small"` in `.ember/config.toml`
+  - Works in direct mode (`mode = "direct"`) - daemon mode support coming in #223
+
 - **MiniLM lightweight embedding adapter for resource-constrained systems** (#221)
   - New `MiniLMEmbedder` adapter using `sentence-transformers/all-MiniLM-L6-v2` (22M params, 384 dims)
   - Uses only ~100MB RAM vs ~1.6GB for Jina - ideal for Raspberry Pi, CI, older laptops

--- a/ember/adapters/local_models/bge_embedder.py
+++ b/ember/adapters/local_models/bge_embedder.py
@@ -1,0 +1,171 @@
+"""BGE-small embedder adapter for retrieval-optimized embedding.
+
+Uses BAAI/bge-small-en-v1.5 via sentence-transformers.
+Small retrieval-focused model (~130MB RAM, 33M params).
+"""
+
+import hashlib
+from typing import TYPE_CHECKING
+
+# Lazy import - only load when actually needed
+if TYPE_CHECKING:
+    from sentence_transformers import SentenceTransformer
+
+
+class BGESmallEmbedder:
+    """Embedder using bge-small-en-v1.5 model.
+
+    Implements the Embedder protocol for retrieval-optimized embedding.
+    Uses BAAI/bge-small-en-v1.5 (33M params, 384 dims).
+
+    Features:
+    - 384-dimensional embeddings
+    - 512 token context length
+    - Optimized for retrieval tasks
+    - Small memory footprint (~130MB)
+    - General-purpose text embeddings (not code-specific)
+
+    Note: BGE models can benefit from instruction prefixes for queries,
+    but for code indexing we use direct embedding without prefixes.
+    """
+
+    MODEL_NAME = "BAAI/bge-small-en-v1.5"
+    MODEL_DIM = 384
+    DEFAULT_MAX_SEQ_LENGTH = 512
+    DEFAULT_BATCH_SIZE = 32
+
+    def __init__(
+        self,
+        max_seq_length: int = DEFAULT_MAX_SEQ_LENGTH,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        device: str | None = None,
+    ):
+        """Initialize the BGE-small Embedder.
+
+        Args:
+            max_seq_length: Maximum sequence length for tokenization (1-512).
+            batch_size: Batch size for encoding.
+            device: Device to run on ('cpu', 'cuda', 'mps', or None for auto).
+        """
+        self._max_seq_length = max_seq_length
+        self._batch_size = batch_size
+        self._device = device
+        self._model: SentenceTransformer | None = None
+
+    def _ensure_model_loaded(self) -> "SentenceTransformer":
+        """Lazy-load the model on first use.
+
+        Returns:
+            Loaded SentenceTransformer model.
+
+        Raises:
+            RuntimeError: If model fails to load.
+        """
+        if self._model is None:
+            # Disable tokenizers parallelism before import to prevent fork warning
+            # when daemon spawns a subprocess. The warning occurs because tokenizers
+            # initializes thread pools which don't survive fork() properly.
+            # Using setdefault allows users to override if needed.
+            import os
+
+            os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+
+            # Import here to avoid loading heavy dependencies at module import time
+            from sentence_transformers import SentenceTransformer
+
+            try:
+                # Try to load from local cache first to avoid network calls
+                # This prevents timeouts when HuggingFace is slow/unreachable
+                try:
+                    self._model = SentenceTransformer(
+                        self.MODEL_NAME,
+                        device=self._device,
+                        local_files_only=True,  # Use cached model, no network
+                    )
+                except (OSError, ValueError):
+                    # Model not cached yet, download from HuggingFace
+                    self._model = SentenceTransformer(
+                        self.MODEL_NAME,
+                        device=self._device,
+                    )
+
+                self._model.max_seq_length = self._max_seq_length
+            except Exception as e:
+                raise RuntimeError(f"Failed to load {self.MODEL_NAME}: {e}") from e
+        return self._model
+
+    @property
+    def name(self) -> str:
+        """Model name."""
+        return self.MODEL_NAME
+
+    @property
+    def dim(self) -> int:
+        """Embedding dimension."""
+        return self.MODEL_DIM
+
+    def fingerprint(self) -> str:
+        """Generate deterministic fingerprint for this model configuration.
+
+        Format: {model_name}:v1:sha256({config_json})
+
+        Returns:
+            Stable fingerprint string.
+        """
+        # Include all config that affects embeddings
+        config_parts = [
+            self.MODEL_NAME,
+            str(self.MODEL_DIM),
+            str(self._max_seq_length),
+            "mean_pooling",  # BGE uses mean pooling
+            "normalize",  # Normalized embeddings
+        ]
+        config_str = "|".join(config_parts)
+        config_hash = hashlib.sha256(config_str.encode()).hexdigest()[:16]
+        return f"{self.MODEL_NAME}:v1:{config_hash}"
+
+    def ensure_loaded(self) -> None:
+        """Ensure the model is loaded into memory.
+
+        This method can be called proactively to load the model before
+        the first embedding call, making the first embedding faster.
+        If the model is already loaded, this is a no-op.
+
+        Useful for showing explicit loading progress to users.
+        """
+        self._ensure_model_loaded()
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch of texts into vectors.
+
+        Args:
+            texts: List of text strings to embed.
+
+        Returns:
+            List of embedding vectors (one per input text).
+            Each vector is a list of floats of length self.dim.
+
+        Raises:
+            RuntimeError: If model fails to load or embed.
+        """
+        if not texts:
+            return []
+
+        try:
+            model = self._ensure_model_loaded()
+
+            # sentence-transformers handles batching internally
+            # but we can specify batch_size for control
+            embeddings = model.encode(
+                texts,
+                batch_size=self._batch_size,
+                show_progress_bar=False,
+                convert_to_numpy=True,
+                normalize_embeddings=True,  # L2 normalization
+            )
+
+            # Convert numpy arrays to lists
+            return [emb.tolist() for emb in embeddings]
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to embed {len(texts)} texts: {e}") from e

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -120,6 +120,10 @@ def _create_embedder(config, show_progress: bool = True):
             from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
 
             return MiniLMEmbedder()
+        elif model_name in ("bge-small", "bge-small-en-v1.5"):
+            from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+            return BGESmallEmbedder()
         else:
             # Default to Jina code embedder for any other value
             # including "local-default-code-embed", "jina-code-v2", etc.

--- a/tests/unit/adapters/test_bge_embedder_unit.py
+++ b/tests/unit/adapters/test_bge_embedder_unit.py
@@ -1,0 +1,323 @@
+"""Unit tests for BGESmallEmbedder (no model loading required)."""
+
+import contextlib
+import os
+from unittest.mock import MagicMock, patch
+
+
+class TestTokenizersParallelismEnvVar:
+    """Tests for TOKENIZERS_PARALLELISM environment variable fix."""
+
+    def test_ensure_model_loaded_sets_tokenizers_parallelism(self) -> None:
+        """Test _ensure_model_loaded sets TOKENIZERS_PARALLELISM before import."""
+        # Clean state - remove any existing value
+        original_value = os.environ.pop("TOKENIZERS_PARALLELISM", None)
+        try:
+            with patch(
+                "ember.adapters.local_models.bge_embedder.SentenceTransformer",
+                create=True,
+            ) as mock_st:
+                # Set up mock to capture env var at import time
+                env_at_import_time = {}
+
+                def capture_env(*args, **kwargs):
+                    env_at_import_time["TOKENIZERS_PARALLELISM"] = os.environ.get(
+                        "TOKENIZERS_PARALLELISM"
+                    )
+                    return MagicMock()
+
+                mock_st.side_effect = capture_env
+
+                # Import after patching
+                from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+                embedder = BGESmallEmbedder()
+                embedder._model = None  # Force re-initialization
+
+                # Trigger model loading (this will call our mock)
+                with contextlib.suppress(Exception):
+                    embedder._ensure_model_loaded()
+
+                # Verify env var was set before import
+                assert os.environ.get("TOKENIZERS_PARALLELISM") == "false"
+        finally:
+            # Restore original value
+            if original_value is not None:
+                os.environ["TOKENIZERS_PARALLELISM"] = original_value
+            else:
+                os.environ.pop("TOKENIZERS_PARALLELISM", None)
+
+    def test_ensure_model_loaded_does_not_override_user_setting(self) -> None:
+        """Test _ensure_model_loaded doesn't override user's TOKENIZERS_PARALLELISM."""
+        original_value = os.environ.get("TOKENIZERS_PARALLELISM")
+        try:
+            # User has explicitly set TOKENIZERS_PARALLELISM=true
+            os.environ["TOKENIZERS_PARALLELISM"] = "true"
+
+            with patch(
+                "ember.adapters.local_models.bge_embedder.SentenceTransformer",
+                create=True,
+            ) as mock_st:
+                mock_st.return_value = MagicMock()
+
+                from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+                embedder = BGESmallEmbedder()
+                embedder._model = None  # Force re-initialization
+
+                with contextlib.suppress(Exception):
+                    embedder._ensure_model_loaded()
+
+                # Verify user's setting is preserved (setdefault doesn't override)
+                assert os.environ.get("TOKENIZERS_PARALLELISM") == "true"
+        finally:
+            # Restore original value
+            if original_value is not None:
+                os.environ["TOKENIZERS_PARALLELISM"] = original_value
+            else:
+                os.environ.pop("TOKENIZERS_PARALLELISM", None)
+
+
+class TestEmbedderConfiguration:
+    """Tests for BGESmallEmbedder configuration (no model loading)."""
+
+    def test_default_configuration(self) -> None:
+        """Test embedder uses correct default values."""
+        from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+        embedder = BGESmallEmbedder()
+
+        assert embedder._max_seq_length == 512
+        assert embedder._batch_size == 32
+        assert embedder._device is None
+        assert embedder._model is None
+
+    def test_custom_configuration(self) -> None:
+        """Test embedder accepts custom configuration."""
+        from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+        embedder = BGESmallEmbedder(
+            max_seq_length=256,
+            batch_size=64,
+            device="cpu",
+        )
+
+        assert embedder._max_seq_length == 256
+        assert embedder._batch_size == 64
+        assert embedder._device == "cpu"
+
+    def test_model_constants(self) -> None:
+        """Test model constants are correct."""
+        from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+        assert BGESmallEmbedder.MODEL_NAME == "BAAI/bge-small-en-v1.5"
+        assert BGESmallEmbedder.MODEL_DIM == 384
+        assert BGESmallEmbedder.DEFAULT_MAX_SEQ_LENGTH == 512
+        assert BGESmallEmbedder.DEFAULT_BATCH_SIZE == 32
+
+
+class TestEmbedderProperties:
+    """Tests for BGESmallEmbedder protocol properties."""
+
+    def test_name_property(self) -> None:
+        """Test name property returns model name."""
+        from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+        embedder = BGESmallEmbedder()
+        assert embedder.name == "BAAI/bge-small-en-v1.5"
+
+    def test_dim_property(self) -> None:
+        """Test dim property returns embedding dimension."""
+        from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+        embedder = BGESmallEmbedder()
+        assert embedder.dim == 384
+
+    def test_fingerprint_format(self) -> None:
+        """Test fingerprint has correct format."""
+        from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+        embedder = BGESmallEmbedder()
+        fingerprint = embedder.fingerprint()
+
+        # Should be model_name:version:hash
+        parts = fingerprint.split(":")
+        assert len(parts) == 3
+        assert parts[0] == "BAAI/bge-small-en-v1.5"
+        assert parts[1] == "v1"
+        assert len(parts[2]) == 16  # SHA256 truncated to 16 chars
+
+    def test_fingerprint_changes_with_config(self) -> None:
+        """Test fingerprint changes when config changes."""
+        from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+        embedder1 = BGESmallEmbedder(max_seq_length=512)
+        embedder2 = BGESmallEmbedder(max_seq_length=256)
+
+        assert embedder1.fingerprint() != embedder2.fingerprint()
+
+    def test_fingerprint_is_deterministic(self) -> None:
+        """Test fingerprint is deterministic for same config."""
+        from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+        embedder1 = BGESmallEmbedder()
+        embedder2 = BGESmallEmbedder()
+
+        assert embedder1.fingerprint() == embedder2.fingerprint()
+
+
+class TestEmbedTextsWithMock:
+    """Tests for embed_texts using mocked model."""
+
+    def test_embed_texts_empty_list(self) -> None:
+        """Test embed_texts returns empty list for empty input."""
+        from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+        embedder = BGESmallEmbedder()
+        result = embedder.embed_texts([])
+        assert result == []
+
+    def test_embed_texts_calls_model_encode(self) -> None:
+        """Test embed_texts calls model.encode with correct parameters."""
+        import numpy as np
+
+        with patch(
+            "sentence_transformers.SentenceTransformer"
+        ) as mock_st:
+            mock_model = MagicMock()
+            mock_model.encode.return_value = np.array([[0.1] * 384, [0.2] * 384])
+            mock_st.return_value = mock_model
+
+            from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+            embedder = BGESmallEmbedder(batch_size=16)
+            embedder._model = None  # Force fresh load
+
+            result = embedder.embed_texts(["text1", "text2"])
+
+            mock_model.encode.assert_called_once_with(
+                ["text1", "text2"],
+                batch_size=16,
+                show_progress_bar=False,
+                convert_to_numpy=True,
+                normalize_embeddings=True,
+            )
+            assert len(result) == 2
+            assert len(result[0]) == 384
+
+    def test_embed_texts_error_handling(self) -> None:
+        """Test embed_texts wraps model errors in RuntimeError."""
+        import pytest
+
+        with patch(
+            "sentence_transformers.SentenceTransformer"
+        ) as mock_st:
+            mock_model = MagicMock()
+            mock_model.encode.side_effect = Exception("Model error")
+            mock_st.return_value = mock_model
+
+            from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+            embedder = BGESmallEmbedder()
+            embedder._model = None
+
+            with pytest.raises(RuntimeError, match="Failed to embed 2 texts"):
+                embedder.embed_texts(["text1", "text2"])
+
+
+class TestEnsureLoaded:
+    """Tests for ensure_loaded method."""
+
+    def test_ensure_loaded_loads_model(self) -> None:
+        """Test ensure_loaded triggers model loading."""
+        with patch(
+            "sentence_transformers.SentenceTransformer"
+        ) as mock_st:
+            mock_st.return_value = MagicMock()
+
+            from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+            embedder = BGESmallEmbedder()
+            embedder._model = None
+
+            embedder.ensure_loaded()
+
+            mock_st.assert_called()
+
+    def test_ensure_loaded_idempotent(self) -> None:
+        """Test ensure_loaded only loads model once."""
+        with patch(
+            "sentence_transformers.SentenceTransformer"
+        ) as mock_st:
+            mock_model = MagicMock()
+            mock_st.return_value = mock_model
+
+            from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+            embedder = BGESmallEmbedder()
+            embedder._model = None
+
+            embedder.ensure_loaded()
+            embedder.ensure_loaded()
+            embedder.ensure_loaded()
+
+            # Should only create model once
+            assert mock_st.call_count == 1
+
+
+class TestModelLoading:
+    """Tests for model loading behavior."""
+
+    def test_local_files_only_tried_first(self) -> None:
+        """Test that local_files_only=True is tried first."""
+        with patch(
+            "sentence_transformers.SentenceTransformer"
+        ) as mock_st:
+            mock_st.return_value = MagicMock()
+
+            from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+            embedder = BGESmallEmbedder(device="cpu")
+            embedder._model = None
+            embedder._ensure_model_loaded()
+
+            # First call should have local_files_only=True
+            first_call = mock_st.call_args_list[0]
+            assert first_call.kwargs.get("local_files_only") is True
+
+    def test_fallback_to_download_on_cache_miss(self) -> None:
+        """Test fallback to download when model not cached."""
+        with patch(
+            "sentence_transformers.SentenceTransformer"
+        ) as mock_st:
+            # First call raises OSError (not cached), second succeeds
+            mock_st.side_effect = [OSError("Not found"), MagicMock()]
+
+            from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+            embedder = BGESmallEmbedder()
+            embedder._model = None
+            embedder._ensure_model_loaded()
+
+            # Should have been called twice
+            assert mock_st.call_count == 2
+            # Second call should not have local_files_only
+            second_call = mock_st.call_args_list[1]
+            assert "local_files_only" not in second_call.kwargs
+
+    def test_model_load_failure_raises_runtime_error(self) -> None:
+        """Test that model load failure raises RuntimeError."""
+        import pytest
+
+        with patch(
+            "sentence_transformers.SentenceTransformer"
+        ) as mock_st:
+            mock_st.side_effect = Exception("Download failed")
+
+            from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+            embedder = BGESmallEmbedder()
+            embedder._model = None
+
+            with pytest.raises(RuntimeError, match="Failed to load"):
+                embedder._ensure_model_loaded()


### PR DESCRIPTION
## Summary

Add `bge-small-en-v1.5` as a retrieval-optimized embedding option for resource-constrained systems.

Implements #222

## Changes

- Add `BGESmallEmbedder` adapter using `BAAI/bge-small-en-v1.5` (33M params, 384 dims)
- Add comprehensive unit tests for `BGESmallEmbedder` (18 tests)
- Register `bge-small` in model selection logic in `cli.py`
- Update CHANGELOG with new embedding adapter

## Model Details

| Property | Value |
|----------|-------|
| HuggingFace ID | BAAI/bge-small-en-v1.5 |
| Parameters | 33M |
| Dimensions | 384 |
| Memory | ~130MB runtime |
| Context | 512 tokens |

## Acceptance Criteria

- [x] `BGESmallEmbedder` implements `Embedder` protocol
- [x] Handles BGE-specific requirements (lazy loading, cache-first, env var safety)
- [x] Unit tests pass (18 tests)
- [x] Can be selected via config: `model = "bge-small"`

## Test Plan

- [x] Run `uv run pytest tests/unit/adapters/test_bge_embedder_unit.py -v` - all 18 tests pass
- [x] Run `uv run ruff check .` - no lint errors
- [x] Run full unit test suite (`uv run pytest --ignore=tests/integration`) - all 446 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)