### PR TITLE
fix: pass embedder dimension to SqliteVecAdapter in find/search commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-*No changes yet*
+### Fixed
+- **SqliteVecAdapter now uses correct embedding dimension** (#249)
+  - `SqliteVecAdapter` was hardcoded to 768 dimensions (Jina), breaking MiniLM and BGE models which use 384 dimensions
+  - `ember find` and `ember search` commands now pass the embedder's dimension to `SqliteVecAdapter`
+  - Non-Jina models (minilm, bge-small) now work correctly with vector search
 
 ## [1.2.0] - 2025-12-12
 

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -768,10 +768,11 @@ def find(
     from ember.domain.entities import Query
 
     # Initialize dependencies
-    text_search = SQLiteFTS(db_path)
-    vector_search = SqliteVecAdapter(db_path)
-    chunk_repo = SQLiteChunkRepository(db_path)
+    # Create embedder first to get its dimension for vector search
     embedder = _create_embedder(config)
+    text_search = SQLiteFTS(db_path)
+    vector_search = SqliteVecAdapter(db_path, vector_dim=embedder.dim)
+    chunk_repo = SQLiteChunkRepository(db_path)
 
     # Create search use case
     search_usecase = SearchUseCase(
@@ -937,10 +938,11 @@ def search(
     from ember.domain.entities import Query
 
     # Initialize search dependencies
-    text_search = SQLiteFTS(db_path)
-    vector_search = SqliteVecAdapter(db_path)
-    chunk_repo = SQLiteChunkRepository(db_path)
+    # Create embedder first to get its dimension for vector search
     embedder = _create_embedder(config, show_progress=False)  # No progress for interactive
+    text_search = SQLiteFTS(db_path)
+    vector_search = SqliteVecAdapter(db_path, vector_dim=embedder.dim)
+    chunk_repo = SQLiteChunkRepository(db_path)
 
     # Create search use case
     search_usecase = SearchUseCase(

--- a/tests/unit/adapters/test_sqlite_vec_adapter.py
+++ b/tests/unit/adapters/test_sqlite_vec_adapter.py
@@ -1,0 +1,125 @@
+"""Unit tests for SqliteVecAdapter dimension handling.
+
+Tests for issue #249: SqliteVecAdapter hardcodes 768 dimensions, breaks non-Jina models.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from ember.adapters.sqlite.schema import init_database
+from ember.adapters.vss.sqlite_vec_adapter import SqliteVecAdapter
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    """Create an initialized database."""
+    path = tmp_path / "test.db"
+    init_database(path)
+    return path
+
+
+def test_sqlite_vec_adapter_uses_default_768_dimension(db_path: Path) -> None:
+    """Test that default dimension is 768 (Jina)."""
+    adapter = SqliteVecAdapter(db_path)
+    assert adapter.vector_dim == 768
+
+
+def test_sqlite_vec_adapter_accepts_custom_dimension(db_path: Path) -> None:
+    """Test that custom dimension can be passed."""
+    adapter = SqliteVecAdapter(db_path, vector_dim=384)
+    assert adapter.vector_dim == 384
+
+
+def test_sqlite_vec_adapter_creates_table_with_correct_dimension(tmp_path: Path) -> None:
+    """Test that vec_chunks table is created with the specified dimension.
+
+    This is the key bug fix test for issue #249. The vec0 table should be
+    created with the dimension specified at construction time, not hardcoded 768.
+    """
+    db_path = tmp_path / "test.db"
+    init_database(db_path)
+
+    # Create adapter with 384 dimensions (MiniLM/BGE)
+    adapter = SqliteVecAdapter(db_path, vector_dim=384)
+
+    # Verify the table was created with correct dimension by checking schema
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    # Query the table schema - vec0 tables store their config in the internal schema
+    cursor.execute("SELECT sql FROM sqlite_master WHERE name = 'vec_chunks'")
+    row = cursor.fetchone()
+    conn.close()
+    adapter.close()
+
+    # The CREATE statement should contain float[384]
+    assert row is not None, "vec_chunks table should exist"
+    create_sql = row[0]
+    assert "float[384]" in create_sql, f"Expected float[384] in: {create_sql}"
+
+
+def test_sqlite_vec_adapter_dimension_mismatch_fails(tmp_path: Path) -> None:
+    """Test that querying with wrong dimension fails with clear error.
+
+    This ensures users get a clear error when model dimensions don't match.
+    """
+    db_path = tmp_path / "test.db"
+    init_database(db_path)
+
+    # Create adapter with 384 dimensions
+    adapter = SqliteVecAdapter(db_path, vector_dim=384)
+
+    # Try to query with a 768-dimensional vector (wrong!)
+    wrong_dim_vector = [0.1] * 768
+
+    with pytest.raises(Exception) as exc_info:
+        adapter.query(wrong_dim_vector, topk=10)
+
+    # Should get dimension mismatch error from sqlite-vec
+    error_msg = str(exc_info.value).lower()
+    assert "dimension" in error_msg or "mismatch" in error_msg
+
+
+def test_sqlite_vec_adapter_correct_dimension_succeeds(tmp_path: Path) -> None:
+    """Test that querying with correct dimension works."""
+    db_path = tmp_path / "test.db"
+    init_database(db_path)
+
+    # Create adapter with 384 dimensions
+    adapter = SqliteVecAdapter(db_path, vector_dim=384)
+
+    # Query with correct dimension (384)
+    correct_dim_vector = [0.1] * 384
+
+    # Should not raise - no vectors yet so empty results
+    results = adapter.query(correct_dim_vector, topk=10)
+    assert isinstance(results, list)
+    adapter.close()
+
+
+def test_sqlite_vec_adapter_dimension_384_for_minilm(db_path: Path) -> None:
+    """Test that MiniLM's 384 dimensions work correctly."""
+    adapter = SqliteVecAdapter(db_path, vector_dim=384)
+
+    # Query with 384-dim vector
+    vector = [0.5] * 384
+    results = adapter.query(vector, topk=5)
+
+    # Should succeed without dimension errors
+    assert isinstance(results, list)
+    adapter.close()
+
+
+def test_sqlite_vec_adapter_dimension_768_for_jina(db_path: Path) -> None:
+    """Test that Jina's 768 dimensions work correctly."""
+    adapter = SqliteVecAdapter(db_path, vector_dim=768)
+
+    # Query with 768-dim vector
+    vector = [0.5] * 768
+    results = adapter.query(vector, topk=5)
+
+    # Should succeed without dimension errors
+    assert isinstance(results, list)
+    adapter.close()


### PR DESCRIPTION
## Summary

Fixes #249 - SqliteVecAdapter hardcodes 768 dimensions, breaks non-Jina models

- Create embedder before SqliteVecAdapter in find/search commands to get its dimension
- Pass `vector_dim=embedder.dim` to SqliteVecAdapter constructor
- Non-Jina models (minilm, bge-small with 384 dimensions) now work correctly

## Changes

- `ember/entrypoints/cli.py`: Reorder instantiation in `find` and `search` commands to create embedder first, then pass its dimension
- `tests/unit/adapters/test_sqlite_vec_adapter.py`: Add 7 unit tests for dimension handling

## Test plan

- [x] All unit tests pass (567 passed)
- [x] New SqliteVecAdapter tests verify dimension handling
- [x] Linting passes
- [x] Tests confirm 384-dim and 768-dim vectors work correctly with matching adapter dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)