### PR TITLE
refactor: reduce init() complexity from 16 to 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Reduced `init()` command complexity from 16 to 3** (#290)
+  - Extracted `_select_embedding_model()` helper for model selection logic
+  - Extracted `_display_system_resources()` for system resource output
+  - Extracted `_prompt_for_model_choice()` for user confirmation prompts
+  - Extracted `_report_init_results()` for success/failure reporting
+  - Added 14 unit tests for the extracted helpers
+  - Model selection logic now testable in isolation
+
 - **Split `cli_utils.py` into focused modules** (#289)
   - Created `ember/core/errors.py`: Error classes and factory functions (103 lines)
   - Created `ember/core/path_utils.py`: Path normalization utilities (58 lines)

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -3,13 +3,20 @@
 Command-line interface for Ember code search tool.
 """
 
+from __future__ import annotations
+
 import functools
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import blake3
 import click
+
+if TYPE_CHECKING:
+    from ember.core.config.init_usecase import InitResponse
+    from ember.core.hardware import SystemResources
 
 from ember.adapters.fs.local import LocalFileSystem
 from ember.adapters.vss.sqlite_vec_adapter import DimensionMismatchError
@@ -402,6 +409,124 @@ def cli(ctx: click.Context, verbose: bool, quiet: bool) -> None:
     ctx.obj["quiet"] = quiet
 
 
+def _select_embedding_model(
+    model: str | None,
+    quiet: bool,
+    yes: bool,
+) -> str:
+    """Select embedding model based on user input or system auto-detection.
+
+    Args:
+        model: User-specified model name, or None for auto-detection.
+        quiet: If True, suppress informational output.
+        yes: If True, accept recommended model without prompting.
+
+    Returns:
+        The selected model name.
+    """
+    from ember.core.hardware import (
+        detect_system_resources,
+        get_model_recommendation_reason,
+        recommend_model,
+    )
+
+    if model is not None:
+        return model
+
+    resources = detect_system_resources()
+    recommended = recommend_model(resources)
+    reason = get_model_recommendation_reason(recommended, resources)
+
+    if not quiet:
+        _display_system_resources(resources, recommended, reason)
+
+    if recommended != "jina-code-v2" and not yes:
+        return _prompt_for_model_choice(resources, recommended)
+
+    return recommended
+
+
+def _display_system_resources(
+    resources: SystemResources,
+    recommended: str,
+    reason: str,
+) -> None:
+    """Display detected system resources to user.
+
+    Args:
+        resources: Detected system resources.
+        recommended: Recommended model name.
+        reason: Human-readable reason for recommendation.
+    """
+    click.echo("\nDetecting system resources...")
+    click.echo(f"  Available RAM: {resources.available_ram_gb:.1f}GB")
+    if resources.gpu is not None:
+        gpu = resources.gpu
+        click.echo(
+            f"  GPU: {gpu.device_name} "
+            f"({gpu.total_vram_gb:.1f}GB VRAM, {gpu.free_vram_gb:.1f}GB free)"
+        )
+    click.echo(f"  Recommended model: {recommended}")
+    click.echo(f"  ({reason})")
+    click.echo()
+
+
+def _prompt_for_model_choice(resources: SystemResources, recommended: str) -> str:
+    """Prompt user to choose between recommended model and default.
+
+    Args:
+        resources: Detected system resources.
+        recommended: Recommended model name.
+
+    Returns:
+        The user's chosen model name.
+    """
+    if resources.gpu is not None and resources.gpu.free_vram_gb < resources.available_ram_gb:
+        click.echo(
+            "The default model (jina-code-v2) requires ~1.6GB VRAM and may cause GPU memory issues."
+        )
+    else:
+        click.echo(
+            "The default model (jina-code-v2) requires ~1.6GB RAM and may cause slowdowns."
+        )
+
+    use_recommended = click.confirm(
+        f"Use recommended model ({recommended}) instead?", default=True
+    )
+    return recommended if use_recommended else "jina-code-v2"
+
+
+def _report_init_results(
+    response: InitResponse,
+    selected_model: str,
+    quiet: bool,
+) -> None:
+    """Report init command results to user.
+
+    Args:
+        response: The InitResponse from the use case.
+        selected_model: The model that was selected.
+        quiet: If True, suppress detailed output.
+    """
+    if response.global_config_created and not quiet:
+        click.echo(f"Created global config at {response.global_config_path}")
+        click.echo(f"  ✓ Using model: {selected_model}")
+        click.echo("")
+
+    if response.was_reinitialized:
+        click.echo(f"Reinitialized existing ember index at {response.ember_dir}")
+    else:
+        click.echo(f"Initialized ember index at {response.ember_dir}")
+
+    if not quiet:
+        click.echo(f"  ✓ Created {response.config_path.name}")
+        click.echo(f"  ✓ Created {response.db_path.name}")
+        click.echo(f"  ✓ Created {response.state_path.name}")
+        if not response.global_config_created:
+            click.echo(f"  ✓ Using model: {selected_model} (from global config)")
+        click.echo("\nNext: Run 'ember sync' to index your codebase")
+
+
 @cli.command()
 @click.option(
     "--force",
@@ -432,89 +557,22 @@ def init(ctx: click.Context, force: bool, model: str | None, yes: bool) -> None:
     Detects available system RAM and GPU VRAM and suggests an appropriate
     embedding model. Use --model to override or --yes to accept the recommendation.
     """
-    # Lazy import - only load when init is actually called
     from ember.adapters.sqlite.initializer import SqliteDatabaseInitializer
     from ember.core.config.init_usecase import InitRequest, InitUseCase
-    from ember.core.hardware import (
-        detect_system_resources,
-        get_model_recommendation_reason,
-        recommend_model,
-    )
     from ember.core.repo_utils import find_repo_root_for_init
 
     repo_root = find_repo_root_for_init()
     quiet = ctx.obj.get("quiet", False)
 
-    # Determine which model to use
-    if model is not None:
-        # User explicitly specified a model
-        selected_model = model
-    else:
-        # Auto-detect and suggest
-        resources = detect_system_resources()
-        recommended = recommend_model(resources)
-        reason = get_model_recommendation_reason(recommended, resources)
+    selected_model = _select_embedding_model(model, quiet, yes)
 
-        if not quiet:
-            click.echo("\nDetecting system resources...")
-            click.echo(f"  Available RAM: {resources.available_ram_gb:.1f}GB")
-            if resources.gpu is not None:
-                gpu = resources.gpu
-                click.echo(
-                    f"  GPU: {gpu.device_name} "
-                    f"({gpu.total_vram_gb:.1f}GB VRAM, {gpu.free_vram_gb:.1f}GB free)"
-                )
-            click.echo(f"  Recommended model: {recommended}")
-            click.echo(f"  ({reason})")
-            click.echo()
-
-        # Check if the default (jina) is NOT recommended and we need to prompt
-        if recommended != "jina-code-v2" and not yes:
-            # Determine the limiting factor for the warning message
-            if resources.gpu is not None and resources.gpu.free_vram_gb < resources.available_ram_gb:
-                click.echo(
-                    "The default model (jina-code-v2) requires ~1.6GB VRAM and may cause GPU memory issues."
-                )
-            else:
-                click.echo(
-                    "The default model (jina-code-v2) requires ~1.6GB RAM and may cause slowdowns."
-                )
-            use_recommended = click.confirm(
-                f"Use recommended model ({recommended}) instead?", default=True
-            )
-            selected_model = recommended if use_recommended else "jina-code-v2"
-        else:
-            selected_model = recommended
-
-    # Create use case with injected dependencies
     db_initializer = SqliteDatabaseInitializer()
     use_case = InitUseCase(db_initializer=db_initializer, version="1.2.0")
     request = InitRequest(repo_root=repo_root, force=force, model=selected_model)
 
     try:
         response = use_case.execute(request)
-
-        # Report global config creation first (if this is first run)
-        if response.global_config_created and not quiet:
-            click.echo(f"Created global config at {response.global_config_path}")
-            click.echo(f"  ✓ Using model: {selected_model}")
-            click.echo("")
-
-        # Report success
-        if response.was_reinitialized:
-            click.echo(f"Reinitialized existing ember index at {response.ember_dir}")
-        else:
-            click.echo(f"Initialized ember index at {response.ember_dir}")
-
-        if not quiet:
-            click.echo(f"  ✓ Created {response.config_path.name}")
-            click.echo(f"  ✓ Created {response.db_path.name}")
-            click.echo(f"  ✓ Created {response.state_path.name}")
-            if not response.global_config_created:
-                # Only show model here if we didn't already show it above
-                click.echo(f"  ✓ Using model: {selected_model} (from global config)")
-            click.echo("\nNext: Run 'ember sync' to index your codebase")
-
+        _report_init_results(response, selected_model, quiet)
     except FileExistsError as e:
         raise EmberCliError(
             str(e),
@@ -1229,7 +1287,7 @@ def _display_path_status(path: Path, label: str) -> None:
 
 
 def _load_and_display_config(
-    title: str, loader: "Callable[[], EmberConfig]"  # noqa: F821
+    title: str, loader: Callable[[], EmberConfig]  # noqa: F821
 ) -> None:
     """Load config using the provided loader and display it with a title."""
     click.echo(f"\n{title}:")
@@ -1315,7 +1373,7 @@ def config_show(
     _show_effective_config(local_path, global_path, include_local, include_global)
 
 
-def _display_config_summary(config: "EmberConfig") -> None:  # noqa: F821
+def _display_config_summary(config: EmberConfig) -> None:  # noqa: F821
     """Display a summary of config settings."""
     click.echo("  [index]")
     click.echo(f"    model = {config.index.model}")

--- a/tests/unit/test_init_helpers.py
+++ b/tests/unit/test_init_helpers.py
@@ -1,0 +1,300 @@
+"""Unit tests for init command helper functions.
+
+Tests for _select_embedding_model, _display_system_resources,
+_prompt_for_model_choice, and _report_init_results.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from ember.core.hardware import GPUResources, SystemResources
+
+
+class TestSelectEmbeddingModel:
+    """Tests for _select_embedding_model function."""
+
+    def test_returns_explicit_model_when_provided(self) -> None:
+        """Should return user-specified model without prompting."""
+        from ember.entrypoints.cli import _select_embedding_model
+
+        result = _select_embedding_model(
+            model="minilm",
+            quiet=False,
+            yes=False,
+        )
+
+        assert result == "minilm"
+
+    def test_returns_recommended_model_with_yes_flag(self) -> None:
+        """Should return recommended model when --yes is set."""
+        from ember.entrypoints.cli import _select_embedding_model
+
+        with patch("ember.entrypoints.cli.click.echo"), patch(
+            "ember.core.hardware.detect_system_resources"
+        ) as mock_detect:
+            mock_detect.return_value = SystemResources(
+                available_ram_gb=2.0,
+                total_ram_gb=8.0,
+                gpu=None,
+            )
+
+            result = _select_embedding_model(
+                model=None,
+                quiet=True,
+                yes=True,
+            )
+
+            # 2GB RAM should recommend bge-small
+            assert result == "bge-small"
+
+    def test_returns_jina_when_resources_sufficient_and_quiet(self) -> None:
+        """Should return jina-code-v2 for high-resource systems."""
+        from ember.entrypoints.cli import _select_embedding_model
+
+        with patch(
+            "ember.core.hardware.detect_system_resources"
+        ) as mock_detect:
+            mock_detect.return_value = SystemResources(
+                available_ram_gb=8.0,
+                total_ram_gb=16.0,
+                gpu=None,
+            )
+
+            result = _select_embedding_model(
+                model=None,
+                quiet=True,
+                yes=False,
+            )
+
+            assert result == "jina-code-v2"
+
+    def test_prompts_user_when_resources_limited(self) -> None:
+        """Should prompt user when resources don't support jina."""
+        from ember.entrypoints.cli import _select_embedding_model
+
+        with (
+            patch("ember.entrypoints.cli.click.echo"),
+            patch("ember.entrypoints.cli.click.confirm") as mock_confirm,
+            patch("ember.core.hardware.detect_system_resources") as mock_detect,
+        ):
+            mock_confirm.return_value = True
+            mock_detect.return_value = SystemResources(
+                available_ram_gb=2.0,
+                total_ram_gb=8.0,
+                gpu=None,
+            )
+
+            result = _select_embedding_model(
+                model=None,
+                quiet=True,  # quiet to skip display
+                yes=False,
+            )
+
+            # User accepted recommended model
+            assert result == "bge-small"
+            mock_confirm.assert_called_once()
+
+
+class TestDisplaySystemResources:
+    """Tests for _display_system_resources function."""
+
+    def test_displays_ram_info(self) -> None:
+        """Should display available RAM."""
+        from ember.entrypoints.cli import _display_system_resources
+
+        resources = SystemResources(
+            available_ram_gb=4.5,
+            total_ram_gb=16.0,
+            gpu=None,
+        )
+
+        with patch("ember.entrypoints.cli.click.echo") as mock_echo:
+            _display_system_resources(resources, "jina-code-v2", "reason text")
+
+            # Verify RAM was displayed
+            calls = [str(call) for call in mock_echo.call_args_list]
+            assert any("4.5GB" in call for call in calls)
+            assert any("jina-code-v2" in call for call in calls)
+            assert any("reason text" in call for call in calls)
+
+    def test_displays_gpu_info_when_present(self) -> None:
+        """Should display GPU info when available."""
+        from ember.entrypoints.cli import _display_system_resources
+
+        resources = SystemResources(
+            available_ram_gb=8.0,
+            total_ram_gb=16.0,
+            gpu=GPUResources(
+                device_name="NVIDIA RTX 4090",
+                total_vram_gb=24.0,
+                free_vram_gb=20.5,
+                backend="cuda",
+            ),
+        )
+
+        with patch("ember.entrypoints.cli.click.echo") as mock_echo:
+            _display_system_resources(resources, "jina-code-v2", "reason")
+
+            calls = [str(call) for call in mock_echo.call_args_list]
+            assert any("NVIDIA RTX 4090" in call for call in calls)
+            assert any("24.0GB" in call for call in calls)
+            assert any("20.5GB" in call for call in calls)
+
+
+class TestPromptForModelChoice:
+    """Tests for _prompt_for_model_choice function."""
+
+    def test_returns_recommended_when_user_accepts(self) -> None:
+        """Should return recommended model when user confirms."""
+        from ember.entrypoints.cli import _prompt_for_model_choice
+
+        resources = SystemResources(
+            available_ram_gb=2.0,
+            total_ram_gb=8.0,
+            gpu=None,
+        )
+
+        with (
+            patch("ember.entrypoints.cli.click.echo"),
+            patch("ember.entrypoints.cli.click.confirm") as mock_confirm,
+        ):
+            mock_confirm.return_value = True
+            result = _prompt_for_model_choice(resources, "bge-small")
+            assert result == "bge-small"
+
+    def test_returns_jina_when_user_declines(self) -> None:
+        """Should return jina-code-v2 when user declines recommendation."""
+        from ember.entrypoints.cli import _prompt_for_model_choice
+
+        resources = SystemResources(
+            available_ram_gb=2.0,
+            total_ram_gb=8.0,
+            gpu=None,
+        )
+
+        with (
+            patch("ember.entrypoints.cli.click.echo"),
+            patch("ember.entrypoints.cli.click.confirm") as mock_confirm,
+        ):
+            mock_confirm.return_value = False
+            result = _prompt_for_model_choice(resources, "bge-small")
+            assert result == "jina-code-v2"
+
+    def test_shows_vram_warning_when_gpu_limited(self) -> None:
+        """Should show VRAM warning when GPU memory is the limiting factor."""
+        from ember.entrypoints.cli import _prompt_for_model_choice
+
+        resources = SystemResources(
+            available_ram_gb=16.0,  # Plenty of RAM
+            total_ram_gb=32.0,
+            gpu=GPUResources(
+                device_name="Low VRAM GPU",
+                total_vram_gb=4.0,
+                free_vram_gb=1.5,  # But low VRAM
+                backend="cuda",
+            ),
+        )
+
+        with (
+            patch("ember.entrypoints.cli.click.echo") as mock_echo,
+            patch("ember.entrypoints.cli.click.confirm"),
+        ):
+            _prompt_for_model_choice(resources, "bge-small")
+            calls = [str(call) for call in mock_echo.call_args_list]
+            assert any("VRAM" in call for call in calls)
+
+    def test_shows_ram_warning_when_ram_limited(self) -> None:
+        """Should show RAM warning when system memory is the limiting factor."""
+        from ember.entrypoints.cli import _prompt_for_model_choice
+
+        resources = SystemResources(
+            available_ram_gb=2.0,  # Low RAM
+            total_ram_gb=8.0,
+            gpu=None,
+        )
+
+        with (
+            patch("ember.entrypoints.cli.click.echo") as mock_echo,
+            patch("ember.entrypoints.cli.click.confirm"),
+        ):
+            _prompt_for_model_choice(resources, "bge-small")
+            calls = [str(call) for call in mock_echo.call_args_list]
+            assert any("RAM" in call for call in calls)
+
+
+class TestReportInitResults:
+    """Tests for _report_init_results function."""
+
+    def test_reports_new_init(self) -> None:
+        """Should report successful new initialization."""
+        from ember.entrypoints.cli import _report_init_results
+
+        response = MagicMock()
+        response.global_config_created = False
+        response.was_reinitialized = False
+        response.ember_dir = Path("/tmp/repo/.ember")
+        response.config_path = MagicMock(name="config.toml")
+        response.db_path = MagicMock(name="index.db")
+        response.state_path = MagicMock(name="state.json")
+
+        with patch("ember.entrypoints.cli.click.echo") as mock_echo:
+            _report_init_results(response, "jina-code-v2", quiet=False)
+
+            calls = [str(call) for call in mock_echo.call_args_list]
+            assert any("Initialized" in call for call in calls)
+            assert any(".ember" in call for call in calls)
+
+    def test_reports_reinit(self) -> None:
+        """Should report reinitialization."""
+        from ember.entrypoints.cli import _report_init_results
+
+        response = MagicMock()
+        response.global_config_created = False
+        response.was_reinitialized = True
+        response.ember_dir = Path("/tmp/repo/.ember")
+        response.config_path = MagicMock(name="config.toml")
+        response.db_path = MagicMock(name="index.db")
+        response.state_path = MagicMock(name="state.json")
+
+        with patch("ember.entrypoints.cli.click.echo") as mock_echo:
+            _report_init_results(response, "jina-code-v2", quiet=False)
+
+            calls = [str(call) for call in mock_echo.call_args_list]
+            assert any("Reinitialized" in call for call in calls)
+
+    def test_reports_global_config_creation(self) -> None:
+        """Should report global config creation on first run."""
+        from ember.entrypoints.cli import _report_init_results
+
+        response = MagicMock()
+        response.global_config_created = True
+        response.global_config_path = Path("/home/user/.config/ember/config.toml")
+        response.was_reinitialized = False
+        response.ember_dir = Path("/tmp/repo/.ember")
+        response.config_path = MagicMock(name="config.toml")
+        response.db_path = MagicMock(name="index.db")
+        response.state_path = MagicMock(name="state.json")
+
+        with patch("ember.entrypoints.cli.click.echo") as mock_echo:
+            _report_init_results(response, "jina-code-v2", quiet=False)
+
+            calls = [str(call) for call in mock_echo.call_args_list]
+            assert any("global config" in call.lower() for call in calls)
+            assert any("jina-code-v2" in call for call in calls)
+
+    def test_quiet_mode_suppresses_details(self) -> None:
+        """Should suppress detailed output in quiet mode."""
+        from ember.entrypoints.cli import _report_init_results
+
+        response = MagicMock()
+        response.global_config_created = False
+        response.was_reinitialized = False
+        response.ember_dir = Path("/tmp/repo/.ember")
+
+        with patch("ember.entrypoints.cli.click.echo") as mock_echo:
+            _report_init_results(response, "jina-code-v2", quiet=True)
+
+            # Only the basic success message should be shown
+            calls = [str(call) for call in mock_echo.call_args_list]
+            assert len(calls) == 1  # Only one message in quiet mode
+            assert any("Initialized" in call for call in calls)


### PR DESCRIPTION
## Summary
- Extract helper functions from `init()` command to reduce cyclomatic complexity from 16 to 3
- Add 14 unit tests for the extracted helper functions
- Model selection logic is now testable in isolation

## Changes
- `_select_embedding_model()`: Model selection with auto-detection
- `_display_system_resources()`: System resource display output  
- `_prompt_for_model_choice()`: User confirmation prompts
- `_report_init_results()`: Success/failure reporting

## Complexity Analysis (via radon)
| Function | Before | After |
|----------|--------|-------|
| `init()` | 16 | **3** |
| `_select_embedding_model()` | - | 5 (A) |
| `_report_init_results()` | - | 6 (B) |
| `_prompt_for_model_choice()` | - | 4 (A) |
| `_display_system_resources()` | - | 2 (A) |

## Test Plan
- [x] All 14 new unit tests pass
- [x] All 10 existing init integration tests pass
- [x] Full test suite passes (928 passed, 1 flaky unrelated)
- [x] Linter passes

Implements #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)