### PR TITLE
fix: pass model_name from config to daemon start/restart commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ember find` and `ember search` commands now pass the embedder's dimension to `SqliteVecAdapter`
   - Non-Jina models (minilm, bge-small) now work correctly with vector search
 
+- **`ember daemon start/restart` now uses configured model**
+  - `ember daemon start` and `ember daemon restart` were ignoring the `model` setting from config.toml
+  - Daemon now starts with the correct embedding model from project configuration
+  - Prevents dimension mismatch errors when using non-default models
+
 ## [1.2.0] - 2025-12-12
 
 ### Changed


### PR DESCRIPTION
## Summary

Fixes dimension mismatch errors when using `ember daemon start` or `ember daemon restart` with non-default models.

The daemon commands were not passing the configured model to `DaemonLifecycle`, causing the daemon to always start with the default model (jina-code-v2, 768 dims) even when config specified minilm or bge-small (384 dims).

## Changes

- `ember daemon start`: Pass `model_name=config.index.model` to DaemonLifecycle
- `ember daemon restart`: Load config and pass `model_name=config.index.model` to DaemonLifecycle

## Test plan

- [x] Unit tests pass (567 passed)
- [x] Linting passes
- [x] Manual testing: `ember daemon start` now respects config model setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)