### PR TITLE
refactor: deduplicate editor command lookup across CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Deduplicated editor command lookup across CLI** (#268)
+  - Created `get_editor()` function in `ember/core/cli_utils.py`
+  - Single source of truth for `$VISUAL > $EDITOR > vim` fallback logic
+  - Fixed inconsistent fallback (was "vi" in `config edit`, now consistently "vim")
+  - Added 5 unit tests for the new function
+
 ### Performance
 - **Cache tree-sitter Query objects per language instead of compiling per file** (#269)
   - Query compilation is expensive; for 1000 Python files we were compiling the same query 1000 times

--- a/ember/core/cli_utils.py
+++ b/ember/core/cli_utils.py
@@ -29,7 +29,7 @@ __all__ = ["RichProgressCallback", "progress_context", "load_cached_results",
            "ensure_daemon_with_progress", "lookup_result_from_cache",
            "lookup_result_by_hash", "display_content_with_context",
            "display_content_with_highlighting", "open_file_in_editor",
-           "get_editor_command", "EDITOR_PATTERNS", "EmberCliError",
+           "get_editor", "get_editor_command", "EDITOR_PATTERNS", "EmberCliError",
            "repo_not_found_error", "no_search_results_error",
            "path_not_in_repo_error", "index_out_of_range_error",
            "normalize_path_filter"]
@@ -194,6 +194,24 @@ def normalize_path_filter(
     return f"{path_rel_to_repo}/**"
 
 
+def get_editor() -> str:
+    """Get the user's preferred editor command.
+
+    Checks environment variables in order of preference:
+    1. $VISUAL - for visual/graphical editors
+    2. $EDITOR - for terminal editors
+    3. 'vim' - default fallback
+
+    Returns:
+        The editor command string to use.
+
+    Example:
+        >>> editor = get_editor()
+        >>> print(f"Opening in {editor}...")
+    """
+    return os.environ.get("VISUAL") or os.environ.get("EDITOR") or "vim"
+
+
 # Editor command patterns for opening files at specific line numbers
 EDITOR_PATTERNS = {
     # Editors that use +line syntax (vim, emacs, nano)
@@ -256,7 +274,7 @@ def open_file_in_editor(file_path: Path, line_num: int) -> None:
         raise click.ClickException(f"File not found: {file_path}")
 
     # Determine editor (priority: $VISUAL > $EDITOR > vim)
-    editor = os.environ.get("VISUAL") or os.environ.get("EDITOR") or "vim"
+    editor = get_editor()
 
     # Check editor is available
     if not shutil.which(editor):

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -18,6 +18,7 @@ from ember.core.cli_utils import (
     display_content_with_context,
     display_content_with_highlighting,
     format_result_header,
+    get_editor,
     load_cached_results,
     lookup_result_by_hash,
     lookup_result_from_cache,
@@ -1061,8 +1062,6 @@ def open_result(ctx: click.Context, index: int) -> None:
     Opens file at the correct line in $EDITOR.
     Can be run from any subdirectory within the repository.
     """
-    import os
-
     repo_root, ember_dir = get_ember_repo_root()
     cache_path = ember_dir / ".last_search.json"
 
@@ -1079,8 +1078,7 @@ def open_result(ctx: click.Context, index: int) -> None:
 
     # Show what we're doing (if not quiet)
     if not ctx.obj.get("quiet", False):
-        editor = os.environ.get("VISUAL") or os.environ.get("EDITOR") or "vim"
-        click.echo(f"Opening in {editor}:")
+        click.echo(f"Opening in {get_editor()}:")
         format_result_header(result, index, show_symbol=True)
 
     # Open in editor
@@ -1343,7 +1341,6 @@ def config_edit(ctx: click.Context, edit_global: bool) -> None:
     Opens the local config by default. Use --global to edit global config.
     Creates the config file if it doesn't exist.
     """
-    import os
     import subprocess
 
     from ember.shared.config_io import (
@@ -1376,7 +1373,7 @@ def config_edit(ctx: click.Context, edit_global: bool) -> None:
             create_minimal_project_config(config_path)
 
     # Open in editor
-    editor = os.environ.get("VISUAL") or os.environ.get("EDITOR") or "vi"
+    editor = get_editor()
     click.echo(f"Opening {config_path} in {editor}...")
     try:
         subprocess.run([editor, str(config_path)], check=True)

--- a/tests/unit/core/test_cli_utils.py
+++ b/tests/unit/core/test_cli_utils.py
@@ -272,6 +272,63 @@ class TestDisplayContentWithHighlighting:
         display_content_with_highlighting(result, mock_config)
 
 
+class TestGetEditor:
+    """Tests for get_editor function."""
+
+    def test_returns_visual_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Should return $VISUAL when set."""
+        from ember.core.cli_utils import get_editor
+
+        monkeypatch.setenv("VISUAL", "code")
+        monkeypatch.setenv("EDITOR", "vim")
+
+        assert get_editor() == "code"
+
+    def test_returns_editor_when_visual_not_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Should return $EDITOR when $VISUAL is not set."""
+        from ember.core.cli_utils import get_editor
+
+        monkeypatch.delenv("VISUAL", raising=False)
+        monkeypatch.setenv("EDITOR", "nano")
+
+        assert get_editor() == "nano"
+
+    def test_returns_vim_when_no_env_vars_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Should return 'vim' as default when no env vars are set."""
+        from ember.core.cli_utils import get_editor
+
+        monkeypatch.delenv("VISUAL", raising=False)
+        monkeypatch.delenv("EDITOR", raising=False)
+
+        assert get_editor() == "vim"
+
+    def test_returns_empty_visual_falls_through_to_editor(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Should return $EDITOR when $VISUAL is empty string."""
+        from ember.core.cli_utils import get_editor
+
+        monkeypatch.setenv("VISUAL", "")
+        monkeypatch.setenv("EDITOR", "emacs")
+
+        assert get_editor() == "emacs"
+
+    def test_returns_empty_editor_falls_through_to_vim(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Should return 'vim' when both env vars are empty."""
+        from ember.core.cli_utils import get_editor
+
+        monkeypatch.setenv("VISUAL", "")
+        monkeypatch.setenv("EDITOR", "")
+
+        assert get_editor() == "vim"
+
+
 class TestOpenFileInEditor:
     """Tests for open_file_in_editor function."""
 


### PR DESCRIPTION
## Summary
- Created `get_editor()` function in `ember/core/cli_utils.py` as single source of truth for editor lookup
- Fixed inconsistent fallback: was "vi" in `config edit`, now consistently "vim" everywhere
- Replaced 3 duplicate `os.environ.get("VISUAL") or os.environ.get("EDITOR") or "vim"` patterns

## Changes
- Added `get_editor()` function to `cli_utils.py` with proper docstring
- Refactored `open_file_in_editor()` to use `get_editor()`
- Updated `open_result` command to use `get_editor()`
- Updated `config edit` command to use `get_editor()`
- Removed unused `import os` from two CLI functions
- Added 5 unit tests for `get_editor()`

## Test plan
- [x] All 887 tests pass
- [x] Ruff linter passes
- [x] New tests cover: $VISUAL priority, $EDITOR fallback, vim default, empty string handling

Implements #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)