### PR TITLE
refactor: add factory methods to RepoState for common construction patterns (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **RepoState factory methods** (#303)
+  - Added `RepoState.uninitialized(version)` factory for creating initial states
+  - Added `RepoState.from_sync(tree_sha, sync_mode, model_fingerprint, version)` factory for post-sync states
+  - Eliminates verbose constructor calls with magic values
+  - Encapsulates common construction patterns for better maintainability
+  - Migrated `state_io.create_initial_state()` and test fixtures to use factories
 - **Typed SearchExplanation dataclass** (#301)
   - Replaced untyped `dict[str, float | str]` with typed `SearchExplanation` dataclass
   - Provides IDE autocomplete and compile-time error detection for score fields

--- a/ember/domain/entities.py
+++ b/ember/domain/entities.py
@@ -4,8 +4,11 @@ Core domain models representing the business concepts of Ember.
 These are pure Python dataclasses with no dependencies on infrastructure.
 """
 
+from __future__ import annotations
+
 import re
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
 
@@ -235,6 +238,57 @@ class RepoState:
             True if the stored fingerprint differs from current model.
         """
         return self.model_fingerprint != current_model_fingerprint
+
+    @classmethod
+    def uninitialized(cls, version: str) -> RepoState:
+        """Create an uninitialized repo state.
+
+        Factory method for creating a RepoState representing a repository
+        that has never been indexed.
+
+        Args:
+            version: Ember version string (e.g., "1.2.0").
+
+        Returns:
+            RepoState with empty tree_sha and default values.
+        """
+        return cls(
+            last_tree_sha="",
+            last_sync_mode=SyncMode.NONE,
+            model_fingerprint="",
+            version=version,
+            indexed_at=datetime.now(UTC).isoformat(),
+        )
+
+    @classmethod
+    def from_sync(
+        cls,
+        tree_sha: str,
+        sync_mode: str | SyncMode,
+        model_fingerprint: str,
+        version: str,
+    ) -> RepoState:
+        """Create state after a successful sync.
+
+        Factory method for creating a RepoState representing a repository
+        that has been successfully indexed.
+
+        Args:
+            tree_sha: Git tree SHA that was indexed.
+            sync_mode: Sync mode used (SyncMode enum or commit SHA string).
+            model_fingerprint: Fingerprint of embedding model used.
+            version: Ember version string (e.g., "1.2.0").
+
+        Returns:
+            RepoState with the provided sync information and current timestamp.
+        """
+        return cls(
+            last_tree_sha=tree_sha,
+            last_sync_mode=sync_mode,
+            model_fingerprint=model_fingerprint,
+            version=version,
+            indexed_at=datetime.now(UTC).isoformat(),
+        )
 
 
 @dataclass(frozen=True)

--- a/ember/shared/state_io.py
+++ b/ember/shared/state_io.py
@@ -5,7 +5,6 @@ The state file tracks what has been indexed and enables incremental sync.
 """
 
 import json
-from datetime import UTC
 from pathlib import Path
 
 from ember.domain.entities import RepoState, SyncMode
@@ -78,14 +77,5 @@ def create_initial_state(path: Path, version: str = "0.1.0") -> None:
         path: Destination path for state.json
         version: Ember version string
     """
-    from datetime import datetime
-
-    state = RepoState(
-        last_tree_sha="",
-        last_sync_mode="none",
-        model_fingerprint="",
-        version=version,
-        indexed_at=datetime.now(UTC).isoformat(),
-    )
-
+    state = RepoState.uninitialized(version=version)
     save_state(state, path)


### PR DESCRIPTION
## Summary
- Add `RepoState.uninitialized(version)` factory method for creating initial states
- Add `RepoState.from_sync(tree_sha, sync_mode, model_fingerprint, version)` factory method for post-sync states
- Migrate `state_io.create_initial_state()` and test fixtures to use the new factories
- Eliminates verbose constructor calls with magic values

Closes #303

## Test plan
- [x] All 998 tests pass
- [x] Linter passes (`uv run ruff check .`)
- [x] New factory method tests added in `tests/unit/domain/test_entities.py`
- [x] Test fixtures updated to use factories for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)