### PR TITLE
feat: add TypeScript interface extraction to TreeSitter (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **TypeScript interface extraction support** (#227)
+  - TreeSitter now extracts TypeScript `interface` declarations as semantic chunks
+  - Works with generic interfaces: `interface Foo<T>`, `interface KeyValuePair<K, V>`
+  - Works with extended interfaces: `interface Admin extends User`
+  - Interfaces have proper symbol names for search (e.g., "User", "Admin")
+  - Also added to TSX files for React TypeScript projects
+
 - **Global config fallback with `ember config` command group** (#225)
   - Config loading now supports a two-tier system: local (.ember/config.toml) and global (~/.config/ember/config.toml)
   - Local config overrides global config on a section-by-section basis

--- a/ember/adapters/parsers/language_registry.py
+++ b/ember/adapters/parsers/language_registry.py
@@ -72,6 +72,8 @@ class LanguageRegistry:
                 name: (property_identifier) @method.name) @method.def
             (class_declaration
                 name: (type_identifier) @class.name) @class.def
+            (interface_declaration
+                name: (type_identifier) @interface.name) @interface.def
             (arrow_function) @arrow.def
         """,
         ),
@@ -87,6 +89,8 @@ class LanguageRegistry:
                 name: (property_identifier) @method.name) @method.def
             (class_declaration
                 name: (type_identifier) @class.name) @class.def
+            (interface_declaration
+                name: (type_identifier) @interface.name) @interface.def
             (arrow_function) @arrow.def
         """,
         ),


### PR DESCRIPTION
## Summary
- Add `interface_declaration` pattern to TypeScript and TSX TreeSitter queries
- Extract interfaces as semantic chunks with proper symbol names
- Support generic interfaces: `interface Foo<T>`, `interface KeyValuePair<K, V>`
- Support extended interfaces: `interface Admin extends User`

## Test plan
- [x] Added 3 new tests for TypeScript interface extraction
- [x] Test basic interface extraction with `interface User { ... }`
- [x] Test generic interfaces with type parameters
- [x] Test interfaces alongside classes and functions (mixed definitions)
- [x] All 20 TreeSitter chunker tests pass
- [x] Full test suite (697 tests) passes

Implements #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)