### PR TITLE
perf: optimize DefinitionMatcher AST traversal with memoization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+- **Optimized DefinitionMatcher AST traversal** (#295)
+  - Added memoization to `match()` method for ancestor lookups
+  - Reduces complexity from O(n*m) to O(n+m) where n=nodes, m=name nodes
+  - Each AST node is now visited at most once instead of repeatedly
+  - Improves performance on large files with 100+ definitions
+
 ### Changed
 - **Batch inserts for sqlite-vec vector sync** (#296)
   - Refactored `_sync_vectors()` to use `executemany()` for batch operations


### PR DESCRIPTION
## Summary
- Add memoization cache to `DefinitionMatcher.match()` to avoid redundant parent traversals
- Reduces time complexity from O(n*m) to O(n+m) for large files with many definitions
- Add benchmark test for files with 150+ definitions

Implements #295

## Changes
- `ember/adapters/parsers/definition_matcher.py`: Add memoized `find_definition_ancestor()` helper
- `tests/unit/test_definition_matcher.py`: Add performance test for large files

## Test plan
- [x] All existing tests pass (12 definition matcher tests)
- [x] Full test suite passes (969 tests)
- [x] Linter passes
- [x] Benchmark test verifies <100ms for 150 definitions with depth 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)