### PR TITLE
refactor: improve SyncResult to distinguish error types (#300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Version is now read from package metadata (`pyproject.toml`) using `importlib.metadata`
   - Removed hardcoded version strings from CLI entrypoint
   - Reduces maintenance burden and eliminates risk of version drift
+- **Improved SyncResult error classification** (#300)
+  - Added `SyncErrorType` enum to distinguish error types (git, database, permission, unknown)
+  - `SyncResult.error_type` allows callers to handle errors appropriately
+  - Git errors detected from `RuntimeError` messages and `subprocess.CalledProcessError`
+  - Database errors detected from `sqlite3.Error` exceptions
+  - Permission errors detected from `PermissionError` and `OSError` with EACCES/EPERM
 - **Narrowed exception handling in error-prone paths** (#298)
   - Replaced broad `except Exception` with specific exception types where possible
   - Added `exc_info=True` logging to preserve full tracebacks for debugging

--- a/tests/unit/test_ensure_synced.py
+++ b/tests/unit/test_ensure_synced.py
@@ -318,7 +318,7 @@ class TestEnsureSyncedReturnsStatus:
 
     def test_returns_error_on_failure(self) -> None:
         """Returns error when sync fails."""
-        from ember.entrypoints.cli import ensure_synced
+        from ember.entrypoints.cli import SyncErrorType, ensure_synced
 
         with (
             patch(
@@ -337,3 +337,183 @@ class TestEnsureSyncedReturnsStatus:
             assert result.synced is False
             assert result.error is not None
             assert "Git error" in result.error
+            # Unknown error type for generic Exception
+            assert result.error_type == SyncErrorType.UNKNOWN
+
+
+class TestEnsureSyncedErrorClassification:
+    """Tests for error classification in ensure_synced()."""
+
+    def test_classifies_git_runtime_error(self) -> None:
+        """RuntimeError with git-related message is classified as GIT_ERROR."""
+        from ember.entrypoints.cli import SyncErrorType, ensure_synced
+
+        with patch("ember.adapters.git_cmd.git_adapter.GitAdapter") as mock_git:
+            mock_git.return_value.get_worktree_tree_sha.side_effect = RuntimeError(
+                "Not a git repository: /test"
+            )
+
+            result = ensure_synced(
+                repo_root=Path("/test"),
+                db_path=Path("/test/.ember/index.db"),
+                config=MagicMock(),
+            )
+
+            assert result.synced is False
+            assert result.error_type == SyncErrorType.GIT_ERROR
+            assert "git repository" in result.error.lower()
+
+    def test_classifies_subprocess_error_as_git(self) -> None:
+        """subprocess.CalledProcessError is classified as GIT_ERROR."""
+        import subprocess
+
+        from ember.entrypoints.cli import SyncErrorType, ensure_synced
+
+        with patch("ember.adapters.git_cmd.git_adapter.GitAdapter") as mock_git:
+            mock_git.return_value.get_worktree_tree_sha.side_effect = (
+                subprocess.CalledProcessError(1, "git status")
+            )
+
+            result = ensure_synced(
+                repo_root=Path("/test"),
+                db_path=Path("/test/.ember/index.db"),
+                config=MagicMock(),
+            )
+
+            assert result.synced is False
+            assert result.error_type == SyncErrorType.GIT_ERROR
+
+    def test_classifies_sqlite_error_as_database(self) -> None:
+        """sqlite3.Error is classified as DATABASE_ERROR."""
+        import sqlite3
+
+        from ember.entrypoints.cli import SyncErrorType, ensure_synced
+
+        with (
+            patch("ember.adapters.git_cmd.git_adapter.GitAdapter") as mock_git,
+            patch(
+                "ember.adapters.sqlite.meta_repository.SQLiteMetaRepository"
+            ) as mock_meta,
+        ):
+            mock_git.return_value.get_worktree_tree_sha.return_value = "new_sha"
+            mock_meta.return_value.get.side_effect = sqlite3.OperationalError(
+                "database is locked"
+            )
+
+            result = ensure_synced(
+                repo_root=Path("/test"),
+                db_path=Path("/test/.ember/index.db"),
+                config=MagicMock(),
+            )
+
+            assert result.synced is False
+            assert result.error_type == SyncErrorType.DATABASE_ERROR
+            assert "locked" in result.error.lower()
+
+    def test_classifies_permission_error(self) -> None:
+        """PermissionError is classified as PERMISSION_ERROR."""
+        from ember.entrypoints.cli import SyncErrorType, ensure_synced
+
+        with patch("ember.adapters.git_cmd.git_adapter.GitAdapter") as mock_git:
+            mock_git.return_value.get_worktree_tree_sha.side_effect = PermissionError(
+                "Access denied"
+            )
+
+            result = ensure_synced(
+                repo_root=Path("/test"),
+                db_path=Path("/test/.ember/index.db"),
+                config=MagicMock(),
+            )
+
+            assert result.synced is False
+            assert result.error_type == SyncErrorType.PERMISSION_ERROR
+
+    def test_classifies_oserror_eacces_as_permission(self) -> None:
+        """OSError with EACCES errno is classified as PERMISSION_ERROR."""
+        import errno
+
+        from ember.entrypoints.cli import SyncErrorType, ensure_synced
+
+        with patch("ember.adapters.git_cmd.git_adapter.GitAdapter") as mock_git:
+            error = OSError(errno.EACCES, "Permission denied")
+            mock_git.return_value.get_worktree_tree_sha.side_effect = error
+
+            result = ensure_synced(
+                repo_root=Path("/test"),
+                db_path=Path("/test/.ember/index.db"),
+                config=MagicMock(),
+            )
+
+            assert result.synced is False
+            assert result.error_type == SyncErrorType.PERMISSION_ERROR
+
+    def test_classifies_unknown_error(self) -> None:
+        """Generic exceptions are classified as UNKNOWN."""
+        from ember.entrypoints.cli import SyncErrorType, ensure_synced
+
+        with patch("ember.adapters.git_cmd.git_adapter.GitAdapter") as mock_git:
+            mock_git.return_value.get_worktree_tree_sha.side_effect = ValueError(
+                "Something went wrong"
+            )
+
+            result = ensure_synced(
+                repo_root=Path("/test"),
+                db_path=Path("/test/.ember/index.db"),
+                config=MagicMock(),
+            )
+
+            assert result.synced is False
+            assert result.error_type == SyncErrorType.UNKNOWN
+
+    def test_successful_sync_has_no_error_type(self) -> None:
+        """Successful sync has error_type=NONE."""
+        from ember.entrypoints.cli import SyncErrorType, ensure_synced
+
+        with (
+            patch("ember.adapters.git_cmd.git_adapter.GitAdapter") as mock_git,
+            patch(
+                "ember.adapters.sqlite.meta_repository.SQLiteMetaRepository"
+            ) as mock_meta,
+            patch("ember.entrypoints.cli._create_indexing_usecase") as mock_usecase,
+            patch("ember.entrypoints.cli.progress_context") as mock_progress_ctx,
+        ):
+            mock_git.return_value.get_worktree_tree_sha.return_value = "new_sha"
+            mock_meta.return_value.get.return_value = "old_sha"
+            mock_usecase.return_value.execute.return_value = MockIndexResponse(
+                files_indexed=5
+            )
+            mock_progress_ctx.return_value.__enter__ = MagicMock(return_value=None)
+            mock_progress_ctx.return_value.__exit__ = MagicMock(return_value=None)
+
+            result = ensure_synced(
+                repo_root=Path("/test"),
+                db_path=Path("/test/.ember/index.db"),
+                config=MagicMock(),
+            )
+
+            assert result.synced is True
+            assert result.error is None
+            assert result.error_type == SyncErrorType.NONE
+
+    def test_already_synced_has_no_error_type(self) -> None:
+        """Already synced (no changes) has error_type=NONE."""
+        from ember.entrypoints.cli import SyncErrorType, ensure_synced
+
+        with (
+            patch("ember.adapters.git_cmd.git_adapter.GitAdapter") as mock_git,
+            patch(
+                "ember.adapters.sqlite.meta_repository.SQLiteMetaRepository"
+            ) as mock_meta,
+        ):
+            mock_git.return_value.get_worktree_tree_sha.return_value = "same_sha"
+            mock_meta.return_value.get.return_value = "same_sha"
+
+            result = ensure_synced(
+                repo_root=Path("/test"),
+                db_path=Path("/test/.ember/index.db"),
+                config=MagicMock(),
+            )
+
+            assert result.synced is False
+            assert result.error is None
+            assert result.error_type == SyncErrorType.NONE


### PR DESCRIPTION
## Summary
- Added `SyncErrorType` enum to classify sync errors (git, database, permission, unknown)
- Updated `SyncResult` dataclass with `error_type` field
- Error classification in `ensure_synced()` based on exception type
- Added 8 tests covering all error classification scenarios

Implements #300

## Changes
- **ember/entrypoints/cli.py**: Added `SyncErrorType` enum and updated error handling
- **tests/unit/test_ensure_synced.py**: Added `TestEnsureSyncedErrorClassification` test class

## Error Classification Logic
| Exception Type | Classification |
|----------------|----------------|
| `PermissionError` | `PERMISSION_ERROR` |
| `OSError` with EACCES/EPERM | `PERMISSION_ERROR` |
| `sqlite3.Error` | `DATABASE_ERROR` |
| `subprocess.CalledProcessError` | `GIT_ERROR` |
| `RuntimeError` with git keywords | `GIT_ERROR` |
| Other exceptions | `UNKNOWN` |

## Acceptance Criteria
- [x] SyncResult includes error classification
- [x] Callers can distinguish error types
- [x] Tests cover different error scenarios

## Test Plan
- [x] Run `uv run pytest` - all 980 tests pass
- [x] Run `uv run ruff check .` - all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)