### PR TITLE
fix: add test isolation for global config in TomlConfigProvider tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Existing projects continue to work (full project configs still override everything)
 
 ### Fixed
+- **Test isolation: global config no longer leaks into unit tests** (#254)
+  - Config provider tests now mock `get_global_config_path()` to prevent user's `~/.config/ember/config.toml` from affecting test results
+  - Added `no_global_config` fixture for consistent test isolation
+
 - **SqliteVecAdapter now uses correct embedding dimension** (#249)
   - `SqliteVecAdapter` was hardcoded to 768 dimensions (Jina), breaking MiniLM and BGE models which use 384 dimensions
   - `ember find` and `ember search` commands now pass the embedder's dimension to `SqliteVecAdapter`


### PR DESCRIPTION
## Summary

- Add `no_global_config` pytest fixture to mock `get_global_config_path()` in config provider tests
- Apply fixture to 6 tests that were vulnerable to leaking from user's actual global config
- Remove duplicate inline mocking in favor of the shared fixture

Fixes #254

## Test plan

- [x] All 11 config provider tests pass
- [x] Full test suite passes (767 passed)
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)