### PR TITLE
refactor: create VERSION constant for single source of truth (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Single source of truth for version** (#299)
+  - Created `ember/version.py` module with `__version__` constant
+  - Version is now read from package metadata (`pyproject.toml`) using `importlib.metadata`
+  - Removed hardcoded version strings from CLI entrypoint
+  - Reduces maintenance burden and eliminates risk of version drift
 - **Narrowed exception handling in error-prone paths** (#298)
   - Replaced broad `except Exception` with specific exception types where possible
   - Added `exc_info=True` logging to preserve full tracebacks for debugging

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -38,6 +38,7 @@ from ember.core.cli_utils import (
 )
 from ember.core.indexing.index_usecase import ModelMismatchError
 from ember.core.presentation import ResultPresenter
+from ember.version import __version__
 
 
 def handle_cli_errors(command_name: str):
@@ -416,7 +417,7 @@ def check_and_auto_sync(
 
 
 @click.group()
-@click.version_option(version="1.2.0", prog_name="ember")
+@click.version_option(version=__version__, prog_name="ember")
 @click.option(
     "--verbose",
     "-v",
@@ -598,7 +599,7 @@ def init(ctx: click.Context, force: bool, model: str | None, yes: bool) -> None:
     selected_model = _select_embedding_model(model, quiet, yes)
 
     db_initializer = SqliteDatabaseInitializer()
-    use_case = InitUseCase(db_initializer=db_initializer, version="1.2.0")
+    use_case = InitUseCase(db_initializer=db_initializer, version=__version__)
     request = InitRequest(repo_root=repo_root, force=force, model=selected_model)
 
     try:

--- a/ember/version.py
+++ b/ember/version.py
@@ -1,0 +1,9 @@
+"""Version information for Ember.
+
+This module provides a single source of truth for the package version,
+reading from the installed package metadata (pyproject.toml).
+"""
+
+from importlib.metadata import version
+
+__version__ = version("ember")

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,26 @@
+"""Tests for ember.version module."""
+
+import re
+
+from ember.version import __version__
+
+
+class TestVersion:
+    """Tests for version constant."""
+
+    def test_version_is_string(self) -> None:
+        """Version should be a string."""
+        assert isinstance(__version__, str)
+
+    def test_version_matches_semver_pattern(self) -> None:
+        """Version should follow semantic versioning pattern."""
+        # Pattern: major.minor.patch with optional pre-release/build metadata
+        semver_pattern = r"^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$"
+        assert re.match(
+            semver_pattern, __version__
+        ), f"Version '{__version__}' does not match semver pattern"
+
+    def test_version_not_empty(self) -> None:
+        """Version should not be empty."""
+        assert __version__
+        assert len(__version__) > 0


### PR DESCRIPTION
## Summary
- Created `ember/version.py` module with `__version__` constant that reads from package metadata
- Removed hardcoded version strings from CLI entrypoint (`cli.py`)
- Added tests for version module (semver pattern validation)

Implements #299

## Changes
- **ember/version.py**: New module using `importlib.metadata.version()` to read version from `pyproject.toml`
- **ember/entrypoints/cli.py**: Updated `@click.version_option` and `InitUseCase` call to use `__version__`
- **tests/unit/test_version.py**: Tests for version string format and semver compliance

## Acceptance Criteria
- [x] Single source of truth for version
- [x] All hardcoded version strings removed
- [x] Tests pass

## Test Plan
- [x] Run `uv run pytest` - all 972 tests pass
- [x] Run `uv run ruff check .` - all checks pass
- [x] Run `uv run ember --version` - outputs `ember, version 1.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)