### PR TITLE
test: use specific exception types in test assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Use specific exception types in test assertions** (#270)
+  - `tests/integration/test_search_usecase.py`: Changed `pytest.raises((sqlite3.OperationalError, Exception))` to `pytest.raises(ValueError)` for empty query test
+  - `tests/integration/test_search_usecase.py`: Removed `except Exception: pass` block that hid FTS5 query failures; uncovered that hyphenated queries fail (documented as FTS5 limitation)
+  - `tests/unit/test_config_provider.py`: Changed loose OR assertion to specific `"Invalid TOML"` check
+  - `tests/unit/adapters/test_global_config.py`: Changed loose OR assertion to specific `"Failed to parse global config"` check
+  - `tests/conftest.py`: Changed `except Exception` to `except (ValueError, AttributeError, TypeError)` for URL validation utility
+  - Improves test reliability by catching bugs instead of masking them
+
 - **Deduplicated editor command lookup across CLI** (#268)
   - Created `get_editor()` function in `ember/core/cli_utils.py`
   - Single source of truth for `$VISUAL > $EDITOR > vim` fallback logic

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1439,7 +1439,7 @@ def is_valid_url(url: str) -> bool:
     try:
         result = urlparse(url)
         return all([result.scheme, result.netloc])
-    except Exception:
+    except (ValueError, AttributeError, TypeError):
         return False
 
 

--- a/tests/unit/adapters/test_global_config.py
+++ b/tests/unit/adapters/test_global_config.py
@@ -218,7 +218,7 @@ syntax_highlighting = false
         default = EmberConfig.default()
         assert result == default
         # Should log warning about global config
-        assert "global" in caplog.text.lower() or "Failed" in caplog.text
+        assert "Failed to parse global config" in caplog.text
 
     def test_array_fields_merge_correctly(
         self, provider: TomlConfigProvider, tmp_path: Path

--- a/tests/unit/test_config_provider.py
+++ b/tests/unit/test_config_provider.py
@@ -112,7 +112,7 @@ def test_load_config_invalid_toml_logs_warning(caplog):
         assert len(caplog.records) == 1
         assert caplog.records[0].levelname == "WARNING"
         assert "config.toml" in caplog.text
-        assert "Invalid TOML" in caplog.text or "parse" in caplog.text.lower()
+        assert "Invalid TOML" in caplog.text
 
 
 def test_load_config_missing_file_no_warning(caplog):


### PR DESCRIPTION
## Summary
- Changed `pytest.raises((sqlite3.OperationalError, Exception))` to `pytest.raises(ValueError)` for empty query test since Query entity validates and rejects empty text
- Removed `except Exception: pass` block that silently swallowed query failures; uncovered that hyphenated queries fail in FTS5 (documented as limitation)
- Changed loose OR assertions to specific message checks for config parse errors
- Changed `conftest.py` `is_valid_url()` to catch specific exceptions instead of broad Exception

Implements #270

## Test plan
- [x] All tests pass (`uv run pytest` - 887 passed)
- [x] Linter passes (`uv run ruff check .`)
- [x] Verified empty query test correctly catches ValueError
- [x] Verified special character test works with valid FTS5 queries
- [x] Verified config tests correctly check for specific error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)