### PR TITLE
refactor: deduplicate kwargs building logic in create_embedder()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Deduplicated kwargs building logic in `create_embedder()`** (#272)
+  - Extracted `_build_embedder_kwargs()` helper function to build kwargs dict once
+  - Extracted `_get_embedder_class()` to separate class lookup from instantiation
+  - Reduced cyclomatic complexity from 11 to ~4
+  - Adding new embedding models no longer requires duplicating kwargs logic
+
 ### Added
 - **RepoState validation and domain behavior** (#271)
   - Added `SyncMode` enum for type-safe sync mode values (`none`, `worktree`, `staged`)

--- a/tests/unit/adapters/test_model_registry.py
+++ b/tests/unit/adapters/test_model_registry.py
@@ -8,11 +8,41 @@ from ember.adapters.local_models.registry import (
     DEFAULT_MODEL,
     MODEL_PRESETS,
     SUPPORTED_MODELS,
+    _build_embedder_kwargs,
     create_embedder,
     get_model_info,
     list_available_models,
     resolve_model_name,
 )
+
+
+class TestBuildEmbedderKwargs:
+    """Tests for _build_embedder_kwargs helper function."""
+
+    def test_batch_size_always_included(self):
+        """Test that batch_size is always in kwargs."""
+        result = _build_embedder_kwargs(batch_size=32, device=None, max_seq_length=None)
+        assert result == {"batch_size": 32}
+
+    def test_device_included_when_not_none(self):
+        """Test that device is included when provided."""
+        result = _build_embedder_kwargs(batch_size=32, device="cuda", max_seq_length=None)
+        assert result == {"batch_size": 32, "device": "cuda"}
+
+    def test_max_seq_length_included_when_not_none(self):
+        """Test that max_seq_length is included when provided."""
+        result = _build_embedder_kwargs(batch_size=32, device=None, max_seq_length=512)
+        assert result == {"batch_size": 32, "max_seq_length": 512}
+
+    def test_all_params_included_when_provided(self):
+        """Test that all params are included when provided."""
+        result = _build_embedder_kwargs(batch_size=64, device="mps", max_seq_length=256)
+        assert result == {"batch_size": 64, "device": "mps", "max_seq_length": 256}
+
+    def test_device_cpu(self):
+        """Test that device=cpu works correctly."""
+        result = _build_embedder_kwargs(batch_size=32, device="cpu", max_seq_length=None)
+        assert result == {"batch_size": 32, "device": "cpu"}
 
 
 class TestResolveModelName:


### PR DESCRIPTION
## Summary
- Extracted `_build_embedder_kwargs()` helper function to build kwargs dict once
- Extracted `_get_embedder_class()` to separate class lookup from instantiation  
- Reduced cyclomatic complexity from 11 to ~4
- Adding new embedding models no longer requires duplicating kwargs logic

Implements #272

## Test plan
- [x] All 34 registry tests pass (including 5 new tests for the helper)
- [x] Full test suite passes (915 tests)
- [x] Linter passes
- [x] No behavior changes - same kwargs are passed to embedder constructors

🤖 Generated with [Claude Code](https://claude.com/claude-code)