### PR TITLE
feat: add Go/Rust struct, enum, trait extraction to TreeSitter (#232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Go struct and interface extraction** (#232)
+  - TreeSitter now extracts Go struct definitions: `type User struct { ... }`
+  - TreeSitter now extracts Go interface definitions: `type Reader interface { ... }`
+  - Works with generic types (Go 1.18+): `type Container[T any] struct { ... }`
+  - Works with embedded interfaces: `type ReadWriter interface { Reader; Writer }`
+  - Comprehensive test coverage for Go constructs (6 new test cases)
+
+- **Rust struct, enum, and trait extraction** (#232)
+  - TreeSitter now extracts Rust struct definitions: `struct User { ... }`, `struct Empty;`, `struct Tuple(i32, i32);`
+  - TreeSitter now extracts Rust enum definitions: `enum Status { Active, Inactive }`
+  - TreeSitter now extracts Rust trait definitions: `trait Display { ... }`
+  - Works with generic types: `struct Container<T> { ... }`, `trait Iterator<T> { ... }`
+  - Works with trait bounds: `trait Comparable: PartialEq + PartialOrd { ... }`
+  - Comprehensive test coverage for Rust constructs (8 new test cases)
+
 - **Comprehensive TypeScript TreeSitter test coverage** (#231)
   - Added 18 new test cases for TypeScript code extraction, bringing total to 40+ TS-related tests
   - Test coverage now matches Python's depth across all major TypeScript constructs

--- a/ember/adapters/parsers/language_registry.py
+++ b/ember/adapters/parsers/language_registry.py
@@ -166,6 +166,14 @@ class LanguageRegistry:
                 name: (identifier) @func.name) @func.def
             (method_declaration
                 name: (field_identifier) @method.name) @method.def
+            (type_declaration
+                (type_spec
+                    name: (type_identifier) @struct.name
+                    type: (struct_type))) @struct.def
+            (type_declaration
+                (type_spec
+                    name: (type_identifier) @interface.name
+                    type: (interface_type))) @interface.def
         """,
         ),
         LanguageConfig(
@@ -177,6 +185,12 @@ class LanguageRegistry:
             (function_item
                 name: (identifier) @func.name) @func.def
             (impl_item) @impl.def
+            (struct_item
+                name: (type_identifier) @struct.name) @struct.def
+            (enum_item
+                name: (type_identifier) @enum.name) @enum.def
+            (trait_item
+                name: (type_identifier) @trait.name) @trait.def
         """,
         ),
         LanguageConfig(


### PR DESCRIPTION
## Summary

Enhance TreeSitter query patterns for Go and Rust to extract major language constructs beyond just functions. This completes issue #232 and finalizes the TreeSitter language parity initiative (#226).

## Changes

### Go Additions
- Struct definitions: `type User struct { ... }`
- Interface definitions: `type Reader interface { ... }`
- Generic types (Go 1.18+): `type Container[T any] struct { ... }`
- Embedded interfaces: `type ReadWriter interface { Reader; Writer }`

### Rust Additions
- Struct definitions: `struct User { ... }`, unit structs (`struct Empty;`), tuple structs (`struct Tuple(i32, i32)`)
- Enum definitions: `enum Status { Active, Inactive }`
- Trait definitions: `trait Display { ... }`
- Generic types: `struct Container<T>`, `trait Iterator<T>`
- Trait bounds: `trait Comparable: PartialEq + PartialOrd`

## Test Coverage
- 6 new Go test cases covering structs, interfaces, methods on structs, mixed definitions, embedded interfaces, and generics
- 8 new Rust test cases covering structs, enums, traits, impl blocks, mixed definitions, generic structs, trait bounds, and async functions

## Files Changed
- `ember/adapters/parsers/language_registry.py` - Updated Go and Rust query patterns
- `tests/unit/test_tree_sitter_chunker.py` - Added 14 comprehensive tests
- `CHANGELOG.md` - Documented new features

Implements #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)