### PR TITLE
refactor: reduce config_show() cyclomatic complexity from 21 to 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Refactored `config_show()` to reduce cyclomatic complexity** (#259)
+  - Reduced cyclomatic complexity from 21 to 5 (now grade A)
+  - Extracted helper functions: `_display_path_status()`, `_load_and_display_config()`, `_get_local_config_path()`, `_display_local_config_info()`, `_show_effective_config()`
+  - Removed tautological condition that was always true
+  - Simplified flag logic with clearer include_global/include_local variables
+  - Improved code readability and maintainability
+  - Added 8 new tests to ensure behavior preservation
+
 - **IndexConfig no longer imports from adapters layer** (#264)
   - Model name validation moved from domain model to config loading boundary
   - Fixes clean architecture violation where domain layer imported from adapters

--- a/tests/unit/test_config_commands.py
+++ b/tests/unit/test_config_commands.py
@@ -41,6 +41,170 @@ class TestConfigShow:
         assert result.exit_code == 0
         assert "Not in an Ember repository" in result.output
 
+    def test_show_both_default(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Test showing both configs by default."""
+        ember_dir = tmp_path / ".ember"
+        ember_dir.mkdir()
+        global_config = tmp_path / "global_config.toml"
+
+        with patch(
+            "ember.shared.config_io.get_global_config_path",
+            return_value=global_config,
+        ), patch(
+            "ember.entrypoints.cli.get_ember_repo_root",
+            return_value=(tmp_path, ember_dir),
+        ):
+            result = runner.invoke(cli, ["config", "show"], obj={})
+
+        assert result.exit_code == 0
+        assert "Global config:" in result.output
+        assert "Local config:" in result.output
+
+    def test_show_global_exists_status(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Test that global config shows 'exists' status when file exists."""
+        global_config = tmp_path / "config.toml"
+        global_config.write_text("[index]\nmodel = 'test'\n")
+
+        with patch(
+            "ember.shared.config_io.get_global_config_path",
+            return_value=global_config,
+        ), patch(
+            "ember.entrypoints.cli.get_ember_repo_root",
+            side_effect=RuntimeError("Not in repo"),
+        ):
+            result = runner.invoke(cli, ["config", "show", "--global"], obj={})
+
+        assert result.exit_code == 0
+        assert "exists" in result.output
+
+    def test_show_global_not_created_status(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Test that global config shows 'not created' status when file doesn't exist."""
+        global_config = tmp_path / "nonexistent.toml"
+
+        with patch(
+            "ember.shared.config_io.get_global_config_path",
+            return_value=global_config,
+        ), patch(
+            "ember.entrypoints.cli.get_ember_repo_root",
+            side_effect=RuntimeError("Not in repo"),
+        ):
+            result = runner.invoke(cli, ["config", "show", "--global"], obj={})
+
+        assert result.exit_code == 0
+        assert "not created" in result.output
+
+    def test_show_local_exists_status(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Test that local config shows 'exists' status when file exists."""
+        ember_dir = tmp_path / ".ember"
+        ember_dir.mkdir()
+        local_config = ember_dir / "config.toml"
+        local_config.write_text("[index]\nmodel = 'test'\n")
+        global_config = tmp_path / "global.toml"
+
+        with patch(
+            "ember.shared.config_io.get_global_config_path",
+            return_value=global_config,
+        ), patch(
+            "ember.entrypoints.cli.get_ember_repo_root",
+            return_value=(tmp_path, ember_dir),
+        ):
+            result = runner.invoke(cli, ["config", "show", "--local"], obj={})
+
+        assert result.exit_code == 0
+        assert "exists" in result.output
+
+    def test_show_local_not_created_status(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Test that local config shows 'not created' status when file doesn't exist."""
+        ember_dir = tmp_path / ".ember"
+        ember_dir.mkdir()
+        global_config = tmp_path / "global.toml"
+
+        with patch(
+            "ember.shared.config_io.get_global_config_path",
+            return_value=global_config,
+        ), patch(
+            "ember.entrypoints.cli.get_ember_repo_root",
+            return_value=(tmp_path, ember_dir),
+        ):
+            result = runner.invoke(cli, ["config", "show", "--local"], obj={})
+
+        assert result.exit_code == 0
+        assert "not created" in result.output
+
+    def test_show_effective_config_in_repo(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Test that effective merged config is shown when in a repo."""
+        from ember.domain.config import EmberConfig
+
+        ember_dir = tmp_path / ".ember"
+        ember_dir.mkdir()
+        global_config = tmp_path / "global.toml"
+
+        mock_config = EmberConfig.default()
+
+        with patch(
+            "ember.shared.config_io.get_global_config_path",
+            return_value=global_config,
+        ), patch(
+            "ember.entrypoints.cli.get_ember_repo_root",
+            return_value=(tmp_path, ember_dir),
+        ), patch(
+            "ember.adapters.config.toml_config_provider.TomlConfigProvider.load",
+            return_value=mock_config,
+        ):
+            result = runner.invoke(cli, ["config", "show"], obj={})
+
+        assert result.exit_code == 0
+        assert "Effective configuration" in result.output
+        assert "[index]" in result.output
+        assert "[model]" in result.output
+        assert "[search]" in result.output
+        assert "[display]" in result.output
+
+    def test_show_global_config_content(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Test that global config content is shown when --global and file exists."""
+        from ember.domain.config import EmberConfig
+
+        global_config = tmp_path / "config.toml"
+        global_config.write_text("[index]\nmodel = 'test'\n")
+
+        mock_config = EmberConfig.default()
+
+        with patch(
+            "ember.shared.config_io.get_global_config_path",
+            return_value=global_config,
+        ), patch(
+            "ember.entrypoints.cli.get_ember_repo_root",
+            side_effect=RuntimeError("Not in repo"),
+        ), patch(
+            "ember.shared.config_io.load_config",
+            return_value=mock_config,
+        ):
+            result = runner.invoke(cli, ["config", "show", "--global"], obj={})
+
+        assert result.exit_code == 0
+        assert "Global configuration:" in result.output
+
+    def test_show_config_load_error(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Test that config load errors are displayed gracefully."""
+        ember_dir = tmp_path / ".ember"
+        ember_dir.mkdir()
+        global_config = tmp_path / "global.toml"
+
+        with patch(
+            "ember.shared.config_io.get_global_config_path",
+            return_value=global_config,
+        ), patch(
+            "ember.entrypoints.cli.get_ember_repo_root",
+            return_value=(tmp_path, ember_dir),
+        ), patch(
+            "ember.adapters.config.toml_config_provider.TomlConfigProvider.load",
+            side_effect=ValueError("Invalid config format"),
+        ):
+            result = runner.invoke(cli, ["config", "show"], obj={})
+
+        assert result.exit_code == 0
+        assert "Error loading config" in result.output
+
 
 class TestConfigPath:
     """Tests for 'ember config path' command."""


### PR DESCRIPTION
## Summary

- Reduced `config_show()` cyclomatic complexity from **21 to 5** (now grade A)
- Extracted 5 helper functions for improved readability
- Removed tautological condition that was always true
- Simplified flag logic with clearer variable names
- Added 8 new tests (10 total) to ensure behavior preservation

Implements #259

## Changes

### Helper Functions Extracted

| Function | Complexity | Purpose |
|----------|------------|---------|
| `_display_path_status()` | A (3) | Display config path with existence status |
| `_load_and_display_config()` | A (2) | Load and display config with error handling |
| `_get_local_config_path()` | A (2) | Get local config path or None if not in repo |
| `_display_local_config_info()` | A (3) | Display local config path and status |
| `_show_effective_config()` | B (6) | Show effective configuration content |
| `config_show()` | **A (5)** | Main function (was C (21)) |

### Flag Logic Simplification

Before:
```python
show_both = not show_global and not show_local
if show_global or show_both:
    ...
if show_local or show_both:
    ...
if show_both or show_local or show_global:  # Always true!
    ...
```

After:
```python
include_global = show_global or not show_local
include_local = show_local or not show_global
if include_global:
    ...
if include_local:
    ...
```

## Test Plan

- [x] All 10 `TestConfigShow` tests pass
- [x] All 813 tests pass
- [x] Ruff linter passes
- [x] Complexity verified with radon: `config_show` now A (5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)