### PR TITLE
refactor: add validation and domain behavior to RepoState (#271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **RepoState validation and domain behavior** (#271)
+  - Added `SyncMode` enum for type-safe sync mode values (`none`, `worktree`, `staged`)
+  - Added validation in `RepoState.__post_init__()`:
+    - `last_tree_sha` must be empty or a valid 40-character hex SHA
+    - `last_sync_mode` must be a `SyncMode` enum value or a valid commit SHA
+    - `version` cannot be empty
+    - `indexed_at` must be a valid ISO-8601 timestamp
+  - Added helper methods to `RepoState`:
+    - `is_uninitialized`: Check if repository has never been indexed
+    - `is_stale(threshold_seconds)`: Check if index is older than threshold
+    - `needs_model_update(fingerprint)`: Check if embedding model changed
+  - String values for sync mode are automatically converted to `SyncMode` enum
+  - Backward compatible: existing state.json files work without changes
+
 ### Changed
 - **Use specific exception types in test assertions** (#270)
   - `tests/integration/test_search_usecase.py`: Changed `pytest.raises((sqlite3.OperationalError, Exception))` to `pytest.raises(ValueError)` for empty query test

--- a/ember/shared/state_io.py
+++ b/ember/shared/state_io.py
@@ -8,7 +8,7 @@ import json
 from datetime import UTC
 from pathlib import Path
 
-from ember.domain.entities import RepoState
+from ember.domain.entities import RepoState, SyncMode
 
 
 def load_state(path: Path) -> RepoState:
@@ -49,9 +49,14 @@ def save_state(state: RepoState, path: Path) -> None:
         state: RepoState to save
         path: Destination path for state.json
     """
+    # Convert SyncMode enum to string for JSON serialization
+    sync_mode = state.last_sync_mode
+    if isinstance(sync_mode, SyncMode):
+        sync_mode = sync_mode.value
+
     data = {
         "last_tree_sha": state.last_tree_sha,
-        "last_sync_mode": state.last_sync_mode,
+        "last_sync_mode": sync_mode,
         "model_fingerprint": state.model_fingerprint,
         "version": state.version,
         "indexed_at": state.indexed_at,


### PR DESCRIPTION
## Summary

- Added `SyncMode` enum for type-safe sync mode values (`none`, `worktree`, `staged`)
- Added validation in `RepoState.__post_init__()` for all fields
- Added helper methods: `is_uninitialized`, `is_stale()`, `needs_model_update()`
- Updated `state_io.py` to handle `SyncMode` enum serialization
- Backward compatible: existing `state.json` files work without changes

## Test plan

- [x] `SyncMode` enum has correct values and string compatibility
- [x] `SyncMode.is_commit_sha()` correctly identifies SHA patterns
- [x] `RepoState` validation rejects invalid tree_sha format
- [x] `RepoState` validation rejects invalid sync_mode values
- [x] `RepoState` validation rejects empty version
- [x] `RepoState` validation rejects invalid ISO-8601 timestamps
- [x] `RepoState.is_uninitialized` returns correct values
- [x] `RepoState.is_stale()` calculates age correctly
- [x] `RepoState.needs_model_update()` compares fingerprints correctly
- [x] Existing `state.json` files load correctly (backward compat)
- [x] All 910 tests pass
- [x] Linter passes

Implements #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)