### PR TITLE
refactor: introduce value objects for domain validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added integration tests to verify thread-safe connection initialization
 
 ### Added
+- **Value objects for domain validation** (#293)
+  - Added `PathFilter` with glob pattern validation at construction
+  - Added `LanguageFilter` with validation against supported languages
+  - Added `ISO8601Timestamp` with parse-once, cached datetime value
+  - Updated `Query` to validate path and language filters
+  - Updated `RepoState` to use `ISO8601Timestamp` for efficient `is_stale()` checks
+  - Invalid inputs now fail fast with clear error messages
+
 - **Buffer size limit for daemon protocol** (#291)
   - Added `MAX_MESSAGE_SIZE` constant (10MB default) to prevent memory exhaustion
   - Added `max_size` parameter to `receive_message()` function

--- a/ember/core/retrieval/search_usecase.py
+++ b/ember/core/retrieval/search_usecase.py
@@ -74,12 +74,12 @@ class SearchUseCase:
         # Pass path_filter to filter during SQL query (not after)
         retrieval_pool = max(query.topk * 5, 100)
         fts_results = self.text_search.query(
-            query.text, topk=retrieval_pool, path_filter=query.path_filter
+            query.text, topk=retrieval_pool, path_filter=query.path_filter_str
         )
 
         # 3. Get vector search results
         vector_results = self.vector_search.query(
-            query_embedding, topk=retrieval_pool, path_filter=query.path_filter
+            query_embedding, topk=retrieval_pool, path_filter=query.path_filter_str
         )
 
         # 4. Fuse results using Reciprocal Rank Fusion
@@ -97,8 +97,8 @@ class SearchUseCase:
         # 7. Apply filters if specified
         filtered_chunks = self._apply_filters(
             retrieval.chunks,
-            path_filter=query.path_filter,
-            lang_filter=query.lang_filter,
+            path_filter=query.path_filter_str,
+            lang_filter=query.lang_filter_str,
         )
 
         # 8. Create SearchResult objects with scores

--- a/ember/domain/value_objects.py
+++ b/ember/domain/value_objects.py
@@ -1,0 +1,192 @@
+"""Domain value objects with validation.
+
+Value objects that provide validation at construction time,
+ensuring invalid states are unrepresentable.
+"""
+
+import fnmatch
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+# Supported language codes from file_preprocessor.py
+SUPPORTED_LANGUAGES: frozenset[str] = frozenset({
+    "py", "ts", "js", "go", "rs", "java", "c", "cpp", "cs",
+    "rb", "php", "swift", "sh", "vue", "svelte", "sql", "proto",
+    "graphql", "txt",
+})
+
+
+@dataclass(frozen=True)
+class PathFilter:
+    """Validated glob pattern for path filtering.
+
+    Ensures the glob pattern is syntactically valid at construction time.
+
+    Attributes:
+        pattern: The glob pattern string.
+
+    Raises:
+        ValueError: If pattern is empty or contains invalid glob syntax.
+    """
+
+    pattern: str
+
+    def __post_init__(self) -> None:
+        """Validate glob pattern syntax."""
+        if not self.pattern:
+            raise ValueError("PathFilter pattern cannot be empty")
+
+        # Validate glob syntax by attempting to compile it
+        # fnmatch.translate converts glob to regex - invalid patterns will fail
+        try:
+            fnmatch.translate(self.pattern)
+        except Exception as e:
+            raise ValueError(f"Invalid glob pattern '{self.pattern}': {e}") from e
+
+        # Additional validation: check for obviously malformed patterns
+        # Empty segments (e.g., "**//file.py") are suspicious
+        if "//" in self.pattern and "://" not in self.pattern:
+            raise ValueError(
+                f"Invalid glob pattern '{self.pattern}': "
+                "contains empty path segment (//)"
+            )
+
+    def matches(self, path: str) -> bool:
+        """Check if a path matches this filter pattern.
+
+        Args:
+            path: The path to check.
+
+        Returns:
+            True if the path matches the pattern.
+        """
+        return fnmatch.fnmatch(path, self.pattern)
+
+    def __str__(self) -> str:
+        """Return the pattern string for use in queries."""
+        return self.pattern
+
+
+@dataclass(frozen=True)
+class LanguageFilter:
+    """Validated language code filter.
+
+    Ensures the language code is one of the supported languages.
+
+    Attributes:
+        code: The language code (e.g., "py", "ts", "go").
+
+    Raises:
+        ValueError: If code is empty or not a supported language.
+    """
+
+    code: str
+
+    def __post_init__(self) -> None:
+        """Validate language code."""
+        if not self.code:
+            raise ValueError("LanguageFilter code cannot be empty")
+
+        if self.code not in SUPPORTED_LANGUAGES:
+            supported = ", ".join(sorted(SUPPORTED_LANGUAGES))
+            raise ValueError(
+                f"Unknown language '{self.code}'. "
+                f"Supported languages: {supported}"
+            )
+
+    def __str__(self) -> str:
+        """Return the code string for use in queries."""
+        return self.code
+
+
+@dataclass(frozen=True)
+class ISO8601Timestamp:
+    """Validated and parsed ISO-8601 timestamp.
+
+    Parses the timestamp once at construction, caching the datetime result.
+    Handles both 'Z' suffix and explicit timezone offsets.
+
+    Attributes:
+        value: The parsed datetime object (always timezone-aware).
+        raw: The original string representation.
+
+    Raises:
+        ValueError: If the string is not a valid ISO-8601 timestamp.
+    """
+
+    value: datetime
+    raw: str
+
+    # Regex for basic ISO-8601 datetime validation
+    _PATTERN = re.compile(
+        r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"  # Basic datetime
+        r"(?:\.\d+)?"  # Optional fractional seconds
+        r"(?:Z|[+-]\d{2}:\d{2})?$"  # Optional timezone
+    )
+
+    @classmethod
+    def from_string(cls, timestamp_str: str) -> "ISO8601Timestamp":
+        """Create an ISO8601Timestamp from a string.
+
+        Args:
+            timestamp_str: ISO-8601 formatted timestamp string.
+
+        Returns:
+            ISO8601Timestamp instance.
+
+        Raises:
+            ValueError: If the string is not a valid ISO-8601 timestamp.
+        """
+        if not timestamp_str:
+            raise ValueError("Timestamp string cannot be empty")
+
+        if not cls._PATTERN.match(timestamp_str):
+            raise ValueError(
+                f"Invalid ISO-8601 timestamp: '{timestamp_str}'. "
+                "Expected format: YYYY-MM-DDTHH:MM:SS[.fff][Z|+HH:MM]"
+            )
+
+        # Parse the timestamp, handling 'Z' suffix
+        parse_str = timestamp_str
+        if parse_str.endswith("Z"):
+            parse_str = parse_str[:-1] + "+00:00"
+
+        try:
+            parsed = datetime.fromisoformat(parse_str)
+            # Ensure timezone-aware
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=UTC)
+            return cls(value=parsed, raw=timestamp_str)
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid ISO-8601 timestamp: '{timestamp_str}': {e}"
+            ) from e
+
+    @classmethod
+    def now(cls) -> "ISO8601Timestamp":
+        """Create a timestamp for the current UTC time.
+
+        Returns:
+            ISO8601Timestamp for now.
+        """
+        now = datetime.now(UTC)
+        raw = now.isoformat()
+        return cls(value=now, raw=raw)
+
+    def is_older_than(self, seconds: int) -> bool:
+        """Check if this timestamp is older than a given number of seconds.
+
+        Args:
+            seconds: Age threshold in seconds.
+
+        Returns:
+            True if the timestamp is more than `seconds` old.
+        """
+        now = datetime.now(UTC)
+        age_seconds = (now - self.value).total_seconds()
+        return age_seconds > seconds
+
+    def __str__(self) -> str:
+        """Return the raw timestamp string."""
+        return self.raw

