### PR TITLE
feat: refactor config system with global + local inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Config system refactored with global + local inheritance** (#252)
+  - Model selection is now a machine-level setting in global config (`~/.config/ember/config.toml`)
+  - Project configs (`.ember/config.toml`) are now minimal and override global settings
+  - `ember init` creates global config on first run (with hardware-detected model)
+  - `ember init` creates minimal project config (only repo-specific overrides)
+  - Prevents model mismatch errors when same repo is used on different machines
+  - Existing projects continue to work (full project configs still override everything)
+
 ### Fixed
 - **SqliteVecAdapter now uses correct embedding dimension** (#249)
   - `SqliteVecAdapter` was hardcoded to 768 dimensions (Jina), breaking MiniLM and BGE models which use 384 dimensions

--- a/ember/core/config/init_usecase.py
+++ b/ember/core/config/init_usecase.py
@@ -8,7 +8,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ember.ports.database import DatabaseInitializer
-from ember.shared.config_io import create_default_config_file
+from ember.shared.config_io import (
+    create_global_config_file,
+    create_minimal_project_config,
+    get_global_config_path,
+)
 from ember.shared.state_io import create_initial_state
 
 
@@ -37,6 +41,8 @@ class InitResponse:
         db_path: Path to created index.db
         state_path: Path to created state.json
         was_reinitialized: True if existing .ember/ was replaced
+        global_config_created: True if global config was created (first run)
+        global_config_path: Path to global config file (may or may not exist)
     """
 
     ember_dir: Path
@@ -44,6 +50,8 @@ class InitResponse:
     db_path: Path
     state_path: Path
     was_reinitialized: bool
+    global_config_created: bool = False
+    global_config_path: Path | None = None
 
 
 class InitUseCase:
@@ -67,9 +75,12 @@ class InitUseCase:
         """Execute the init operation.
 
         Creates .ember/ directory with:
-        - config.toml (default configuration)
+        - config.toml (minimal project configuration)
         - index.db (empty SQLite database with schema)
         - state.json (initial state tracking)
+
+        On first run (no global config exists), also creates:
+        - ~/.config/ember/config.toml (global config with hardware-specific defaults)
 
         Args:
             request: Init request with repo root and options
@@ -85,6 +96,7 @@ class InitUseCase:
         config_path = ember_dir / "config.toml"
         db_path = ember_dir / "index.db"
         state_path = ember_dir / "state.json"
+        global_config_path = get_global_config_path()
 
         # Check if .ember/ already exists
         was_reinitialized = False
@@ -93,11 +105,17 @@ class InitUseCase:
                 raise FileExistsError(f"Directory {ember_dir} already exists")
             was_reinitialized = True
 
+        # Create global config if it doesn't exist (first run)
+        global_config_created = False
+        if not global_config_path.exists():
+            create_global_config_file(global_config_path, model=request.model)
+            global_config_created = True
+
         # Create .ember/ directory
         ember_dir.mkdir(parents=True, exist_ok=True)
 
-        # Create config.toml with defaults
-        create_default_config_file(config_path, model=request.model)
+        # Create minimal project config (settings inherit from global)
+        create_minimal_project_config(config_path)
 
         # Initialize database with schema
         self._db_initializer.init_database(db_path)
@@ -111,4 +129,6 @@ class InitUseCase:
             db_path=db_path,
             state_path=state_path,
             was_reinitialized=was_reinitialized,
+            global_config_created=global_config_created,
+            global_config_path=global_config_path,
         )


### PR DESCRIPTION
## Summary
- Refactors config system to use global (~/.config/ember/config.toml) + local (.ember/config.toml) inheritance
- Model selection is now a machine-level setting, not a repo-level setting
- Prevents model mismatch errors when same repo is used on different machines

Implements #252

## Changes
- Add `create_minimal_project_config()` for repo-specific overrides only
- Add `create_global_config_file()` for machine-specific defaults (model, daemon settings)
- Update `InitUseCase` to create global config on first run with hardware-detected model
- Update `ember config show` to display effective merged config
- Update `ember config edit` to use appropriate templates (global vs local)
- Update tests to use isolated global config paths

## Config Inheritance Model
```
~/.config/ember/config.toml     (global defaults - machine-specific)
    ↓ overwritten by
.ember/config.toml              (project overrides - repo-specific)
```

## Migration
- Existing projects continue to work unchanged (full project configs still override everything)
- Users can gradually move machine-specific settings to global config

## Test Plan
- [x] All 758 tests pass
- [x] Linter passes (ruff check)
- [x] Integration tests updated for new config behavior
- [x] Unit tests isolated from user's actual global config

🤖 Generated with [Claude Code](https://claude.com/claude-code)