### PR TITLE
refactor: extract find/search dependency setup to shared function (#297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Improves performance on large files with 100+ definitions
 
 ### Changed
+- **Extracted search dependency setup to shared function** (#297)
+  - Created `_create_search_usecase()` helper to centralize SearchUseCase initialization
+  - Reduces code duplication between `find` and `search` commands
+  - Makes maintenance easier and ensures consistent initialization
+
 - **Batch inserts for sqlite-vec vector sync** (#296)
   - Refactored `_sync_vectors()` to use `executemany()` for batch operations
   - Reduced SQL operations from 2N+1 to 4 for N vectors (2 executemany + 1 select + 1 commit)


### PR DESCRIPTION
## Summary

- Extract duplicated SearchUseCase initialization from `find` and `search` commands into `_create_search_usecase()` helper
- Reduces code duplication (~20 lines of duplicated setup code consolidated)
- Ensures consistent dependency initialization across commands

Implements #297

## Changes

- Added `_create_search_usecase(db_path, embedder) -> SearchUseCase` helper function
- Refactored `find` command to use shared helper
- Refactored `search` command to use shared helper
- Added `SearchUseCase` to TYPE_CHECKING imports for proper type annotation

## Test Plan

- [x] All 969 tests pass
- [x] Linter passes (`ruff check .`)
- [x] No user-visible changes (internal refactoring only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)