### PR TITLE
feat: support global config fallback (~/.config/ember)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Global config fallback with `ember config` command group** (#225)
+  - Config loading now supports a two-tier system: local (.ember/config.toml) and global (~/.config/ember/config.toml)
+  - Local config overrides global config on a section-by-section basis
+  - Global config location: `~/.config/ember/config.toml` (Linux/macOS), `%APPDATA%/ember/config.toml` (Windows)
+  - Respects `XDG_CONFIG_HOME` environment variable on Linux/macOS
+  - New `ember config` command group with subcommands:
+    - `ember config show` - Display config locations and effective merged settings
+    - `ember config edit [--global]` - Open config in your editor (creates if missing)
+    - `ember config path [--global|--local]` - Print paths for scripting
+  - Use cases: consistent settings across multiple repos, organization-wide defaults
+
 - **Auto-detect hardware and recommend embedding model during init** (#224)
   - `ember init` now detects available system RAM and recommends an appropriate model
   - Shows resource detection output: available RAM, recommended model, and reasoning

--- a/ember/adapters/config/toml_config_provider.py
+++ b/ember/adapters/config/toml_config_provider.py
@@ -1,13 +1,23 @@
 """TOML-based configuration provider.
 
-Loads configuration from .ember/config.toml with graceful fallback to defaults.
+Loads configuration from .ember/config.toml with global config fallback.
+
+Config loading priority (highest to lowest):
+1. Local: .ember/config.toml (repo-specific)
+2. Global: ~/.config/ember/config.toml (user defaults)
+3. Built-in defaults
 """
 
 import logging
 from pathlib import Path
 
 from ember.domain.config import EmberConfig
-from ember.shared.config_io import load_config
+from ember.shared.config_io import (
+    config_data_to_ember_config,
+    get_global_config_path,
+    load_config_data,
+    merge_config_data,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -15,33 +25,65 @@ logger = logging.getLogger(__name__)
 class TomlConfigProvider:
     """Configuration provider that loads from TOML files.
 
-    Implements graceful degradation:
-    - If config.toml exists and is valid, load it
-    - If config.toml is missing or invalid, fall back to defaults
-    - Partial configs are supported (missing sections use defaults)
+    Implements config cascade:
+    1. Load global config (~/.config/ember/config.toml) if present
+    2. Load local config (.ember/config.toml) if present
+    3. Local values override global values (section-level merge)
+    4. Missing values fall back to built-in defaults
+
+    Gracefully handles missing or invalid configs with warnings.
     """
 
     def load(self, ember_dir: Path) -> EmberConfig:
-        """Load configuration from ember directory.
+        """Load configuration with global fallback.
 
         Args:
             ember_dir: Path to .ember directory containing config.toml
 
         Returns:
-            EmberConfig instance with loaded or default values
+            EmberConfig instance with merged global/local values or defaults
         """
-        config_path = ember_dir / "config.toml"
+        local_path = ember_dir / "config.toml"
+        global_path = get_global_config_path()
 
-        # If config file doesn't exist, return defaults
-        if not config_path.exists():
+        # Start with empty data (defaults will be applied by dataclasses)
+        merged_data: dict = {}
+
+        # Load global config if exists
+        if global_path.exists():
+            try:
+                global_data = load_config_data(global_path)
+                merged_data = global_data
+                logger.debug("Loaded global config from %s", global_path)
+            except (FileNotFoundError, ValueError) as e:
+                logger.warning(
+                    "Failed to parse global config at %s: %s. Ignoring global config.",
+                    global_path,
+                    e,
+                )
+
+        # Load and merge local config if exists
+        if local_path.exists():
+            try:
+                local_data = load_config_data(local_path)
+                merged_data = merge_config_data(merged_data, local_data)
+                logger.debug("Loaded local config from %s", local_path)
+            except (FileNotFoundError, ValueError) as e:
+                logger.warning(
+                    "Failed to parse config.toml: %s. Using global/default configuration.",
+                    e,
+                )
+
+        # If no config was loaded, return defaults
+        if not merged_data:
             return EmberConfig.default()
 
-        # Try to load config, fall back to defaults on error
+        # Convert merged data to EmberConfig
         try:
-            return load_config(config_path)
-        except (FileNotFoundError, ValueError) as e:
+            return config_data_to_ember_config(merged_data)
+        except (TypeError, ValueError) as e:
             logger.warning(
-                "Failed to parse config.toml: %s. Using default configuration.",
+                "Invalid config values: %s. Using default configuration.",
                 e,
             )
             return EmberConfig.default()

--- a/tests/unit/adapters/test_global_config.py
+++ b/tests/unit/adapters/test_global_config.py
@@ -1,0 +1,259 @@
+"""Unit tests for global config fallback functionality."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ember.adapters.config.toml_config_provider import TomlConfigProvider
+from ember.domain.config import EmberConfig
+from ember.shared.config_io import get_global_config_path
+
+
+class TestGetGlobalConfigPath:
+    """Tests for global config path resolution."""
+
+    def test_uses_xdg_config_home_when_set(self) -> None:
+        """Test that XDG_CONFIG_HOME is respected on Unix-like systems."""
+        with patch.dict(os.environ, {"XDG_CONFIG_HOME": "/custom/config"}):
+            result = get_global_config_path()
+
+        assert result == Path("/custom/config/ember/config.toml")
+
+    def test_defaults_to_home_config_when_xdg_not_set(self) -> None:
+        """Test default ~/.config/ember when XDG_CONFIG_HOME not set."""
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("ember.shared.config_io.Path.home") as mock_home,
+        ):
+            mock_home.return_value = Path("/home/user")
+            # Ensure XDG_CONFIG_HOME is not set
+            os.environ.pop("XDG_CONFIG_HOME", None)
+            result = get_global_config_path()
+
+        assert result == Path("/home/user/.config/ember/config.toml")
+
+    @patch("ember.shared.config_io.platform.system")
+    def test_uses_appdata_on_windows(self, mock_system: object) -> None:
+        """Test that %APPDATA%/ember is used on Windows."""
+        mock_system.return_value = "Windows"  # type: ignore[attr-defined]
+        with patch.dict(os.environ, {"APPDATA": "C:\\Users\\Test\\AppData\\Roaming"}):
+            result = get_global_config_path()
+
+        assert result == Path("C:\\Users\\Test\\AppData\\Roaming/ember/config.toml")
+
+
+class TestGlobalConfigFallback:
+    """Tests for global config fallback behavior."""
+
+    @pytest.fixture
+    def provider(self) -> TomlConfigProvider:
+        """Create a TomlConfigProvider instance."""
+        return TomlConfigProvider()
+
+    def test_global_config_used_when_local_missing(
+        self, provider: TomlConfigProvider, tmp_path: Path
+    ) -> None:
+        """Test that global config is used when local config is missing."""
+        # Setup: local .ember dir exists but has no config.toml
+        ember_dir = tmp_path / ".ember"
+        ember_dir.mkdir()
+
+        # Setup: global config with custom settings
+        global_config_dir = tmp_path / "global_config" / "ember"
+        global_config_dir.mkdir(parents=True)
+        global_config = global_config_dir / "config.toml"
+        global_config.write_text(
+            """
+[search]
+topk = 42
+
+[display]
+theme = "monokai"
+"""
+        )
+
+        # Patch to use our temp global config path
+        with patch(
+            "ember.adapters.config.toml_config_provider.get_global_config_path",
+            return_value=global_config,
+        ):
+            result = provider.load(ember_dir)
+
+        # Should use global config values
+        assert result.search.topk == 42
+        assert result.display.theme == "monokai"
+
+    def test_local_config_overrides_global(
+        self, provider: TomlConfigProvider, tmp_path: Path
+    ) -> None:
+        """Test that local config values override global config values."""
+        # Setup: local config
+        ember_dir = tmp_path / ".ember"
+        ember_dir.mkdir()
+        local_config = ember_dir / "config.toml"
+        local_config.write_text(
+            """
+[search]
+topk = 100
+"""
+        )
+
+        # Setup: global config with different values
+        global_config_dir = tmp_path / "global_config" / "ember"
+        global_config_dir.mkdir(parents=True)
+        global_config = global_config_dir / "config.toml"
+        global_config.write_text(
+            """
+[search]
+topk = 42
+rerank = true
+
+[display]
+theme = "monokai"
+"""
+        )
+
+        with patch(
+            "ember.adapters.config.toml_config_provider.get_global_config_path",
+            return_value=global_config,
+        ):
+            result = provider.load(ember_dir)
+
+        # Local value should override global
+        assert result.search.topk == 100
+        # Global values not in local should be used
+        assert result.search.rerank is True
+        assert result.display.theme == "monokai"
+
+    def test_defaults_used_when_both_configs_missing(
+        self, provider: TomlConfigProvider, tmp_path: Path
+    ) -> None:
+        """Test that defaults are used when both configs are missing."""
+        ember_dir = tmp_path / ".ember"
+        ember_dir.mkdir()
+
+        # Global config doesn't exist
+        global_config = tmp_path / "nonexistent" / "config.toml"
+
+        with patch(
+            "ember.adapters.config.toml_config_provider.get_global_config_path",
+            return_value=global_config,
+        ):
+            result = provider.load(ember_dir)
+
+        # Should return defaults
+        default = EmberConfig.default()
+        assert result.search.topk == default.search.topk
+        assert result.index.model == default.index.model
+
+    def test_partial_local_config_merges_with_global(
+        self, provider: TomlConfigProvider, tmp_path: Path
+    ) -> None:
+        """Test that partial local config merges with global config."""
+        # Setup: local config with only index section
+        ember_dir = tmp_path / ".ember"
+        ember_dir.mkdir()
+        local_config = ember_dir / "config.toml"
+        local_config.write_text(
+            """
+[index]
+model = "jina-code-v2"
+"""
+        )
+
+        # Setup: global config with search and display sections
+        global_config_dir = tmp_path / "global_config" / "ember"
+        global_config_dir.mkdir(parents=True)
+        global_config = global_config_dir / "config.toml"
+        global_config.write_text(
+            """
+[index]
+model = "minilm"
+
+[search]
+topk = 50
+
+[display]
+theme = "github-dark"
+syntax_highlighting = false
+"""
+        )
+
+        with patch(
+            "ember.adapters.config.toml_config_provider.get_global_config_path",
+            return_value=global_config,
+        ):
+            result = provider.load(ember_dir)
+
+        # Local index overrides global
+        assert result.index.model == "jina-code-v2"
+        # Global search used
+        assert result.search.topk == 50
+        # Global display used
+        assert result.display.theme == "github-dark"
+        assert result.display.syntax_highlighting is False
+
+    def test_invalid_global_config_falls_back_to_defaults(
+        self, provider: TomlConfigProvider, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test that invalid global config is ignored gracefully."""
+        ember_dir = tmp_path / ".ember"
+        ember_dir.mkdir()
+
+        # Setup: invalid global config
+        global_config_dir = tmp_path / "global_config" / "ember"
+        global_config_dir.mkdir(parents=True)
+        global_config = global_config_dir / "config.toml"
+        global_config.write_text("[invalid toml")
+
+        with patch(
+            "ember.adapters.config.toml_config_provider.get_global_config_path",
+            return_value=global_config,
+        ):
+            result = provider.load(ember_dir)
+
+        # Should return defaults
+        default = EmberConfig.default()
+        assert result == default
+        # Should log warning about global config
+        assert "global" in caplog.text.lower() or "Failed" in caplog.text
+
+    def test_array_fields_merge_correctly(
+        self, provider: TomlConfigProvider, tmp_path: Path
+    ) -> None:
+        """Test that array fields from local completely replace global (no append)."""
+        # Setup: local config with include patterns
+        ember_dir = tmp_path / ".ember"
+        ember_dir.mkdir()
+        local_config = ember_dir / "config.toml"
+        local_config.write_text(
+            """
+[index]
+include = ["**/*.py"]
+"""
+        )
+
+        # Setup: global config with different include patterns
+        global_config_dir = tmp_path / "global_config" / "ember"
+        global_config_dir.mkdir(parents=True)
+        global_config = global_config_dir / "config.toml"
+        global_config.write_text(
+            """
+[index]
+include = ["**/*.rs", "**/*.go"]
+ignore = [".git/", "target/"]
+"""
+        )
+
+        with patch(
+            "ember.adapters.config.toml_config_provider.get_global_config_path",
+            return_value=global_config,
+        ):
+            result = provider.load(ember_dir)
+
+        # Local include should completely replace global (not merge)
+        assert result.index.include == ["**/*.py"]
+        # Global ignore should be used (not in local)
+        assert result.index.ignore == [".git/", "target/"]

--- a/tests/unit/test_config_commands.py
+++ b/tests/unit/test_config_commands.py
@@ -1,0 +1,125 @@
+"""Unit tests for ember config CLI commands."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ember.entrypoints.cli import cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a CLI test runner."""
+    return CliRunner()
+
+
+class TestConfigShow:
+    """Tests for 'ember config show' command."""
+
+    def test_show_global_only(self, runner: CliRunner) -> None:
+        """Test showing only global config location."""
+        with patch(
+            "ember.shared.config_io.get_global_config_path",
+            return_value=Path("/home/user/.config/ember/config.toml"),
+        ):
+            result = runner.invoke(cli, ["config", "show", "--global"], obj={})
+
+        assert result.exit_code == 0
+        assert "/home/user/.config/ember/config.toml" in result.output
+        assert "Global config:" in result.output
+
+    def test_show_local_not_in_repo(self, runner: CliRunner) -> None:
+        """Test showing local config when not in a repository."""
+        with patch(
+            "ember.entrypoints.cli.get_ember_repo_root",
+            side_effect=RuntimeError("Not in repo"),
+        ):
+            result = runner.invoke(cli, ["config", "show", "--local"], obj={})
+
+        assert result.exit_code == 0
+        assert "Not in an Ember repository" in result.output
+
+
+class TestConfigPath:
+    """Tests for 'ember config path' command."""
+
+    def test_path_global_only(self, runner: CliRunner) -> None:
+        """Test getting global config path only."""
+        with patch(
+            "ember.shared.config_io.get_global_config_path",
+            return_value=Path("/home/user/.config/ember/config.toml"),
+        ):
+            result = runner.invoke(cli, ["config", "path", "--global"], obj={})
+
+        assert result.exit_code == 0
+        assert result.output.strip() == "/home/user/.config/ember/config.toml"
+
+    def test_path_local_only_in_repo(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Test getting local config path when in a repository."""
+        ember_dir = tmp_path / ".ember"
+        ember_dir.mkdir()
+
+        with patch(
+            "ember.entrypoints.cli.get_ember_repo_root",
+            return_value=(tmp_path, ember_dir),
+        ):
+            result = runner.invoke(cli, ["config", "path", "--local"], obj={})
+
+        assert result.exit_code == 0
+        assert str(ember_dir / "config.toml") in result.output
+
+    def test_path_both(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Test getting both config paths."""
+        ember_dir = tmp_path / ".ember"
+        ember_dir.mkdir()
+
+        with patch(
+            "ember.shared.config_io.get_global_config_path",
+            return_value=Path("/home/user/.config/ember/config.toml"),
+        ), patch(
+            "ember.entrypoints.cli.get_ember_repo_root",
+            return_value=(tmp_path, ember_dir),
+        ):
+            result = runner.invoke(cli, ["config", "path"], obj={})
+
+        assert result.exit_code == 0
+        assert "global:" in result.output
+        assert "local:" in result.output
+
+
+class TestConfigEdit:
+    """Tests for 'ember config edit' command."""
+
+    def test_edit_global_not_in_repo(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Test editing global config when not in a repository."""
+        global_config = tmp_path / "config.toml"
+
+        with (
+            patch(
+                "ember.shared.config_io.get_global_config_path",
+                return_value=global_config,
+            ),
+            patch(
+                "ember.entrypoints.cli.get_ember_repo_root",
+                side_effect=RuntimeError("Not in repo"),
+            ),
+            patch.dict("os.environ", {"EDITOR": "echo"}),
+        ):
+            result = runner.invoke(cli, ["config", "edit", "--global"], obj={})
+
+        assert result.exit_code == 0
+        # Config file should be created
+        assert global_config.exists()
+
+    def test_edit_local_not_in_repo_fails(self, runner: CliRunner) -> None:
+        """Test that editing local config fails when not in a repository."""
+        with patch(
+            "ember.entrypoints.cli.get_ember_repo_root",
+            side_effect=RuntimeError("Not in repo"),
+        ):
+            result = runner.invoke(cli, ["config", "edit"], obj={})
+
+        assert result.exit_code == 1
+        assert "Not in an Ember repository" in result.output


### PR DESCRIPTION
## Summary

Implements #225 - Global config fallback for consistent settings across repositories.

- **Global config location**: `~/.config/ember/config.toml` (Linux/macOS with XDG support), `%APPDATA%/ember/config.toml` (Windows)
- **Config merging**: Local config overrides global config on a section-by-section basis
- **New CLI commands**: `ember config show|edit|path` for managing configs

## Changes

### Core Implementation
- Add `get_global_config_path()` in `ember/shared/config_io.py` for cross-platform path resolution
- Add `merge_config_data()`, `load_config_data()`, `config_data_to_ember_config()` helper functions
- Update `TomlConfigProvider.load()` to implement the config cascade:
  1. Load global config if exists
  2. Load local config if exists  
  3. Merge with local taking precedence
  4. Fall back to defaults for missing values

### CLI Commands
- `ember config show` - Display config file locations and effective merged settings
- `ember config edit [--global]` - Open config in editor (creates default if missing)
- `ember config path [--global|--local]` - Print bare paths for scripting

### Improved Error Handling
- TypeError from unknown config keys now falls back to defaults gracefully (was propagating)

## Test Plan

- [x] 9 new tests for global config path resolution and fallback behavior
- [x] 7 new tests for CLI commands  
- [x] Updated 1 existing test for improved error handling
- [x] All 694 tests pass
- [x] Linting passes

## Acceptance Criteria from Issue

- [x] `~/.config/ember/config.toml` is read if present
- [x] Local config overrides global
- [x] Missing sections use global/defaults
- [x] Works with XDG_CONFIG_HOME on Linux
- [x] Works on Windows (`%APPDATA%/ember`)
- [x] `ember config --global` command to edit global config

Implements #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)