### PR TITLE
test: add TypeScript export statement test coverage (#230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **TypeScript/JavaScript export statement handling** (#230)
+  - TreeSitter correctly captures exported functions, classes, interfaces, and type aliases
+  - Exported declarations include the `export` keyword in chunk content
+  - Comprehensive test coverage for all export patterns:
+    - `export function processData()` - named function exports
+    - `export class UserService` - class exports
+    - `export const handler = () => {}` - arrow function exports
+    - `export default class App` - default exports
+    - `export interface Config` - interface exports
+    - `export type Status = ...` - type alias exports
+  - Works across TypeScript (.ts), JavaScript (.js), TSX (.tsx), and JSX (.jsx) files
+
 - **Named arrow function extraction for TypeScript/JavaScript** (#229)
   - TreeSitter now extracts named arrow functions with proper symbol names
   - Supports all assignment patterns: `const foo = () => {}`, `let bar = () => {}`, `var baz = () => {}`


### PR DESCRIPTION
## Summary

- Add comprehensive test coverage for TypeScript/JavaScript export statements
- Verify TreeSitter correctly captures exported declarations with the `export` keyword
- Tests cover all export patterns from issue requirements

## Details

The existing TreeSitter implementation already handles exports correctly because:
1. Inner declarations (function_declaration, class_declaration, etc.) are matched regardless of being wrapped in export_statement
2. Content extraction by line numbers naturally includes the full line with the export keyword

This PR adds test coverage to document and verify this behavior.

## Test Coverage Added

- `test_tree_sitter_typescript_export_function` - exported function declarations
- `test_tree_sitter_typescript_export_class` - exported class declarations  
- `test_tree_sitter_typescript_export_const` - exported arrow functions
- `test_tree_sitter_typescript_export_default_class` - default exports
- `test_tree_sitter_typescript_export_interface` - exported interfaces
- `test_tree_sitter_typescript_export_type` - exported type aliases
- `test_tree_sitter_typescript_mixed_exports` - mixed exported/non-exported
- `test_tree_sitter_tsx_exports` - TSX file exports
- `test_tree_sitter_javascript_exports` - JavaScript file exports

## Acceptance Criteria

- [x] `export function` captures function name
- [x] `export class` captures class name
- [x] `export const/let` captures variable name
- [x] `export default` captures name if present
- [x] Test coverage added

Implements #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)