### PR TITLE
refactor: add thread-safe locking to SQLite connection initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Thread-safe SQLite connection initialization** (#292)
+  - Added double-checked locking pattern to `_get_connection()` in all SQLite adapters
+  - Prevents race condition where multiple threads could create separate connections
+  - Affected adapters: `SQLiteChunkRepository`, `SQLiteFTS`, `SqliteVecAdapter`
+  - Added integration tests to verify thread-safe connection initialization
+
 ### Added
 - **Buffer size limit for daemon protocol** (#291)
   - Added `MAX_MESSAGE_SIZE` constant (10MB default) to prevent memory exhaustion


### PR DESCRIPTION
## Summary

- Adds double-checked locking pattern to `_get_connection()` in all SQLite adapters
- Prevents race condition where multiple threads could create separate connections simultaneously
- Adds integration tests to verify thread-safe connection initialization

Fixes #292

## Changes

- Added `threading.Lock` to `SQLiteChunkRepository`, `SQLiteFTS`, `SqliteVecAdapter`
- Updated `_get_connection()` in each adapter to use double-checked locking pattern
- Added `TestConnectionInitializationRaceCondition` test class with 3 tests

## Test plan

- [x] All existing tests pass (935 passed)
- [x] New thread safety tests pass
- [x] Ruff linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)