### PR TITLE
test: add comprehensive TypeScript TreeSitter test coverage (#231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Comprehensive TypeScript TreeSitter test coverage** (#231)
+  - Added 18 new test cases for TypeScript code extraction, bringing total to 40+ TS-related tests
+  - Test coverage now matches Python's depth across all major TypeScript constructs
+  - New tests cover: async functions, nested classes, generic functions/classes/arrow functions,
+    decorators, malformed code handling, TSX functional/class components, method signatures,
+    computed properties, function overloads, and namespaces
+  - Tests document expected behavior for each TypeScript pattern
+
 - **TypeScript/JavaScript export statement handling** (#230)
   - TreeSitter correctly captures exported functions, classes, interfaces, and type aliases
   - Exported declarations include the `export` keyword in chunk content


### PR DESCRIPTION
## Summary

- Adds 18 new test cases for TypeScript TreeSitter code extraction
- Brings total TypeScript-related tests from ~22 to 40+
- Test coverage now matches Python's depth across all major constructs

## New Test Coverage

### Async Functions
- `test_tree_sitter_typescript_async_functions` - async function declarations
- `test_tree_sitter_typescript_async_arrow_functions` - async arrow functions

### Classes & Nesting
- `test_tree_sitter_typescript_nested_classes` - classes defined inside other classes/functions

### Generics
- `test_tree_sitter_typescript_generic_functions` - generic function declarations
- `test_tree_sitter_typescript_generic_classes` - generic class declarations
- `test_tree_sitter_typescript_generic_arrow_functions` - generic arrow functions

### Edge Cases
- `test_tree_sitter_typescript_decorators` - decorated classes/methods (Angular-style)
- `test_tree_sitter_typescript_malformed_code` - error recovery with broken syntax
- `test_tree_sitter_typescript_incomplete_statements` - handling partial code

### React/TSX
- `test_tree_sitter_tsx_functional_components` - React functional components
- `test_tree_sitter_tsx_class_components` - React class components

### Advanced Patterns
- `test_tree_sitter_typescript_method_signatures` - async/generic/static methods
- `test_tree_sitter_typescript_computed_properties` - computed property names
- `test_tree_sitter_typescript_overloaded_functions` - function overloads
- `test_tree_sitter_typescript_namespace` - namespace declarations

## Acceptance Criteria

- [x] ≥15 TypeScript test cases (now 40+)
- [x] All major constructs covered
- [x] Edge cases (malformed, nested) covered
- [x] TSX/JSX-specific tests included
- [x] Tests document expected behavior for future reference

## Test Plan

- [x] `uv run pytest tests/unit/test_tree_sitter_chunker.py -v` - all 55 tests pass
- [x] `uv run pytest` - all 732 tests pass
- [x] `uv run ruff check .` - no linting issues

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)