### PR TITLE
feat: detect embedding model mismatch early with clear error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Existing projects continue to work (full project configs still override everything)
 
 ### Fixed
+- **Dimension mismatch after model change now detected early** (#247)
+  - `ember sync` now fails fast with clear error when embedding model differs from index
+  - Run `ember sync --force` to rebuild index with the new model
+  - `DimensionMismatchError` provides helpful message if search is attempted with wrong model
+  - Prevents cryptic sqlite-vec errors when model dimensions don't match
+
 - **Test isolation: global config no longer leaks into unit tests** (#254)
   - Config provider tests now mock `get_global_config_path()` to prevent user's `~/.config/ember/config.toml` from affecting test results
   - Added `no_global_config` fixture for consistent test isolation

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -12,6 +12,7 @@ import blake3
 import click
 
 from ember.adapters.fs.local import LocalFileSystem
+from ember.adapters.vss.sqlite_vec_adapter import DimensionMismatchError
 from ember.core.cli_utils import (
     EmberCliError,
     display_content_with_context,
@@ -26,6 +27,7 @@ from ember.core.cli_utils import (
     repo_not_found_error,
     validate_result_index,
 )
+from ember.core.indexing.index_usecase import ModelMismatchError
 from ember.core.presentation import ResultPresenter
 
 
@@ -51,6 +53,18 @@ def handle_cli_errors(command_name: str):
             except EmberCliError:
                 # Let EmberCliError propagate to use its format_message()
                 raise
+            except ModelMismatchError as e:
+                # Embedding model changed - clear action required
+                raise EmberCliError(
+                    str(e),
+                    hint="The embedding model in your config differs from the one used to build the index.",
+                ) from e
+            except DimensionMismatchError as e:
+                # Vector dimension mismatch - clear action required
+                raise EmberCliError(
+                    str(e),
+                    hint="The embedding model in your config differs from the one used to build the index.",
+                ) from e
             except RuntimeError as e:
                 # Convert RuntimeError to EmberCliError with generic hint
                 raise EmberCliError(


### PR DESCRIPTION
## Summary

- Add `ModelMismatchError` that's raised when sync detects a model change without `--force`
- Add `DimensionMismatchError` that catches sqlite-vec dimension errors and provides helpful message
- Update CLI error handler to display clear, actionable messages for both errors

**Before:** Users saw cryptic errors like "Dimension mismatch for ... Expected 768 dimensions but received 384"

**After:** Users see "Embedding model changed: jina-code-v2 → minilm. Run 'ember sync --force' to rebuild the index."

Fixes #247

## Test plan

- [x] Model mismatch on sync without --force raises ModelMismatchError
- [x] Model mismatch on sync with --force proceeds normally
- [x] Dimension mismatch in search raises DimensionMismatchError with helpful message
- [x] All 773 tests pass
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)