### PR TITLE
fix: add error handling for critical operations in _index_file()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Error handling for critical operations in `_index_file()`** (#262)
+  - Embedding failures now roll back any chunks added during that file's indexing
+  - Embedding count is validated to match chunk count before storing vectors
+  - `vector_repo.add()` failures trigger cleanup of partially stored data
+  - `chunk_repo.delete_all_for_path()` failures are caught and logged
+  - `chunk_repo.add()` failures are handled with proper rollback
+  - `file_repo.track_file()` failures don't fail the overall indexing (non-critical)
+  - Detailed error logging for debugging partial failures
+  - Index state remains consistent even when individual file indexing fails
+
 ### Added
 - **GPU VRAM detection for smarter model recommendations** (#248)
   - `ember init` now detects GPU (CUDA/MPS) and available VRAM


### PR DESCRIPTION
## Summary

- Add comprehensive error handling to `_index_file()` to prevent index inconsistency
- Implement rollback mechanism for chunks when embedding or storage operations fail
- Validate embedding count matches chunk count before storing vectors
- Make file tracking failures non-fatal (metadata only)

Fixes #262

## Changes

- Wrap `chunk_repo.delete_all_for_path()` in try/except block
- Add try/except around chunk storage and embedding operations
- Track added chunk IDs for rollback on failure
- Validate `len(embeddings) == len(chunks)` before storing vectors
- Rollback chunks on any failure during storage/embedding
- Make `file_repo.track_file()` failures non-fatal with warning log
- Add 7 new unit tests covering error scenarios

## Test plan

- [x] Run new unit tests: `pytest tests/unit/core/test_indexing_usecase.py::TestIndexFileErrorHandling -v`
- [x] Run full test suite: `pytest` (795 passed, 2 skipped)
- [x] Run linter: `ruff check .` (all checks passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)