### PR TITLE
refactor: move config merge logic from I/O layer to domain (#302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Domain-level config merging** (#302)
+  - Moved config merge logic from I/O layer to domain model
+  - Added `from_partial()` methods to all config dataclasses for type-safe merging
+  - `EmberConfig.from_partial(base, data)` merges partial config data with validation
+  - Sub-config classes (`IndexConfig`, `SearchConfig`, etc.) also have `from_partial()`
+  - Ensures merged configs are validated at each merge step
+  - Unknown config keys are now gracefully ignored (forward compatibility)
+  - Deprecated `merge_config_data()` in favor of domain merging
 - **RepoState factory methods** (#303)
   - Added `RepoState.uninitialized(version)` factory for creating initial states
   - Added `RepoState.from_sync(tree_sha, sync_mode, model_fingerprint, version)` factory for post-sync states

--- a/ember/adapters/config/toml_config_provider.py
+++ b/ember/adapters/config/toml_config_provider.py
@@ -13,10 +13,9 @@ from pathlib import Path
 
 from ember.domain.config import EmberConfig
 from ember.shared.config_io import (
-    config_data_to_ember_config,
+    _validate_model_name,
     get_global_config_path,
     load_config_data,
-    merge_config_data,
 )
 
 logger = logging.getLogger(__name__)
@@ -37,6 +36,9 @@ class TomlConfigProvider:
     def load(self, ember_dir: Path) -> EmberConfig:
         """Load configuration with global fallback.
 
+        Uses domain-level merging via EmberConfig.from_partial to ensure
+        validation happens at each merge step.
+
         Args:
             ember_dir: Path to .ember directory containing config.toml
 
@@ -46,14 +48,14 @@ class TomlConfigProvider:
         local_path = ember_dir / "config.toml"
         global_path = get_global_config_path()
 
-        # Start with empty data (defaults will be applied by dataclasses)
-        merged_data: dict = {}
+        # Start with built-in defaults
+        config = EmberConfig.default()
 
-        # Load global config if exists
+        # Apply global config overrides if exists
         if global_path.exists():
             try:
                 global_data = load_config_data(global_path)
-                merged_data = global_data
+                config = EmberConfig.from_partial(config, global_data)
                 logger.debug("Loaded global config from %s", global_path)
             except (FileNotFoundError, ValueError) as e:
                 logger.warning(
@@ -62,11 +64,11 @@ class TomlConfigProvider:
                     e,
                 )
 
-        # Load and merge local config if exists
+        # Apply local config overrides if exists
         if local_path.exists():
             try:
                 local_data = load_config_data(local_path)
-                merged_data = merge_config_data(merged_data, local_data)
+                config = EmberConfig.from_partial(config, local_data)
                 logger.debug("Loaded local config from %s", local_path)
             except (FileNotFoundError, ValueError) as e:
                 logger.warning(
@@ -74,16 +76,15 @@ class TomlConfigProvider:
                     e,
                 )
 
-        # If no config was loaded, return defaults
-        if not merged_data:
-            return EmberConfig.default()
-
-        # Convert merged data to EmberConfig
+        # Validate model name at config boundary (adapter layer)
+        # Model validation involves the registry (adapter), so it stays here
         try:
-            return config_data_to_ember_config(merged_data)
-        except (TypeError, ValueError) as e:
+            _validate_model_name(config.index.model)
+        except ValueError as e:
             logger.warning(
-                "Invalid config values: %s. Using default configuration.",
+                "Invalid model configuration: %s. Using default model.",
                 e,
             )
             return EmberConfig.default()
+
+        return config

--- a/ember/shared/config_io.py
+++ b/ember/shared/config_io.py
@@ -72,6 +72,11 @@ def load_config_data(path: Path) -> dict[str, Any]:
 def merge_config_data(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
     """Merge two config dictionaries, with override values taking precedence.
 
+    .. deprecated::
+        Use EmberConfig.from_partial() for config merging. This function performs
+        merging at the dict level without domain validation. The domain method
+        ensures validation at each merge step.
+
     Performs a shallow merge at the section level - if a section exists in override,
     its values completely replace the base section's values.
 

--- a/tests/unit/domain/test_config.py
+++ b/tests/unit/domain/test_config.py
@@ -4,6 +4,7 @@ import pytest
 
 from ember.domain.config import (
     DisplayConfig,
+    EmberConfig,
     IndexConfig,
     ModelConfig,
     RedactionConfig,
@@ -217,3 +218,218 @@ class TestDisplayConfigValidation:
         assert config.syntax_highlighting is False
         assert config.color_scheme == "always"
         assert config.theme == "monokai"
+
+
+# =============================================================================
+# Config from_partial merge tests
+# =============================================================================
+
+
+class TestIndexConfigFromPartial:
+    """Tests for IndexConfig.from_partial merge method."""
+
+    def test_from_partial_empty_dict_returns_base(self):
+        """Test that empty partial dict returns base values unchanged."""
+        base = IndexConfig(model="custom-model", line_window=200)
+        result = IndexConfig.from_partial(base, {})
+
+        assert result.model == "custom-model"
+        assert result.line_window == 200
+
+    def test_from_partial_overrides_specified_keys(self):
+        """Test that only specified keys are overridden."""
+        base = IndexConfig(model="base-model", line_window=120, batch_size=32)
+        result = IndexConfig.from_partial(base, {"model": "new-model"})
+
+        assert result.model == "new-model"
+        assert result.line_window == 120  # Unchanged
+        assert result.batch_size == 32  # Unchanged
+
+    def test_from_partial_validates_result(self):
+        """Test that merged config is validated."""
+        base = IndexConfig()
+        with pytest.raises(ValueError, match="line_window must be positive"):
+            IndexConfig.from_partial(base, {"line_window": 0})
+
+    def test_from_partial_override_multiple_fields(self):
+        """Test overriding multiple fields at once."""
+        base = IndexConfig()
+        result = IndexConfig.from_partial(
+            base,
+            {"model": "minilm", "chunk": "lines", "batch_size": 64},
+        )
+
+        assert result.model == "minilm"
+        assert result.chunk == "lines"
+        assert result.batch_size == 64
+
+
+class TestSearchConfigFromPartial:
+    """Tests for SearchConfig.from_partial merge method."""
+
+    def test_from_partial_empty_dict_returns_base(self):
+        """Test that empty partial dict returns base values unchanged."""
+        base = SearchConfig(topk=50, rerank=True)
+        result = SearchConfig.from_partial(base, {})
+
+        assert result.topk == 50
+        assert result.rerank is True
+
+    def test_from_partial_overrides_specified_keys(self):
+        """Test that only specified keys are overridden."""
+        base = SearchConfig(topk=20, rerank=False)
+        result = SearchConfig.from_partial(base, {"topk": 100})
+
+        assert result.topk == 100
+        assert result.rerank is False  # Unchanged
+
+    def test_from_partial_validates_result(self):
+        """Test that merged config is validated."""
+        base = SearchConfig()
+        with pytest.raises(ValueError, match="topk must be positive"):
+            SearchConfig.from_partial(base, {"topk": 0})
+
+
+class TestRedactionConfigFromPartial:
+    """Tests for RedactionConfig.from_partial merge method."""
+
+    def test_from_partial_empty_dict_returns_base(self):
+        """Test that empty partial dict returns base values unchanged."""
+        base = RedactionConfig(max_file_mb=10)
+        result = RedactionConfig.from_partial(base, {})
+
+        assert result.max_file_mb == 10
+
+    def test_from_partial_overrides_patterns(self):
+        """Test that patterns list can be overridden."""
+        base = RedactionConfig()
+        custom_patterns = [r"custom_pattern"]
+        result = RedactionConfig.from_partial(base, {"patterns": custom_patterns})
+
+        assert result.patterns == custom_patterns
+
+    def test_from_partial_validates_result(self):
+        """Test that merged config is validated."""
+        base = RedactionConfig()
+        with pytest.raises(ValueError, match="max_file_mb must be positive"):
+            RedactionConfig.from_partial(base, {"max_file_mb": 0})
+
+
+class TestModelConfigFromPartial:
+    """Tests for ModelConfig.from_partial merge method."""
+
+    def test_from_partial_empty_dict_returns_base(self):
+        """Test that empty partial dict returns base values unchanged."""
+        base = ModelConfig(mode="direct", daemon_timeout=600)
+        result = ModelConfig.from_partial(base, {})
+
+        assert result.mode == "direct"
+        assert result.daemon_timeout == 600
+
+    def test_from_partial_overrides_mode(self):
+        """Test that mode can be overridden."""
+        base = ModelConfig(mode="daemon")
+        result = ModelConfig.from_partial(base, {"mode": "direct"})
+
+        assert result.mode == "direct"
+
+    def test_from_partial_validates_result(self):
+        """Test that merged config is validated."""
+        base = ModelConfig()
+        with pytest.raises(ValueError, match="daemon_timeout must be positive"):
+            ModelConfig.from_partial(base, {"daemon_timeout": 0})
+
+
+class TestDisplayConfigFromPartial:
+    """Tests for DisplayConfig.from_partial merge method."""
+
+    def test_from_partial_empty_dict_returns_base(self):
+        """Test that empty partial dict returns base values unchanged."""
+        base = DisplayConfig(theme="monokai")
+        result = DisplayConfig.from_partial(base, {})
+
+        assert result.theme == "monokai"
+
+    def test_from_partial_overrides_specified_keys(self):
+        """Test that only specified keys are overridden."""
+        base = DisplayConfig(syntax_highlighting=True, theme="ansi")
+        result = DisplayConfig.from_partial(base, {"theme": "github-dark"})
+
+        assert result.syntax_highlighting is True  # Unchanged
+        assert result.theme == "github-dark"
+
+
+class TestEmberConfigFromPartial:
+    """Tests for EmberConfig.from_partial merge method."""
+
+    def test_from_partial_empty_dict_returns_base(self):
+        """Test that empty partial dict returns base config unchanged."""
+        base = EmberConfig.default()
+        result = EmberConfig.from_partial(base, {})
+
+        assert result.index.model == base.index.model
+        assert result.search.topk == base.search.topk
+
+    def test_from_partial_merges_single_section(self):
+        """Test merging a single section."""
+        base = EmberConfig.default()
+        result = EmberConfig.from_partial(base, {"search": {"topk": 100}})
+
+        assert result.search.topk == 100
+        assert result.index.model == base.index.model  # Other sections unchanged
+
+    def test_from_partial_merges_multiple_sections(self):
+        """Test merging multiple sections."""
+        base = EmberConfig.default()
+        result = EmberConfig.from_partial(
+            base,
+            {
+                "index": {"model": "minilm", "batch_size": 64},
+                "search": {"topk": 50, "rerank": True},
+                "display": {"theme": "monokai"},
+            },
+        )
+
+        assert result.index.model == "minilm"
+        assert result.index.batch_size == 64
+        assert result.search.topk == 50
+        assert result.search.rerank is True
+        assert result.display.theme == "monokai"
+
+    def test_from_partial_validates_all_sections(self):
+        """Test that validation runs on all merged sections."""
+        base = EmberConfig.default()
+
+        # Invalid index config
+        with pytest.raises(ValueError, match="line_window must be positive"):
+            EmberConfig.from_partial(base, {"index": {"line_window": 0}})
+
+        # Invalid search config
+        with pytest.raises(ValueError, match="topk must be positive"):
+            EmberConfig.from_partial(base, {"search": {"topk": -1}})
+
+    def test_from_partial_partial_section_override(self):
+        """Test that partial section overrides preserve unspecified keys."""
+        base = EmberConfig(
+            index=IndexConfig(model="base-model", line_window=200, batch_size=16)
+        )
+        result = EmberConfig.from_partial(base, {"index": {"model": "new-model"}})
+
+        assert result.index.model == "new-model"
+        assert result.index.line_window == 200  # Preserved
+        assert result.index.batch_size == 16  # Preserved
+
+    def test_from_partial_chained_merges(self):
+        """Test that multiple from_partial calls can be chained (global + local)."""
+        defaults = EmberConfig.default()
+
+        # Simulate global config
+        global_data = {"index": {"model": "jina-code-v2"}, "search": {"topk": 30}}
+        with_global = EmberConfig.from_partial(defaults, global_data)
+
+        # Simulate local config (overrides global)
+        local_data = {"search": {"topk": 10}}
+        final = EmberConfig.from_partial(with_global, local_data)
+
+        assert final.index.model == "jina-code-v2"  # From global
+        assert final.search.topk == 10  # Overridden by local


### PR DESCRIPTION
## Summary
- Moved config merge logic from I/O layer to domain model
- Added `from_partial()` methods to all config dataclasses for type-safe merging
- Updated TomlConfigProvider to use domain-level merging
- Deprecated `merge_config_data()` in favor of domain merging

## Changes
- `IndexConfig.from_partial(base, partial)` - merge index settings
- `SearchConfig.from_partial(base, partial)` - merge search settings  
- `RedactionConfig.from_partial(base, partial)` - merge redaction settings
- `ModelConfig.from_partial(base, partial)` - merge model/daemon settings
- `DisplayConfig.from_partial(base, partial)` - merge display settings
- `EmberConfig.from_partial(base, data)` - merge full config with all sections
- TomlConfigProvider now uses `EmberConfig.from_partial()` for config cascade
- Unknown config keys are gracefully ignored (forward compatibility)

## Acceptance Criteria
- [x] `EmberConfig.from_partial()` method in domain
- [x] Merged config is validated
- [x] I/O layer only handles serialization
- [x] Tests cover merge edge cases (21 new tests)

Implements #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)