### PR TITLE
fix: surface missing chunks to users instead of silently degrading (#265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Model validation still happens at config load time (same user experience)
 
 ### Fixed
+- **SearchUseCase now surfaces missing chunks to users** (#265)
+  - Added `SearchResultSet` dataclass wrapping results with metadata
+  - CLI displays yellow warning when chunks are missing due to index corruption
+  - `is_degraded` property indicates when results are degraded
+  - Added 6 new unit tests for `SearchResultSet` behavior
+  - Backward compatible: `SearchResultSet` supports iteration and `len()`
+
 - **Error handling for critical operations in `_index_file()`** (#262)
   - Embedding failures now roll back any chunks added during that file's indexing
   - Embedding count is validated to match chunk count before storing vectors

--- a/ember/domain/entities.py
+++ b/ember/domain/entities.py
@@ -173,3 +173,36 @@ class SearchResult:
         if len(lines) > max_lines:
             preview_lines.append("...")
         return "\n".join(preview_lines)
+
+
+@dataclass
+class SearchResultSet:
+    """Collection of search results with metadata.
+
+    Wraps search results with information about retrieval quality,
+    particularly for detecting index degradation when chunks are missing.
+
+    Attributes:
+        results: List of search results.
+        requested_count: Number of results originally requested.
+        missing_chunks: Number of chunks that couldn't be retrieved.
+        warning: User-facing warning message if results are degraded.
+    """
+
+    results: list[SearchResult]
+    requested_count: int = 0
+    missing_chunks: int = 0
+    warning: str | None = None
+
+    @property
+    def is_degraded(self) -> bool:
+        """Check if results are degraded due to missing chunks."""
+        return self.missing_chunks > 0
+
+    def __iter__(self):
+        """Allow iteration over results for backward compatibility."""
+        return iter(self.results)
+
+    def __len__(self) -> int:
+        """Return number of results for backward compatibility."""
+        return len(self.results)

--- a/tests/integration/test_search_usecase.py
+++ b/tests/integration/test_search_usecase.py
@@ -589,12 +589,13 @@ def test_missing_chunks_logged(db_path: Path, caplog: pytest.LogCaptureFixture) 
 
     # Enable logging capture at WARNING level
     with caplog.at_level(logging.WARNING):
-        chunks = use_case._retrieve_chunks(chunk_ids)
+        result = use_case._retrieve_chunks(chunk_ids)
 
     # Should return only the 2 found chunks
-    assert len(chunks) == 2
-    assert chunks[0].id == "chunk_1"
-    assert chunks[1].id == "chunk_2"
+    assert len(result.chunks) == 2
+    assert result.chunks[0].id == "chunk_1"
+    assert result.chunks[1].id == "chunk_2"
+    assert result.missing_count == 3
 
     # Should have logged a warning about missing chunks
     assert len(caplog.records) == 1


### PR DESCRIPTION
## Summary

- Added `SearchResultSet` dataclass to wrap search results with metadata about missing chunks
- CLI now displays yellow warning when results are degraded due to missing chunks
- Index corruption is surfaced to users instead of being silently hidden

## Changes

**New domain entity:**
- `SearchResultSet` with `results`, `requested_count`, `missing_chunks`, `warning`
- `is_degraded` property to check if results are degraded
- Implements `__iter__` and `__len__` for backward compatibility

**SearchUseCase updates:**
- `_retrieve_chunks()` now returns `_RetrievalResult` with chunks and missing count
- `search()` returns `SearchResultSet` instead of `list[SearchResult]`
- Warning message generated when chunks are missing

**CLI updates:**
- Displays yellow warning to stderr when `result_set.warning` is set
- Interactive search wrapper extracts `results` list for TUI compatibility

## Test plan

- [x] 6 new unit tests for `SearchResultSet`
- [x] Updated integration test for `_retrieve_chunks()`
- [x] All 868 tests passing
- [x] Linter passes

Implements #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)