### PR TITLE
feat: change search command positional arg from query to path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Interactive search now accepts path argument instead of query**
+  - `ember search tests` restricts search to `tests/` directory
+  - `ember search .` restricts search to current directory
+  - `ember search` (no argument) searches entire repository
+  - Query text is now always entered interactively in the TUI
+  - Consistent with `ember find` command behavior for path filtering
+  - `--in` flag for glob patterns still available, but mutually exclusive with PATH argument
+
 ### Added
 - **Go struct and interface extraction** (#232)
   - TreeSitter now extracts Go struct definitions: `type User struct { ... }`


### PR DESCRIPTION
## Summary
- Changed `ember search` positional argument from `initial_query` to `path`
- `ember search tests` restricts search to `tests/` directory
- `ember search .` restricts search to current directory
- `ember search` (no argument) searches entire repository
- Query text is now always entered interactively in the TUI
- Consistent with `ember find` command behavior for path filtering

## Test plan
- [x] Updated `test_search_path_and_in_filter_mutually_exclusive` to test new PATH vs `--in` mutual exclusion
- [x] Added `test_search_accepts_path_argument` to verify path argument parsing
- [x] Added `test_search_no_path_argument` to verify optional path behavior
- [x] All 54 CLI integration tests pass
- [x] Ruff linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)