### PR TITLE
feat: implement embedding model selection logic (#223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Embedding model selection logic with daemon support** (#223)
+  - New model registry (`ember/adapters/local_models/registry.py`) centralizes model selection
+  - Supports user-friendly presets (`jina-code-v2`, `minilm`, `bge-small`) and full HuggingFace IDs
+  - Daemon mode now respects `model` config - can run MiniLM or BGE-small in daemon mode
+  - Config validation rejects unknown model names with helpful error messages
+  - `create_embedder()` factory function for consistent embedder creation
+  - `get_model_info()` and `list_available_models()` for programmatic model discovery
+  - All models (Jina, MiniLM, BGE-small) now work in both daemon and direct modes
+  - Example config: `model = "minilm"` with `mode = "daemon"` for memory-efficient indexing
+
 - **BGE-small retrieval-optimized embedding adapter** (#222)
   - New `BGESmallEmbedder` adapter using `BAAI/bge-small-en-v1.5` (33M params, 384 dims)
   - Uses only ~130MB RAM - good balance between accuracy and resource usage
   - Optimized for retrieval tasks, strong MTEB leaderboard performance
   - 512 token context length (vs 256 for MiniLM)
   - Can be selected via config: `model = "bge-small"` in `.ember/config.toml`
-  - Works in direct mode (`mode = "direct"`) - daemon mode support coming in #223
 
 - **MiniLM lightweight embedding adapter for resource-constrained systems** (#221)
   - New `MiniLMEmbedder` adapter using `sentence-transformers/all-MiniLM-L6-v2` (22M params, 384 dims)
   - Uses only ~100MB RAM vs ~1.6GB for Jina - ideal for Raspberry Pi, CI, older laptops
   - ~5x faster inference than larger models
   - Can be selected via config: `model = "minilm"` in `.ember/config.toml`
-  - Works in direct mode (`mode = "direct"`) - daemon mode support coming in #223
 
 - **Unified sync behavior with visible progress across all commands** (#209)
   - Added `ensure_synced()` helper function as single entry point for sync-before-run

--- a/ember/adapters/daemon/client.py
+++ b/ember/adapters/daemon/client.py
@@ -18,7 +18,7 @@ from ember.adapters.daemon.protocol import (
 )
 
 if TYPE_CHECKING:
-    from ember.adapters.local_models.jina_embedder import JinaCodeEmbedder
+    from ember.ports.embedders import Embedder
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +45,7 @@ class DaemonEmbedderClient:
         max_seq_length: int = 512,
         batch_size: int = 32,
         daemon_timeout: int = 900,
+        model_name: str | None = None,
     ):
         """Initialize daemon client.
 
@@ -55,6 +56,7 @@ class DaemonEmbedderClient:
             max_seq_length: Max sequence length for fallback embedder
             batch_size: Batch size for fallback embedder
             daemon_timeout: Daemon idle timeout in seconds
+            model_name: Embedding model preset or HuggingFace ID
         """
         self.socket_path = socket_path or (Path.home() / ".ember" / "daemon.sock")
         self.fallback_enabled = fallback
@@ -62,11 +64,16 @@ class DaemonEmbedderClient:
         self.max_seq_length = max_seq_length
         self.batch_size = batch_size
         self.daemon_timeout = daemon_timeout
+        self.model_name = model_name
 
         # Lazy-loaded fallback embedder
-        self._fallback_embedder: JinaCodeEmbedder | None = None
+        self._fallback_embedder: Embedder | None = None
         self._using_fallback = False
         self._daemon_start_attempted = False
+
+        # Cached model info from daemon health check
+        self._cached_model_name: str | None = None
+        self._cached_model_dim: int | None = None
 
     @property
     def name(self) -> str:
@@ -74,46 +81,62 @@ class DaemonEmbedderClient:
         # Use fallback embedder if we've switched to it
         if self._using_fallback and self._fallback_embedder:
             return self._fallback_embedder.name
-        # Otherwise return the Jina model name (same as direct mode)
-        from ember.adapters.local_models.jina_embedder import JinaCodeEmbedder
+        # Use cached value from daemon if available
+        if self._cached_model_name:
+            return self._cached_model_name
+        # Otherwise use model info from registry
+        from ember.adapters.local_models.registry import get_model_info
 
-        return JinaCodeEmbedder.MODEL_NAME
+        info = get_model_info(self.model_name or "jina-code-v2")
+        return info["name"]
 
     @property
     def dim(self) -> int:
         """Embedding dimension."""
         if self._using_fallback and self._fallback_embedder:
             return self._fallback_embedder.dim
-        from ember.adapters.local_models.jina_embedder import JinaCodeEmbedder
+        # Use cached value from daemon if available
+        if self._cached_model_dim:
+            return self._cached_model_dim
+        # Otherwise use model info from registry
+        from ember.adapters.local_models.registry import get_model_info
 
-        return JinaCodeEmbedder.MODEL_DIM
+        info = get_model_info(self.model_name or "jina-code-v2")
+        return info["dim"]
 
     def fingerprint(self) -> str:
         """Unique fingerprint identifying model + config."""
         if self._using_fallback and self._fallback_embedder:
             return self._fallback_embedder.fingerprint()
 
-        # Generate fingerprint matching direct mode
-        from ember.adapters.local_models.jina_embedder import JinaCodeEmbedder
+        # Generate fingerprint matching direct mode using registry
+        from ember.adapters.local_models.registry import create_embedder
 
         # Use a temporary embedder just for fingerprint (doesn't load model)
-        temp_embedder = JinaCodeEmbedder(
-            max_seq_length=self.max_seq_length, batch_size=self.batch_size
+        temp_embedder = create_embedder(
+            model_name=self.model_name,
+            max_seq_length=self.max_seq_length,
+            batch_size=self.batch_size,
         )
         return temp_embedder.fingerprint()
 
-    def _get_fallback_embedder(self) -> "JinaCodeEmbedder":
+    def _get_fallback_embedder(self) -> "Embedder":
         """Get or create fallback embedder.
 
         Returns:
-            JinaCodeEmbedder instance for direct mode
+            Embedder instance for direct mode
         """
         if self._fallback_embedder is None:
-            from ember.adapters.local_models.jina_embedder import JinaCodeEmbedder
+            from ember.adapters.local_models.registry import create_embedder
 
-            logger.info("Creating fallback embedder (direct mode)")
-            self._fallback_embedder = JinaCodeEmbedder(
-                max_seq_length=self.max_seq_length, batch_size=self.batch_size
+            logger.info(
+                f"Creating fallback embedder (direct mode): "
+                f"{self.model_name or 'default'}"
+            )
+            self._fallback_embedder = create_embedder(
+                model_name=self.model_name,
+                max_seq_length=self.max_seq_length,
+                batch_size=self.batch_size,
             )
         return self._fallback_embedder
 
@@ -138,7 +161,9 @@ class DaemonEmbedderClient:
 
             logger.info("Daemon not running, starting...")
             lifecycle = DaemonLifecycle(
-                socket_path=self.socket_path, idle_timeout=self.daemon_timeout
+                socket_path=self.socket_path,
+                idle_timeout=self.daemon_timeout,
+                model_name=self.model_name,
             )
             self._daemon_start_attempted = True
             return lifecycle.ensure_running()

--- a/ember/adapters/daemon/lifecycle.py
+++ b/ember/adapters/daemon/lifecycle.py
@@ -25,6 +25,7 @@ class DaemonLifecycle:
         pid_file: Path | None = None,
         log_file: Path | None = None,
         idle_timeout: int = 900,
+        model_name: str | None = None,
     ):
         """Initialize lifecycle manager.
 
@@ -33,12 +34,14 @@ class DaemonLifecycle:
             pid_file: Path to PID file (default: ~/.ember/daemon.pid)
             log_file: Path to log file (default: ~/.ember/daemon.log)
             idle_timeout: Daemon idle timeout in seconds
+            model_name: Embedding model preset or HuggingFace ID
         """
         ember_dir = Path.home() / ".ember"
         self.socket_path = socket_path or (ember_dir / "daemon.sock")
         self.pid_file = pid_file or (ember_dir / "daemon.pid")
         self.log_file = log_file or (ember_dir / "daemon.log")
         self.idle_timeout = idle_timeout
+        self.model_name = model_name
 
         # Ensure ember directory exists
         ember_dir.mkdir(parents=True, exist_ok=True)
@@ -302,6 +305,10 @@ class DaemonLifecycle:
             "--log-level",
             "INFO",
         ]
+
+        # Add model selection if specified
+        if self.model_name:
+            cmd.extend(["--model", self.model_name])
 
         try:
             if foreground:

--- a/ember/adapters/local_models/__init__.py
+++ b/ember/adapters/local_models/__init__.py
@@ -1,0 +1,23 @@
+"""Local embedding model adapters.
+
+Provides implementations of the Embedder protocol using local sentence-transformers
+models with different size/performance tradeoffs.
+"""
+
+from ember.adapters.local_models.registry import (
+    MODEL_PRESETS,
+    SUPPORTED_MODELS,
+    create_embedder,
+    get_model_info,
+    list_available_models,
+    resolve_model_name,
+)
+
+__all__ = [
+    "MODEL_PRESETS",
+    "SUPPORTED_MODELS",
+    "create_embedder",
+    "get_model_info",
+    "list_available_models",
+    "resolve_model_name",
+]

--- a/ember/adapters/local_models/registry.py
+++ b/ember/adapters/local_models/registry.py
@@ -1,0 +1,211 @@
+"""Model registry for embedding model selection.
+
+Maps user-friendly preset names and HuggingFace model IDs to embedder classes.
+Provides a factory function to create the appropriate embedder based on config.
+"""
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    pass
+
+
+class Embedder(Protocol):
+    """Embedder protocol for type checking."""
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def dim(self) -> int: ...
+
+    def fingerprint(self) -> str: ...
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]: ...
+
+    def ensure_loaded(self) -> None: ...
+
+
+# Preset names map to HuggingFace model IDs
+# Users can use either the preset name or the full HF ID
+MODEL_PRESETS: dict[str, str] = {
+    # Default code-optimized model (161M params, 768 dims, ~1.6GB)
+    "jina-code-v2": "jinaai/jina-embeddings-v2-base-code",
+    "local-default-code-embed": "jinaai/jina-embeddings-v2-base-code",  # Legacy name
+    # Lightweight option (22M params, 384 dims, ~100MB)
+    "minilm": "sentence-transformers/all-MiniLM-L6-v2",
+    "all-minilm-l6-v2": "sentence-transformers/all-MiniLM-L6-v2",
+    # Small retrieval-optimized (33M params, 384 dims, ~130MB)
+    "bge-small": "BAAI/bge-small-en-v1.5",
+    "bge-small-en-v1.5": "BAAI/bge-small-en-v1.5",
+}
+
+# Full HuggingFace model IDs that we support directly
+SUPPORTED_MODELS: set[str] = {
+    "jinaai/jina-embeddings-v2-base-code",
+    "sentence-transformers/all-MiniLM-L6-v2",
+    "BAAI/bge-small-en-v1.5",
+}
+
+# Default model when none specified
+DEFAULT_MODEL = "jinaai/jina-embeddings-v2-base-code"
+
+
+def resolve_model_name(model_name: str) -> str:
+    """Resolve a model name to its canonical HuggingFace ID.
+
+    Args:
+        model_name: User-provided model name (preset or HF ID)
+
+    Returns:
+        Canonical HuggingFace model ID
+
+    Raises:
+        ValueError: If model name is not recognized
+    """
+    # Normalize case for preset lookup
+    normalized = model_name.lower()
+
+    # Check if it's a preset
+    if normalized in MODEL_PRESETS:
+        return MODEL_PRESETS[normalized]
+
+    # Check if it's a supported full model ID (case-sensitive)
+    if model_name in SUPPORTED_MODELS:
+        return model_name
+
+    # Not recognized
+    valid_options = sorted(set(MODEL_PRESETS.keys()) | SUPPORTED_MODELS)
+    raise ValueError(
+        f"Unknown embedding model: '{model_name}'. "
+        f"Valid options are: {', '.join(valid_options)}"
+    )
+
+
+def create_embedder(
+    model_name: str | None = None,
+    max_seq_length: int | None = None,
+    batch_size: int = 32,
+    device: str | None = None,
+) -> Embedder:
+    """Create an embedder instance based on model name.
+
+    Args:
+        model_name: Model preset name or HuggingFace ID (default: jina-code-v2)
+        max_seq_length: Maximum sequence length (default: model-specific)
+        batch_size: Batch size for encoding
+        device: Device to run on ('cpu', 'cuda', 'mps', or None for auto)
+
+    Returns:
+        Embedder instance implementing the Embedder protocol
+
+    Raises:
+        ValueError: If model name is not recognized
+    """
+    # Resolve to canonical model ID
+    resolved = DEFAULT_MODEL if model_name is None else resolve_model_name(model_name)
+
+    # Create the appropriate embedder
+    if resolved == "jinaai/jina-embeddings-v2-base-code":
+        from ember.adapters.local_models.jina_embedder import JinaCodeEmbedder
+
+        kwargs: dict = {"batch_size": batch_size}
+        if device is not None:
+            kwargs["device"] = device
+        if max_seq_length is not None:
+            kwargs["max_seq_length"] = max_seq_length
+        return JinaCodeEmbedder(**kwargs)
+
+    elif resolved == "sentence-transformers/all-MiniLM-L6-v2":
+        from ember.adapters.local_models.minilm_embedder import MiniLMEmbedder
+
+        kwargs = {"batch_size": batch_size}
+        if device is not None:
+            kwargs["device"] = device
+        if max_seq_length is not None:
+            kwargs["max_seq_length"] = max_seq_length
+        return MiniLMEmbedder(**kwargs)
+
+    elif resolved == "BAAI/bge-small-en-v1.5":
+        from ember.adapters.local_models.bge_embedder import BGESmallEmbedder
+
+        kwargs = {"batch_size": batch_size}
+        if device is not None:
+            kwargs["device"] = device
+        if max_seq_length is not None:
+            kwargs["max_seq_length"] = max_seq_length
+        return BGESmallEmbedder(**kwargs)
+
+    else:
+        # This shouldn't happen if resolve_model_name works correctly
+        raise ValueError(f"No embedder implementation for model: {resolved}")
+
+
+def get_model_info(model_name: str) -> dict:
+    """Get information about a model.
+
+    Args:
+        model_name: Model preset name or HuggingFace ID
+
+    Returns:
+        Dictionary with model information
+
+    Raises:
+        ValueError: If model name is not recognized
+    """
+    resolved = resolve_model_name(model_name)
+
+    info = {
+        "name": resolved,
+        "preset": model_name if model_name.lower() in MODEL_PRESETS else None,
+    }
+
+    if resolved == "jinaai/jina-embeddings-v2-base-code":
+        info.update({
+            "dim": 768,
+            "params": "161M",
+            "memory": "~1.6GB",
+            "max_seq_length": 8192,
+            "description": "Code-optimized model with excellent code understanding",
+        })
+    elif resolved == "sentence-transformers/all-MiniLM-L6-v2":
+        info.update({
+            "dim": 384,
+            "params": "22M",
+            "memory": "~100MB",
+            "max_seq_length": 256,
+            "description": "Lightweight general-purpose model, very fast",
+        })
+    elif resolved == "BAAI/bge-small-en-v1.5":
+        info.update({
+            "dim": 384,
+            "params": "33M",
+            "memory": "~130MB",
+            "max_seq_length": 512,
+            "description": "Small retrieval-optimized model, good accuracy",
+        })
+
+    return info
+
+
+def list_available_models() -> list[dict]:
+    """List all available models with their info.
+
+    Returns:
+        List of model info dictionaries
+    """
+    # Use unique resolved model names
+    seen = set()
+    models = []
+
+    for preset in sorted(MODEL_PRESETS.keys()):
+        resolved = MODEL_PRESETS[preset]
+        if resolved not in seen:
+            seen.add(resolved)
+            info = get_model_info(preset)
+            # Find all presets for this model
+            presets = [p for p, r in MODEL_PRESETS.items() if r == resolved]
+            info["presets"] = presets
+            models.append(info)
+
+    return models

--- a/ember/domain/config.py
+++ b/ember/domain/config.py
@@ -77,6 +77,22 @@ class IndexConfig:
                 f"overlap_lines ({self.overlap_lines}) must be less than "
                 f"line_window ({self.line_window})"
             )
+        # Validate model name
+        self._validate_model()
+
+    def _validate_model(self) -> None:
+        """Validate that the model name is recognized.
+
+        Raises:
+            ValueError: If model name is not a known preset or supported model
+        """
+        # Import here to avoid circular imports
+        from ember.adapters.local_models.registry import resolve_model_name
+
+        try:
+            resolve_model_name(self.model)
+        except ValueError as e:
+            raise ValueError(f"Invalid model configuration: {e}") from e
 
 
 @dataclass(frozen=True)

--- a/tests/unit/adapters/test_model_registry.py
+++ b/tests/unit/adapters/test_model_registry.py
@@ -1,0 +1,253 @@
+"""Tests for the model registry."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ember.adapters.local_models.registry import (
+    DEFAULT_MODEL,
+    MODEL_PRESETS,
+    SUPPORTED_MODELS,
+    create_embedder,
+    get_model_info,
+    list_available_models,
+    resolve_model_name,
+)
+
+
+class TestResolveModelName:
+    """Tests for resolve_model_name function."""
+
+    def test_resolve_preset_jina_code_v2(self):
+        """Test resolving jina-code-v2 preset."""
+        assert resolve_model_name("jina-code-v2") == "jinaai/jina-embeddings-v2-base-code"
+
+    def test_resolve_preset_minilm(self):
+        """Test resolving minilm preset."""
+        assert resolve_model_name("minilm") == "sentence-transformers/all-MiniLM-L6-v2"
+
+    def test_resolve_preset_bge_small(self):
+        """Test resolving bge-small preset."""
+        assert resolve_model_name("bge-small") == "BAAI/bge-small-en-v1.5"
+
+    def test_resolve_preset_case_insensitive(self):
+        """Test that preset names are case-insensitive."""
+        assert resolve_model_name("MINILM") == "sentence-transformers/all-MiniLM-L6-v2"
+        assert resolve_model_name("MiniLM") == "sentence-transformers/all-MiniLM-L6-v2"
+        assert resolve_model_name("BGE-SMALL") == "BAAI/bge-small-en-v1.5"
+
+    def test_resolve_legacy_default_name(self):
+        """Test resolving legacy 'local-default-code-embed' name."""
+        assert (
+            resolve_model_name("local-default-code-embed")
+            == "jinaai/jina-embeddings-v2-base-code"
+        )
+
+    def test_resolve_full_huggingface_id(self):
+        """Test resolving full HuggingFace model ID."""
+        assert (
+            resolve_model_name("jinaai/jina-embeddings-v2-base-code")
+            == "jinaai/jina-embeddings-v2-base-code"
+        )
+        assert (
+            resolve_model_name("sentence-transformers/all-MiniLM-L6-v2")
+            == "sentence-transformers/all-MiniLM-L6-v2"
+        )
+        assert resolve_model_name("BAAI/bge-small-en-v1.5") == "BAAI/bge-small-en-v1.5"
+
+    def test_resolve_unknown_model_raises_error(self):
+        """Test that unknown model names raise ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            resolve_model_name("unknown-model")
+        assert "Unknown embedding model" in str(exc_info.value)
+        assert "unknown-model" in str(exc_info.value)
+
+    def test_resolve_error_shows_valid_options(self):
+        """Test that error message includes valid options."""
+        with pytest.raises(ValueError) as exc_info:
+            resolve_model_name("invalid")
+        error_msg = str(exc_info.value)
+        assert "jina-code-v2" in error_msg or "minilm" in error_msg
+
+
+class TestCreateEmbedder:
+    """Tests for create_embedder function."""
+
+    @patch("ember.adapters.local_models.jina_embedder.JinaCodeEmbedder")
+    def test_create_default_embedder(self, mock_jina):
+        """Test creating default embedder (Jina) when no model specified."""
+        mock_instance = MagicMock()
+        mock_jina.return_value = mock_instance
+
+        result = create_embedder()
+
+        mock_jina.assert_called_once()
+        assert result == mock_instance
+
+    @patch("ember.adapters.local_models.jina_embedder.JinaCodeEmbedder")
+    def test_create_jina_embedder_by_preset(self, mock_jina):
+        """Test creating Jina embedder using preset name."""
+        mock_instance = MagicMock()
+        mock_jina.return_value = mock_instance
+
+        result = create_embedder(model_name="jina-code-v2")
+
+        mock_jina.assert_called_once()
+        assert result == mock_instance
+
+    @patch("ember.adapters.local_models.minilm_embedder.MiniLMEmbedder")
+    def test_create_minilm_embedder(self, mock_minilm):
+        """Test creating MiniLM embedder."""
+        mock_instance = MagicMock()
+        mock_minilm.return_value = mock_instance
+
+        result = create_embedder(model_name="minilm")
+
+        mock_minilm.assert_called_once()
+        assert result == mock_instance
+
+    @patch("ember.adapters.local_models.bge_embedder.BGESmallEmbedder")
+    def test_create_bge_embedder(self, mock_bge):
+        """Test creating BGE-small embedder."""
+        mock_instance = MagicMock()
+        mock_bge.return_value = mock_instance
+
+        result = create_embedder(model_name="bge-small")
+
+        mock_bge.assert_called_once()
+        assert result == mock_instance
+
+    @patch("ember.adapters.local_models.minilm_embedder.MiniLMEmbedder")
+    def test_create_embedder_passes_batch_size(self, mock_minilm):
+        """Test that batch_size is passed to embedder."""
+        mock_instance = MagicMock()
+        mock_minilm.return_value = mock_instance
+
+        create_embedder(model_name="minilm", batch_size=64)
+
+        mock_minilm.assert_called_once()
+        call_kwargs = mock_minilm.call_args[1]
+        assert call_kwargs["batch_size"] == 64
+
+    @patch("ember.adapters.local_models.minilm_embedder.MiniLMEmbedder")
+    def test_create_embedder_passes_max_seq_length(self, mock_minilm):
+        """Test that max_seq_length is passed to embedder."""
+        mock_instance = MagicMock()
+        mock_minilm.return_value = mock_instance
+
+        create_embedder(model_name="minilm", max_seq_length=128)
+
+        mock_minilm.assert_called_once()
+        call_kwargs = mock_minilm.call_args[1]
+        assert call_kwargs["max_seq_length"] == 128
+
+    @patch("ember.adapters.local_models.minilm_embedder.MiniLMEmbedder")
+    def test_create_embedder_passes_device(self, mock_minilm):
+        """Test that device is passed to embedder."""
+        mock_instance = MagicMock()
+        mock_minilm.return_value = mock_instance
+
+        create_embedder(model_name="minilm", device="cuda")
+
+        mock_minilm.assert_called_once()
+        call_kwargs = mock_minilm.call_args[1]
+        assert call_kwargs["device"] == "cuda"
+
+    def test_create_embedder_unknown_model_raises_error(self):
+        """Test that unknown model names raise ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            create_embedder(model_name="unknown-model")
+        assert "Unknown embedding model" in str(exc_info.value)
+
+
+class TestGetModelInfo:
+    """Tests for get_model_info function."""
+
+    def test_get_jina_info(self):
+        """Test getting info for Jina model."""
+        info = get_model_info("jina-code-v2")
+        assert info["name"] == "jinaai/jina-embeddings-v2-base-code"
+        assert info["dim"] == 768
+        assert info["params"] == "161M"
+        assert info["preset"] == "jina-code-v2"
+
+    def test_get_minilm_info(self):
+        """Test getting info for MiniLM model."""
+        info = get_model_info("minilm")
+        assert info["name"] == "sentence-transformers/all-MiniLM-L6-v2"
+        assert info["dim"] == 384
+        assert info["params"] == "22M"
+        assert info["preset"] == "minilm"
+
+    def test_get_bge_info(self):
+        """Test getting info for BGE-small model."""
+        info = get_model_info("bge-small")
+        assert info["name"] == "BAAI/bge-small-en-v1.5"
+        assert info["dim"] == 384
+        assert info["params"] == "33M"
+        assert info["preset"] == "bge-small"
+
+    def test_get_info_by_huggingface_id(self):
+        """Test getting info using full HuggingFace ID."""
+        info = get_model_info("jinaai/jina-embeddings-v2-base-code")
+        assert info["name"] == "jinaai/jina-embeddings-v2-base-code"
+        assert info["dim"] == 768
+        # Preset should be None when using full ID
+        assert info["preset"] is None
+
+    def test_get_info_unknown_model_raises_error(self):
+        """Test that unknown model names raise ValueError."""
+        with pytest.raises(ValueError):
+            get_model_info("unknown-model")
+
+
+class TestListAvailableModels:
+    """Tests for list_available_models function."""
+
+    def test_returns_list(self):
+        """Test that function returns a list."""
+        result = list_available_models()
+        assert isinstance(result, list)
+
+    def test_contains_all_unique_models(self):
+        """Test that list contains all unique models."""
+        result = list_available_models()
+        # Should have 3 unique models (Jina, MiniLM, BGE)
+        assert len(result) == 3
+
+    def test_each_model_has_required_fields(self):
+        """Test that each model info has required fields."""
+        result = list_available_models()
+        for model in result:
+            assert "name" in model
+            assert "dim" in model
+            assert "params" in model
+            assert "memory" in model
+            assert "presets" in model
+
+    def test_presets_are_populated(self):
+        """Test that presets list is populated for each model."""
+        result = list_available_models()
+        for model in result:
+            assert len(model["presets"]) > 0
+
+
+class TestModelPresets:
+    """Tests for MODEL_PRESETS constant."""
+
+    def test_all_presets_resolve_to_supported_models(self):
+        """Test that all presets map to supported models."""
+        for preset, resolved in MODEL_PRESETS.items():
+            assert resolved in SUPPORTED_MODELS, f"Preset {preset} maps to unsupported model"
+
+
+class TestDefaultModel:
+    """Tests for DEFAULT_MODEL constant."""
+
+    def test_default_is_jina(self):
+        """Test that default model is Jina."""
+        assert DEFAULT_MODEL == "jinaai/jina-embeddings-v2-base-code"
+
+    def test_default_is_supported(self):
+        """Test that default model is in supported models."""
+        assert DEFAULT_MODEL in SUPPORTED_MODELS

--- a/tests/unit/adapters/test_toml_config_provider.py
+++ b/tests/unit/adapters/test_toml_config_provider.py
@@ -46,7 +46,7 @@ topk = 50
         config_file.write_text(
             """
 [index]
-model = "custom-model"
+model = "minilm"
 chunk = "lines"
 line_window = 200
 line_stride = 150
@@ -78,7 +78,7 @@ theme = "monokai"
         result = provider.load(ember_dir)
 
         # Verify index section
-        assert result.index.model == "custom-model"
+        assert result.index.model == "minilm"
         assert result.index.chunk == "lines"
         assert result.index.line_window == 200
         assert result.index.line_stride == 150


### PR DESCRIPTION
## Summary

Implements centralized model registry and selection logic for configurable embedding models. This completes the foundation for #220 (configurable embedding models for resource-constrained systems).

- New model registry (`ember/adapters/local_models/registry.py`) centralizes model selection
- Daemon mode now respects `model` config - can run MiniLM or BGE-small in daemon mode
- Config validation rejects unknown model names with helpful error messages
- All models (Jina, MiniLM, BGE-small) now work in both daemon and direct modes

### Key Changes

| Component | Change |
|-----------|--------|
| `registry.py` | New file with `create_embedder()`, `resolve_model_name()`, `get_model_info()` |
| `server.py` | Accepts `--model` arg, uses registry to create embedder |
| `lifecycle.py` | Passes `model_name` when starting daemon |
| `client.py` | Reports correct model info for selected model |
| `cli.py` | Uses registry for both daemon and direct modes |
| `config.py` | Validates model names on load |

### Example Config

```toml
[index]
model = "minilm"  # or "bge-small", "jina-code-v2"

[model]
mode = "daemon"  # now works with all models!
```

### Available Models

| Preset | Model | Params | Memory | Use Case |
|--------|-------|--------|--------|----------|
| `jina-code-v2` | jinaai/jina-embeddings-v2-base-code | 161M | ~1.6GB | Best code understanding (default) |
| `minilm` | sentence-transformers/all-MiniLM-L6-v2 | 22M | ~100MB | Minimal footprint, very fast |
| `bge-small` | BAAI/bge-small-en-v1.5 | 33M | ~130MB | Good retrieval accuracy, small |

Implements #223

## Test Plan

- [x] 28 new unit tests for model registry (all passing)
- [x] All 626 existing tests pass
- [x] Linter passes (`ruff check .`)
- [x] Config validation rejects invalid model names
- [x] Daemon starts with correct model when configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)