--- a/ember/shared/state_io.py
+++ b/ember/shared/state_io.py
@@ -59,7 +59,7 @@ def save_state(state: RepoState, path: Path) -> None:
         "last_sync_mode": sync_mode,
         "model_fingerprint": state.model_fingerprint,
         "version": state.version,
-        "indexed_at": state.indexed_at,
+        "indexed_at": state.indexed_at_str,
     }
 
     # Ensure parent directory exists

--- a/tests/unit/domain/test_entities.py
+++ b/tests/unit/domain/test_entities.py
@@ -457,7 +457,7 @@ class TestRepoStateValidation:
 
     def test_repo_state_invalid_timestamp_raises_error(self):
         """Test that invalid ISO-8601 timestamp raises ValueError."""
-        with pytest.raises(ValueError, match="indexed_at must be a valid ISO-8601"):
+        with pytest.raises(ValueError, match="Invalid ISO-8601 timestamp"):
             RepoState(
                 last_tree_sha="a" * 40,
                 last_sync_mode=SyncMode.WORKTREE,
@@ -477,7 +477,8 @@ class TestRepoStateValidation:
             version="1.0.0",
             indexed_at="2025-01-15T10:30:00+00:00",
         )
-        assert state.indexed_at == "2025-01-15T10:30:00+00:00"
+        # indexed_at is now ISO8601Timestamp, use indexed_at_str for raw string
+        assert state.indexed_at_str == "2025-01-15T10:30:00+00:00"
 
         # With Z suffix
         state = RepoState(
@@ -487,7 +488,7 @@ class TestRepoStateValidation:
             version="1.0.0",
             indexed_at="2025-01-15T10:30:00Z",
         )
