### PR TITLE
refactor: extract SearchExplanation typed dataclass from dict (#301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Typed SearchExplanation dataclass** (#301)
+  - Replaced untyped `dict[str, float | str]` with typed `SearchExplanation` dataclass
+  - Provides IDE autocomplete and compile-time error detection for score fields
+  - Fields: `fused_score`, `bm25_score`, `vector_score` with proper types
+  - Added `to_dict()` method for JSON serialization backward compatibility
+  - Immutable (frozen) dataclass for thread safety
+
+### Changed
 - **Single source of truth for version** (#299)
   - Created `ember/version.py` module with `__version__` constant
   - Version is now read from package metadata (`pyproject.toml`) using `importlib.metadata`

--- a/ember/core/presentation/json_formatter.py
+++ b/ember/core/presentation/json_formatter.py
@@ -53,7 +53,7 @@ class JsonResultFormatter:
                     "content": result.chunk.content,
                     "chunk_id": result.chunk.id,
                     "tree_sha": result.chunk.tree_sha,
-                    "explanation": result.explanation,
+                    "explanation": result.explanation.to_dict(),
                 }
                 for result in results
             ],
@@ -84,7 +84,7 @@ class JsonResultFormatter:
                 "start_line": result.chunk.start_line,
                 "end_line": result.chunk.end_line,
                 "content": result.chunk.content,
-                "explanation": result.explanation,
+                "explanation": result.explanation.to_dict(),
             }
 
             # Add context if requested

--- a/ember/core/retrieval/search_usecase.py
+++ b/ember/core/retrieval/search_usecase.py
@@ -7,7 +7,13 @@ with Reciprocal Rank Fusion for optimal retrieval quality.
 import logging
 from dataclasses import dataclass
 
-from ember.domain.entities import Chunk, Query, SearchResult, SearchResultSet
+from ember.domain.entities import (
+    Chunk,
+    Query,
+    SearchExplanation,
+    SearchResult,
+    SearchResultSet,
+)
 from ember.ports.embedders import Embedder
 from ember.ports.repositories import ChunkRepository
 from ember.ports.search import TextSearch, VectorSearch
@@ -116,11 +122,11 @@ class SearchUseCase:
                 score=score,
                 rank=rank,
                 preview=self._generate_preview(chunk),
-                explanation={
-                    "fused_score": score,
-                    "bm25_score": fts_score,
-                    "vector_score": vector_score,
-                },
+                explanation=SearchExplanation(
+                    fused_score=score,
+                    bm25_score=fts_score,
+                    vector_score=vector_score,
+                ),
             )
             results.append(result)
 

--- a/tests/integration/test_search_usecase.py
+++ b/tests/integration/test_search_usecase.py
@@ -139,7 +139,7 @@ def test_search_exact_keyword_match(search_usecase: SearchUseCase) -> None:
     assert results[0].chunk.symbol == "multiply"
     assert "multiply" in results[0].chunk.content.lower()
     # Should have BM25 score
-    assert results[0].explanation["bm25_score"] > 0
+    assert results[0].explanation.bm25_score > 0
 
 
 @pytest.mark.slow
@@ -153,7 +153,7 @@ def test_search_semantic_similarity(search_usecase: SearchUseCase) -> None:
     result_symbols = {r.chunk.symbol for r in results}
     assert result_symbols & {"greet", "farewell"}  # At least one should match
     # Should have vector score
-    assert results[0].explanation["vector_score"] > 0
+    assert results[0].explanation.vector_score > 0
 
 
 @pytest.mark.slow
@@ -163,13 +163,14 @@ def test_search_hybrid_fusion(search_usecase: SearchUseCase) -> None:
     results = search_usecase.search(query)
 
     assert len(results) > 0
-    # Should have both BM25 and vector scores
+    # Should have both BM25 and vector scores (typed access)
     for result in results:
-        assert "bm25_score" in result.explanation
-        assert "vector_score" in result.explanation
-        assert "fused_score" in result.explanation
+        # Typed fields always exist - no need to check "in"
+        assert hasattr(result.explanation, "bm25_score")
+        assert hasattr(result.explanation, "vector_score")
+        assert hasattr(result.explanation, "fused_score")
         # Fused score should be positive
-        assert result.explanation["fused_score"] > 0
+        assert result.explanation.fused_score > 0
 
 
 @pytest.mark.slow

--- a/tests/unit/core/test_result_presenter.py
+++ b/tests/unit/core/test_result_presenter.py
@@ -16,6 +16,7 @@ from ember.core.presentation.context_renderer import ContextRenderer
 from ember.core.presentation.json_formatter import JsonResultFormatter
 from ember.core.presentation.result_presenter import ResultPresenter
 from ember.domain.config import DisplayConfig, EmberConfig
+from ember.domain.entities import SearchExplanation
 
 
 @dataclass
@@ -44,7 +45,9 @@ class MockSearchResult:
     score: float = 0.95
     rank: int = 1
     preview: str = "def test_function():"
-    explanation: dict = field(default_factory=dict)
+    explanation: SearchExplanation = field(
+        default_factory=lambda: SearchExplanation(fused_score=0.0)
+    )
 
     def format_preview(self, max_lines: int = 3) -> str:
         """Generate preview text from chunk content."""


### PR DESCRIPTION
## Summary

- Extracted typed `SearchExplanation` dataclass from untyped `dict[str, float | str]`
- Provides IDE autocomplete and compile-time error detection for score fields
- Added `to_dict()` method for JSON serialization backward compatibility

Implements #301

## Changes

- **ember/domain/entities.py**: Added `SearchExplanation` frozen dataclass with `fused_score`, `bm25_score`, `vector_score` fields
- **ember/core/retrieval/search_usecase.py**: Updated to construct `SearchExplanation` instead of dict
- **ember/core/presentation/json_formatter.py**: Updated to use `to_dict()` for serialization
- **tests/unit/domain/test_entities.py**: Added comprehensive unit tests for `SearchExplanation`
- **tests/integration/test_search_usecase.py**: Updated to use typed attribute access
- **tests/unit/core/test_result_presenter.py**: Updated mock to use `SearchExplanation`

## Acceptance Criteria

- [x] Typed SearchExplanation dataclass
- [x] IDE autocomplete for explanation fields  
- [x] Backward compatibility (JSON output unchanged)
- [x] Tests updated

## Test Coverage

- 10 new unit tests for SearchExplanation
- All 796 unit tests passing
- Linter passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)