### PR TITLE
refactor: deduplicate path handling logic between find() and search() (#266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Deduplicated path handling logic between `find()` and `search()` commands** (#266)
+  - Extracted `normalize_path_filter()` function to `ember/core/cli_utils.py`
+  - Single source of truth for PATH argument to glob pattern conversion
+  - Single source of truth for PATH/--in mutual exclusivity check
+  - Both commands now use identical path normalization logic
+  - Added 9 unit tests for the new function
+
 - **Refactored `DaemonLifecycle.stop()` to reduce cyclomatic complexity** (#263)
   - Reduced cyclomatic complexity from 11 to 5 (target: ≤10)
   - Extracted helper methods: `_reap_zombie()`, `_wait_for_death()`, `_send_signal_and_wait()`, `_stop_with_sigterm()`, `_stop_with_sigkill()`

--- a/ember/core/cli_utils.py
+++ b/ember/core/cli_utils.py
@@ -31,7 +31,8 @@ __all__ = ["RichProgressCallback", "progress_context", "load_cached_results",
            "display_content_with_highlighting", "open_file_in_editor",
            "get_editor_command", "EDITOR_PATTERNS", "EmberCliError",
            "repo_not_found_error", "no_search_results_error",
-           "path_not_in_repo_error", "index_out_of_range_error"]
+           "path_not_in_repo_error", "index_out_of_range_error",
+           "normalize_path_filter"]
 
 
 # =============================================================================
@@ -136,6 +137,61 @@ def index_out_of_range_error(index: int, max_index: int) -> NoReturn:
         f"Index {index} out of range (valid: 1-{max_index})",
         hint="Run 'ember find <query>' to see available results",
     )
+
+
+# =============================================================================
+# Path Normalization
+# =============================================================================
+
+
+def normalize_path_filter(
+    path: str | None,
+    existing_filter: str | None,
+    repo_root: Path,
+    cwd: Path,
+) -> str | None:
+    """Normalize path argument and existing filter into a unified path filter.
+
+    Handles conversion of PATH argument to repo-relative glob pattern, checks
+    for mutual exclusivity with existing filter, and validates path is within
+    repository.
+
+    Args:
+        path: Optional PATH argument from CLI (relative to cwd or absolute).
+        existing_filter: Optional existing --in filter pattern.
+        repo_root: Repository root directory (absolute path).
+        cwd: Current working directory (absolute path).
+
+    Returns:
+        Normalized path filter glob pattern, or None if no path filtering.
+
+    Raises:
+        EmberCliError: If both path and existing_filter are provided,
+            or if path is outside the repository.
+    """
+    if path is None:
+        return existing_filter
+
+    # Convert path argument to absolute, then to relative from repo root
+    path_abs = (cwd / path).resolve()
+
+    # Check if path is within repo
+    try:
+        path_rel_to_repo = path_abs.relative_to(repo_root)
+    except ValueError:
+        path_not_in_repo_error(path)
+
+    # Check for mutually exclusive filter options
+    if existing_filter:
+        raise EmberCliError(
+            f"Cannot use both PATH argument ('{path}') and --in filter ('{existing_filter}')",
+            hint="Use PATH to search a directory subtree, OR --in for glob patterns, but not both",
+        )
+
+    # Create glob pattern for this path subtree
+    if path_rel_to_repo == Path("."):
+        return "*/**"
+    return f"{path_rel_to_repo}/**"
 
 
 # Editor command patterns for opening files at specific line numbers


### PR DESCRIPTION
## Summary

- Extract `normalize_path_filter()` function to `ember/core/cli_utils.py` centralizing path argument handling
- Refactor `find()` and `search()` commands to use shared function
- Eliminate ~40 lines of duplicated code between commands
- Add 9 unit tests for the new function

## Changes

The `find()` and `search()` commands had nearly identical path handling logic (~40 lines each) for:
1. Converting PATH argument to repo-relative glob pattern
2. Checking mutual exclusivity with --in filter
3. Validating path is within repository

This duplication meant:
- Bug fixes had to be applied in two places
- Risk of divergent behavior if one was updated without the other
- Different parameter names (`path_filter` vs `file_pattern`)

Now both commands use `normalize_path_filter()` which provides:
- Single source of truth for PATH → glob conversion
- Consistent error messages and hints
- Unified parameter handling

Implements #266

## Test Plan

- [x] All 877 existing tests pass
- [x] 9 new unit tests for `normalize_path_filter()`
- [x] Integration tests for mutual exclusivity continue to pass
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)