-        assert state.indexed_at == "2025-01-15T10:30:00Z"
+        assert state.indexed_at_str == "2025-01-15T10:30:00Z"
 
 
 # =============================================================================

--- a/tests/unit/domain/test_value_objects.py
+++ b/tests/unit/domain/test_value_objects.py
@@ -1,0 +1,191 @@
+"""Tests for domain value objects."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ember.domain.value_objects import (
+    SUPPORTED_LANGUAGES,
+    ISO8601Timestamp,
+    LanguageFilter,
+    PathFilter,
+)
+
+
+class TestPathFilter:
+    """Tests for PathFilter value object."""
+
+    def test_valid_simple_pattern(self) -> None:
+        """Test that simple patterns are accepted."""
+        pf = PathFilter("*.py")
+        assert pf.pattern == "*.py"
+        assert str(pf) == "*.py"
+
+    def test_valid_glob_patterns(self) -> None:
+        """Test various valid glob patterns."""
+        valid_patterns = [
+            "*.py",
+            "**/*.py",
+            "src/*.ts",
+            "tests/test_*.py",
+            "src/**/test*.py",
+            "file.txt",
+            "[abc].py",
+            "foo?bar.py",
+        ]
+        for pattern in valid_patterns:
+            pf = PathFilter(pattern)
+            assert pf.pattern == pattern
+
+    def test_empty_pattern_raises(self) -> None:
+        """Test that empty pattern raises ValueError."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            PathFilter("")
+
+    def test_double_slash_raises(self) -> None:
+        """Test that double slashes (empty path segment) raise ValueError."""
+        with pytest.raises(ValueError, match="empty path segment"):
+            PathFilter("src//file.py")
+
+    def test_url_with_double_slash_allowed(self) -> None:
+        """Test that URLs with :// are allowed."""
+        # This is an edge case - shouldn't happen in practice but shouldn't fail
+        pf = PathFilter("http://*.example.com")
+        assert pf.pattern == "http://*.example.com"
+
+    def test_matches_positive(self) -> None:
+        """Test that matches() returns True for matching paths."""
+        pf = PathFilter("*.py")
+        assert pf.matches("test.py")
+        assert pf.matches("module.py")
+
+    def test_matches_negative(self) -> None:
+        """Test that matches() returns False for non-matching paths."""
+        pf = PathFilter("*.py")
+        assert not pf.matches("test.ts")
+        # Note: fnmatch's * matches everything including /
+        # This differs from shell glob behavior
+
+    def test_matches_specific_dir(self) -> None:
+        """Test matching with directory prefix."""
+        pf = PathFilter("src/*.py")
+        assert pf.matches("src/test.py")
+        assert not pf.matches("test.py")
+        assert not pf.matches("other/test.py")
+
+
+class TestLanguageFilter:
+    """Tests for LanguageFilter value object."""
+
+    def test_valid_language_codes(self) -> None:
+        """Test that all supported languages are accepted."""
+        for lang in SUPPORTED_LANGUAGES:
+            lf = LanguageFilter(lang)
+            assert lf.code == lang
+            assert str(lf) == lang
+
+    def test_empty_code_raises(self) -> None:
+        """Test that empty code raises ValueError."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            LanguageFilter("")
+
+    def test_unknown_language_raises(self) -> None:
+        """Test that unknown language codes raise ValueError."""
+        with pytest.raises(ValueError, match="Unknown language"):
+            LanguageFilter("cobol")
+
+    def test_error_message_includes_supported(self) -> None:
+        """Test that error message lists supported languages."""
+        with pytest.raises(ValueError, match="Supported languages:"):
+            LanguageFilter("invalid")
+
+
+class TestISO8601Timestamp:
+    """Tests for ISO8601Timestamp value object."""
+
+    def test_parse_with_z_suffix(self) -> None:
+        """Test parsing timestamp with Z suffix."""
+        ts = ISO8601Timestamp.from_string("2024-01-15T10:30:00Z")
+        assert ts.value.year == 2024
+        assert ts.value.month == 1
+        assert ts.value.day == 15
+        assert ts.value.hour == 10
+        assert ts.value.minute == 30
+        assert ts.raw == "2024-01-15T10:30:00Z"
+
+    def test_parse_with_offset(self) -> None:
+        """Test parsing timestamp with explicit offset."""
+        ts = ISO8601Timestamp.from_string("2024-01-15T10:30:00+05:00")
+        assert ts.value.hour == 10
+        assert str(ts.value.tzinfo) == "UTC+05:00"
+
+    def test_parse_with_fractional_seconds(self) -> None:
+        """Test parsing timestamp with fractional seconds."""
+        ts = ISO8601Timestamp.from_string("2024-01-15T10:30:00.123456Z")
+        assert ts.value.microsecond == 123456
+
+    def test_parse_no_timezone(self) -> None:
+        """Test parsing timestamp without timezone (assumes UTC)."""
+        ts = ISO8601Timestamp.from_string("2024-01-15T10:30:00")
+        assert ts.value.tzinfo is not None  # Should be UTC
+
+    def test_empty_string_raises(self) -> None:
+        """Test that empty string raises ValueError."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            ISO8601Timestamp.from_string("")
+
+    def test_invalid_format_raises(self) -> None:
+        """Test that invalid formats raise ValueError."""
+        invalid_timestamps = [
+            "not-a-timestamp",
+            "2024-01-15",  # Date only
+            "10:30:00",  # Time only
+            "2024/01/15T10:30:00Z",  # Wrong date separator
+            "2024-01-15 10:30:00",  # Space instead of T
+        ]
+        for ts_str in invalid_timestamps:
+            with pytest.raises(ValueError, match="Invalid ISO-8601"):
+                ISO8601Timestamp.from_string(ts_str)
+
+    def test_now_creates_current_time(self) -> None:
+        """Test that now() creates a timestamp close to current time."""
+        before = datetime.now(UTC)
+        ts = ISO8601Timestamp.now()
+        after = datetime.now(UTC)
+
+        assert before <= ts.value <= after
+
+    def test_is_older_than_positive(self) -> None:
+        """Test is_older_than returns True for old timestamps."""
+        old_time = datetime.now(UTC) - timedelta(hours=2)
+        ts = ISO8601Timestamp(value=old_time, raw=old_time.isoformat())
+
+        # Should be older than 1 hour
+        assert ts.is_older_than(3600)
+
+    def test_is_older_than_negative(self) -> None:
+        """Test is_older_than returns False for recent timestamps."""
+        ts = ISO8601Timestamp.now()
+
+        # Should not be older than 1 hour
+        assert not ts.is_older_than(3600)
+
+    def test_str_returns_raw(self) -> None:
+        """Test that str() returns the original raw string."""
+        raw = "2024-01-15T10:30:00Z"
+        ts = ISO8601Timestamp.from_string(raw)
+        assert str(ts) == raw
+
+
+class TestSupportedLanguages:
+    """Tests for SUPPORTED_LANGUAGES constant."""
+
+    def test_includes_common_languages(self) -> None:
+        """Test that common languages are included."""
+        common = ["py", "ts", "js", "go", "rs", "java"]
+        for lang in common:
+            assert lang in SUPPORTED_LANGUAGES
+
+    def test_is_frozen(self) -> None:
+        """Test that SUPPORTED_LANGUAGES is immutable."""
+        assert isinstance(SUPPORTED_LANGUAGES, frozenset)


### PR DESCRIPTION
## Summary

- Adds `PathFilter`, `LanguageFilter`, and `ISO8601Timestamp` value objects
- Validates inputs at construction time - invalid states become unrepresentable
- Invalid inputs now fail fast with clear, actionable error messages

Fixes #293

## Changes

- Added `ember/domain/value_objects.py` with three value objects:
  - `PathFilter`: Validates glob pattern syntax
  - `LanguageFilter`: Validates against `SUPPORTED_LANGUAGES` set
  - `ISO8601Timestamp`: Parses once, caches datetime for efficient `is_stale()` checks
- Updated `Query` to validate `path_filter` and `lang_filter` at construction
- Updated `RepoState` to use `ISO8601Timestamp` (simplifies `is_stale()` from 15 lines to 2)
- Updated `search_usecase.py` to use `path_filter_str`/`lang_filter_str` for SQL
- Updated `state_io.py` to use `indexed_at_str` for JSON serialization
- Added 24 unit tests covering all value objects

## Test plan

- [x] All 959 tests pass
- [x] Ruff linter passes
- [x] Backward compatibility maintained (string inputs still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)