### PR TITLE
refactor: extract factory functions from CLI to dedicated module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Extracted factory functions from CLI to dedicated module** (#320)
+  - Created `ember/adapters/factory.py` with `EmbedderFactory`, `UseCaseFactory`, `RepositoryFactory`, `DaemonFactory`, and `ConfigFactory` classes
+  - CLI no longer directly imports 9+ adapter classes for use case instantiation
+  - Factory classes use lazy imports to avoid loading heavy dependencies at module level
+  - Enables easier testing by allowing factories to be mocked instead of individual adapters
+  - Better separation between presentation layer (CLI) and infrastructure (adapters)
 - **Extracted sync error classification to core layer** (#319)
   - Moved `SyncErrorType` and `SyncResult` from CLI to `ember.domain.entities`
   - Created `classify_sync_error()` function in `ember.core.sync` module

--- a/ember/adapters/factory.py
+++ b/ember/adapters/factory.py
@@ -1,0 +1,361 @@
+"""Factory classes for use case and adapter instantiation.
+
+This module centralizes the creation of use cases and their dependencies,
+keeping the CLI layer free from direct adapter imports. This follows the
+Clean Architecture principle that presentation layers should not know
+about concrete infrastructure implementations.
+
+The factories use lazy imports to avoid loading heavy dependencies
+(like ML models) until they're actually needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from ember.core.indexing.index_usecase import IndexingUseCase
+    from ember.core.retrieval.search_usecase import SearchUseCase
+    from ember.domain.config import EmberConfig
+
+
+class Embedder(Protocol):
+    """Protocol for embedder implementations."""
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def dim(self) -> int: ...
+
+    def fingerprint(self) -> str: ...
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]: ...
+
+    def ensure_loaded(self) -> None: ...
+
+
+class EmbedderFactory:
+    """Factory for creating embedder instances.
+
+    Handles the complexity of daemon vs direct mode, daemon lifecycle
+    management, and progress display.
+
+    Args:
+        config: EmberConfig with model and daemon settings.
+    """
+
+    def __init__(self, config: EmberConfig) -> None:
+        """Initialize factory with configuration.
+
+        Args:
+            config: Configuration containing model and daemon settings.
+        """
+        self._config = config
+
+    def create_embedder(self, show_progress: bool = True) -> Embedder:
+        """Create embedder based on configuration.
+
+        Args:
+            show_progress: Show progress bar during daemon startup.
+
+        Returns:
+            Embedder instance (daemon client or direct).
+
+        Raises:
+            RuntimeError: If daemon fails to start.
+            ValueError: If model name is not recognized.
+        """
+        model_name = self._config.index.model
+        batch_size = self._config.index.batch_size
+
+        if self._config.model.mode == "daemon":
+            return self._create_daemon_embedder(model_name, batch_size, show_progress)
+        else:
+            return self._create_direct_embedder(model_name, batch_size)
+
+    def _create_daemon_embedder(
+        self,
+        model_name: str,
+        batch_size: int,
+        show_progress: bool,
+    ) -> Embedder:
+        """Create daemon-based embedder.
+
+        Args:
+            model_name: Name of the embedding model.
+            batch_size: Batch size for embedding.
+            show_progress: Show progress during daemon startup.
+
+        Returns:
+            DaemonEmbedderClient instance.
+        """
+        # Lazy imports to avoid loading heavy dependencies at module level
+        from ember.adapters.daemon.client import DaemonEmbedderClient
+        from ember.adapters.daemon.lifecycle import DaemonLifecycle
+        from ember.core.cli_utils import ensure_daemon_with_progress
+
+        daemon_manager = DaemonLifecycle(
+            idle_timeout=self._config.model.daemon_timeout,
+            model_name=model_name,
+            batch_size=batch_size,
+        )
+
+        # Start daemon if not already running
+        if not daemon_manager.is_running():
+            if show_progress:
+                ensure_daemon_with_progress(daemon_manager, quiet=False)
+            else:
+                daemon_manager.start(foreground=False)
+
+        return DaemonEmbedderClient(
+            fallback=True,
+            auto_start=False,  # Daemon already started above
+            daemon_timeout=self._config.model.daemon_timeout,
+            model_name=model_name,
+            batch_size=batch_size,
+        )
+
+    def _create_direct_embedder(
+        self,
+        model_name: str,
+        batch_size: int,
+    ) -> Embedder:
+        """Create direct embedder (no daemon).
+
+        Args:
+            model_name: Name of the embedding model.
+            batch_size: Batch size for embedding.
+
+        Returns:
+            Direct embedder instance.
+        """
+        # Lazy import
+        from ember.adapters.local_models.registry import (
+            create_embedder as create_embedder_from_registry,
+        )
+
+        return create_embedder_from_registry(
+            model_name=model_name,
+            batch_size=batch_size,
+        )
+
+
+# Module-level alias for direct embedder creation (used by _create_direct_embedder)
+def create_embedder_from_registry(model_name: str, batch_size: int) -> Embedder:
+    """Create embedder directly from registry.
+
+    This is a module-level function that provides access to the registry's
+    create_embedder function with lazy import.
+    """
+    from ember.adapters.local_models.registry import create_embedder
+
+    return create_embedder(model_name=model_name, batch_size=batch_size)
+
+
+class DaemonFactory:
+    """Factory for creating daemon-related instances.
+
+    Handles daemon lifecycle management for daemon commands.
+    """
+
+    def create_daemon_lifecycle(
+        self,
+        idle_timeout: int = 900,
+        model_name: str | None = None,
+        batch_size: int = 32,
+    ):
+        """Create a DaemonLifecycle instance.
+
+        Args:
+            idle_timeout: Idle timeout in seconds.
+            model_name: Name of the embedding model.
+            batch_size: Batch size for embedding.
+
+        Returns:
+            DaemonLifecycle instance.
+        """
+        from ember.adapters.daemon.lifecycle import DaemonLifecycle
+
+        return DaemonLifecycle(
+            idle_timeout=idle_timeout,
+            model_name=model_name,
+            batch_size=batch_size,
+        )
+
+
+class ConfigFactory:
+    """Factory for creating configuration-related instances."""
+
+    def create_config_provider(self):
+        """Create a TomlConfigProvider instance.
+
+        Returns:
+            TomlConfigProvider instance.
+        """
+        from ember.adapters.config.toml_config_provider import TomlConfigProvider
+
+        return TomlConfigProvider()
+
+    def create_db_initializer(self):
+        """Create a SqliteDatabaseInitializer instance.
+
+        Returns:
+            SqliteDatabaseInitializer instance.
+        """
+        from ember.adapters.sqlite.initializer import SqliteDatabaseInitializer
+
+        return SqliteDatabaseInitializer()
+
+
+class RepositoryFactory:
+    """Factory for creating lightweight repository instances.
+
+    Used for quick operations like staleness checks that don't need
+    the full use case infrastructure.
+    """
+
+    def create_git_adapter(self, repo_root: Path):
+        """Create a GitAdapter instance.
+
+        Args:
+            repo_root: Repository root path.
+
+        Returns:
+            GitAdapter instance.
+        """
+        from ember.adapters.git_cmd.git_adapter import GitAdapter
+
+        return GitAdapter(repo_root)
+
+    def create_meta_repository(self, db_path: Path):
+        """Create a SQLiteMetaRepository instance.
+
+        Args:
+            db_path: Path to the SQLite database.
+
+        Returns:
+            SQLiteMetaRepository instance.
+        """
+        from ember.adapters.sqlite.meta_repository import SQLiteMetaRepository
+
+        return SQLiteMetaRepository(db_path)
+
+    def create_chunk_repository(self, db_path: Path):
+        """Create a SQLiteChunkRepository instance.
+
+        Args:
+            db_path: Path to the SQLite database.
+
+        Returns:
+            SQLiteChunkRepository instance.
+        """
+        from ember.adapters.sqlite.chunk_repository import SQLiteChunkRepository
+
+        return SQLiteChunkRepository(db_path)
+
+
+class UseCaseFactory:
+    """Factory for creating use case instances with all dependencies.
+
+    Centralizes the complex dependency wiring for use cases, keeping
+    the CLI layer clean and testable.
+    """
+
+    def create_search_usecase(
+        self,
+        db_path: Path,
+        embedder: Embedder,
+    ) -> SearchUseCase:
+        """Create SearchUseCase with all required dependencies.
+
+        Args:
+            db_path: Path to the SQLite database.
+            embedder: Embedder instance for query vectorization.
+
+        Returns:
+            Configured SearchUseCase ready for search operations.
+        """
+        # Lazy imports
+        from ember.adapters.fts.sqlite_fts import SQLiteFTS
+        from ember.adapters.sqlite.chunk_repository import SQLiteChunkRepository
+        from ember.adapters.vss.sqlite_vec_adapter import SqliteVecAdapter
+        from ember.core.retrieval.search_usecase import SearchUseCase
+
+        text_search = SQLiteFTS(db_path)
+        vector_search = SqliteVecAdapter(db_path, vector_dim=embedder.dim)
+        chunk_repo = SQLiteChunkRepository(db_path)
+
+        return SearchUseCase(
+            text_search=text_search,
+            vector_search=vector_search,
+            chunk_repo=chunk_repo,
+            embedder=embedder,
+        )
+
+    def create_indexing_usecase(
+        self,
+        repo_root: Path,
+        db_path: Path,
+        config: EmberConfig,
+        embedder: Embedder,
+    ) -> IndexingUseCase:
+        """Create IndexingUseCase with all dependencies.
+
+        Args:
+            repo_root: Repository root path.
+            db_path: Path to SQLite database.
+            config: Configuration object with index settings.
+            embedder: Embedder instance for generating embeddings.
+
+        Returns:
+            Initialized IndexingUseCase instance.
+        """
+        # Lazy imports
+        import blake3
+
+        from ember.adapters.fs.local import LocalFileSystem
+        from ember.adapters.git_cmd.git_adapter import GitAdapter
+        from ember.adapters.parsers.line_chunker import LineChunker
+        from ember.adapters.parsers.tree_sitter_chunker import TreeSitterChunker
+        from ember.adapters.sqlite.chunk_repository import SQLiteChunkRepository
+        from ember.adapters.sqlite.file_repository import SQLiteFileRepository
+        from ember.adapters.sqlite.meta_repository import SQLiteMetaRepository
+        from ember.adapters.sqlite.vector_repository import SQLiteVectorRepository
+        from ember.core.chunking.chunk_usecase import ChunkFileUseCase
+        from ember.core.indexing.index_usecase import IndexingUseCase
+
+        # Initialize dependencies
+        vcs = GitAdapter(repo_root)
+        fs = LocalFileSystem()
+
+        # Initialize repositories
+        chunk_repo = SQLiteChunkRepository(db_path)
+        vector_repo = SQLiteVectorRepository(db_path, expected_dim=embedder.dim)
+        file_repo = SQLiteFileRepository(db_path)
+        meta_repo = SQLiteMetaRepository(db_path)
+
+        # Initialize chunking use case with config settings
+        tree_sitter = TreeSitterChunker()
+        line_chunker = LineChunker(
+            window_size=config.index.line_window,
+            stride=config.index.line_stride,
+        )
+        chunk_usecase = ChunkFileUseCase(tree_sitter, line_chunker)
+
+        # Compute project ID (hash of repo root path)
+        project_id = blake3.blake3(str(repo_root).encode("utf-8")).hexdigest()
+
+        # Create and return indexing use case
+        return IndexingUseCase(
+            vcs=vcs,
+            fs=fs,
+            chunk_usecase=chunk_usecase,
+            embedder=embedder,
+            chunk_repo=chunk_repo,
+            vector_repo=vector_repo,
+            file_repo=file_repo,
+            meta_repo=meta_repo,
+            project_id=project_id,
+        )

--- a/tests/unit/adapters/test_factory.py
+++ b/tests/unit/adapters/test_factory.py
@@ -1,0 +1,391 @@
+"""Unit tests for use case factory module.
+
+Tests the factory classes that centralize adapter instantiation,
+ensuring clean architecture separation between CLI and adapters.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ember.adapters.factory import (
+    ConfigFactory,
+    DaemonFactory,
+    EmbedderFactory,
+    RepositoryFactory,
+    UseCaseFactory,
+)
+from ember.domain.config import EmberConfig
+
+
+class TestEmbedderFactory:
+    """Tests for EmbedderFactory class."""
+
+    def test_create_daemon_embedder_when_running(self):
+        """When daemon is running, should return client without starting daemon."""
+        config = EmberConfig.default()
+
+        with patch(
+            "ember.adapters.daemon.lifecycle.DaemonLifecycle"
+        ) as mock_lifecycle_cls, patch(
+            "ember.adapters.daemon.client.DaemonEmbedderClient"
+        ) as mock_client_cls:
+            mock_lifecycle = MagicMock()
+            mock_lifecycle.is_running.return_value = True
+            mock_lifecycle_cls.return_value = mock_lifecycle
+
+            mock_client = MagicMock()
+            mock_client_cls.return_value = mock_client
+
+            factory = EmbedderFactory(config)
+            result = factory.create_embedder(show_progress=True)
+
+            assert result == mock_client
+            mock_lifecycle.is_running.assert_called_once()
+            # Should not attempt to start daemon
+            mock_lifecycle.start.assert_not_called()
+
+    def test_create_daemon_embedder_starts_daemon_with_progress(self):
+        """When daemon not running and show_progress=True, start with progress."""
+        config = EmberConfig.default()
+
+        with patch(
+            "ember.adapters.daemon.lifecycle.DaemonLifecycle"
+        ) as mock_lifecycle_cls, patch(
+            "ember.adapters.daemon.client.DaemonEmbedderClient"
+        ) as mock_client_cls, patch(
+            "ember.core.cli_utils.ensure_daemon_with_progress"
+        ) as mock_ensure:
+            mock_lifecycle = MagicMock()
+            mock_lifecycle.is_running.return_value = False
+            mock_lifecycle_cls.return_value = mock_lifecycle
+
+            mock_client = MagicMock()
+            mock_client_cls.return_value = mock_client
+
+            factory = EmbedderFactory(config)
+            result = factory.create_embedder(show_progress=True)
+
+            assert result == mock_client
+            mock_ensure.assert_called_once_with(mock_lifecycle, quiet=False)
+
+    def test_create_daemon_embedder_starts_silently_without_progress(self):
+        """When daemon not running and show_progress=False, start silently."""
+        config = EmberConfig.default()
+
+        with patch(
+            "ember.adapters.daemon.lifecycle.DaemonLifecycle"
+        ) as mock_lifecycle_cls, patch(
+            "ember.adapters.daemon.client.DaemonEmbedderClient"
+        ) as mock_client_cls:
+            mock_lifecycle = MagicMock()
+            mock_lifecycle.is_running.return_value = False
+            mock_lifecycle_cls.return_value = mock_lifecycle
+
+            mock_client = MagicMock()
+            mock_client_cls.return_value = mock_client
+
+            factory = EmbedderFactory(config)
+            result = factory.create_embedder(show_progress=False)
+
+            assert result == mock_client
+            mock_lifecycle.start.assert_called_once_with(foreground=False)
+
+    def test_create_direct_embedder(self):
+        """When mode is direct, should create embedder directly."""
+        from ember.domain.config import ModelConfig
+
+        config = EmberConfig(model=ModelConfig(mode="direct"))
+
+        with patch(
+            "ember.adapters.local_models.registry.create_embedder"
+        ) as mock_create:
+            mock_embedder = MagicMock()
+            mock_create.return_value = mock_embedder
+
+            factory = EmbedderFactory(config)
+            result = factory.create_embedder()
+
+            assert result == mock_embedder
+            mock_create.assert_called_once_with(
+                model_name=config.index.model,
+                batch_size=config.index.batch_size,
+            )
+
+
+class TestUseCaseFactory:
+    """Tests for UseCaseFactory class."""
+
+    @pytest.fixture
+    def mock_embedder(self):
+        """Create a mock embedder with required properties."""
+        embedder = MagicMock()
+        embedder.dim = 768
+        return embedder
+
+    def test_create_search_usecase(self, mock_embedder):
+        """Should create SearchUseCase with all dependencies."""
+        db_path = Path("/tmp/test.db")
+
+        with patch(
+            "ember.adapters.fts.sqlite_fts.SQLiteFTS"
+        ) as mock_fts_cls, patch(
+            "ember.adapters.vss.sqlite_vec_adapter.SqliteVecAdapter"
+        ) as mock_vec_cls, patch(
+            "ember.adapters.sqlite.chunk_repository.SQLiteChunkRepository"
+        ) as mock_chunk_cls, patch(
+            "ember.core.retrieval.search_usecase.SearchUseCase"
+        ) as mock_usecase_cls:
+            mock_fts = MagicMock()
+            mock_fts_cls.return_value = mock_fts
+
+            mock_vec = MagicMock()
+            mock_vec_cls.return_value = mock_vec
+
+            mock_chunk_repo = MagicMock()
+            mock_chunk_cls.return_value = mock_chunk_repo
+
+            mock_usecase = MagicMock()
+            mock_usecase_cls.return_value = mock_usecase
+
+            factory = UseCaseFactory()
+            result = factory.create_search_usecase(db_path, mock_embedder)
+
+            assert result == mock_usecase
+            mock_fts_cls.assert_called_once_with(db_path)
+            mock_vec_cls.assert_called_once_with(db_path, vector_dim=768)
+            mock_chunk_cls.assert_called_once_with(db_path)
+            mock_usecase_cls.assert_called_once_with(
+                text_search=mock_fts,
+                vector_search=mock_vec,
+                chunk_repo=mock_chunk_repo,
+                embedder=mock_embedder,
+            )
+
+    def test_create_indexing_usecase(self, mock_embedder):
+        """Should create IndexingUseCase with all dependencies."""
+        repo_root = Path("/tmp/repo")
+        db_path = Path("/tmp/test.db")
+        config = EmberConfig.default()
+
+        with patch(
+            "ember.adapters.git_cmd.git_adapter.GitAdapter"
+        ) as mock_git_cls, patch(
+            "ember.adapters.fs.local.LocalFileSystem"
+        ) as mock_fs_cls, patch(
+            "ember.adapters.sqlite.chunk_repository.SQLiteChunkRepository"
+        ) as mock_chunk_cls, patch(
+            "ember.adapters.sqlite.vector_repository.SQLiteVectorRepository"
+        ) as mock_vec_cls, patch(
+            "ember.adapters.sqlite.file_repository.SQLiteFileRepository"
+        ) as mock_file_cls, patch(
+            "ember.adapters.sqlite.meta_repository.SQLiteMetaRepository"
+        ) as mock_meta_cls, patch(
+            "ember.adapters.parsers.tree_sitter_chunker.TreeSitterChunker"
+        ) as mock_ts_cls, patch(
+            "ember.adapters.parsers.line_chunker.LineChunker"
+        ) as mock_line_cls, patch(
+            "ember.core.chunking.chunk_usecase.ChunkFileUseCase"
+        ) as mock_chunk_usecase_cls, patch(
+            "ember.core.indexing.index_usecase.IndexingUseCase"
+        ) as mock_indexing_cls:
+            # Setup mocks
+            mock_git = MagicMock()
+            mock_git_cls.return_value = mock_git
+
+            mock_fs = MagicMock()
+            mock_fs_cls.return_value = mock_fs
+
+            mock_chunk_repo = MagicMock()
+            mock_chunk_cls.return_value = mock_chunk_repo
+
+            mock_vec_repo = MagicMock()
+            mock_vec_cls.return_value = mock_vec_repo
+
+            mock_file_repo = MagicMock()
+            mock_file_cls.return_value = mock_file_repo
+
+            mock_meta_repo = MagicMock()
+            mock_meta_cls.return_value = mock_meta_repo
+
+            mock_ts = MagicMock()
+            mock_ts_cls.return_value = mock_ts
+
+            mock_line = MagicMock()
+            mock_line_cls.return_value = mock_line
+
+            mock_chunk_usecase = MagicMock()
+            mock_chunk_usecase_cls.return_value = mock_chunk_usecase
+
+            mock_indexing = MagicMock()
+            mock_indexing_cls.return_value = mock_indexing
+
+            factory = UseCaseFactory()
+            result = factory.create_indexing_usecase(
+                repo_root, db_path, config, mock_embedder
+            )
+
+            assert result == mock_indexing
+            mock_git_cls.assert_called_once_with(repo_root)
+            mock_fs_cls.assert_called_once()
+            mock_chunk_cls.assert_called_once_with(db_path)
+            mock_vec_cls.assert_called_once_with(db_path, expected_dim=768)
+            mock_file_cls.assert_called_once_with(db_path)
+            mock_meta_cls.assert_called_once_with(db_path)
+            mock_line_cls.assert_called_once_with(
+                window_size=config.index.line_window,
+                stride=config.index.line_stride,
+            )
+
+
+class TestRepositoryFactory:
+    """Tests for RepositoryFactory class."""
+
+    def test_create_git_adapter(self):
+        """Should create GitAdapter instance."""
+        repo_root = Path("/tmp/repo")
+
+        with patch(
+            "ember.adapters.git_cmd.git_adapter.GitAdapter"
+        ) as mock_git_cls:
+            mock_git = MagicMock()
+            mock_git_cls.return_value = mock_git
+
+            factory = RepositoryFactory()
+            result = factory.create_git_adapter(repo_root)
+
+            assert result == mock_git
+            mock_git_cls.assert_called_once_with(repo_root)
+
+    def test_create_meta_repository(self):
+        """Should create SQLiteMetaRepository instance."""
+        db_path = Path("/tmp/test.db")
+
+        with patch(
+            "ember.adapters.sqlite.meta_repository.SQLiteMetaRepository"
+        ) as mock_meta_cls:
+            mock_meta = MagicMock()
+            mock_meta_cls.return_value = mock_meta
+
+            factory = RepositoryFactory()
+            result = factory.create_meta_repository(db_path)
+
+            assert result == mock_meta
+            mock_meta_cls.assert_called_once_with(db_path)
+
+    def test_create_chunk_repository(self):
+        """Should create SQLiteChunkRepository instance."""
+        db_path = Path("/tmp/test.db")
+
+        with patch(
+            "ember.adapters.sqlite.chunk_repository.SQLiteChunkRepository"
+        ) as mock_chunk_cls:
+            mock_chunk = MagicMock()
+            mock_chunk_cls.return_value = mock_chunk
+
+            factory = RepositoryFactory()
+            result = factory.create_chunk_repository(db_path)
+
+            assert result == mock_chunk
+            mock_chunk_cls.assert_called_once_with(db_path)
+
+
+class TestDaemonFactory:
+    """Tests for DaemonFactory class."""
+
+    def test_create_daemon_lifecycle(self):
+        """Should create DaemonLifecycle with parameters."""
+        with patch(
+            "ember.adapters.daemon.lifecycle.DaemonLifecycle"
+        ) as mock_lifecycle_cls:
+            mock_lifecycle = MagicMock()
+            mock_lifecycle_cls.return_value = mock_lifecycle
+
+            factory = DaemonFactory()
+            result = factory.create_daemon_lifecycle(
+                idle_timeout=600,
+                model_name="test-model",
+                batch_size=16,
+            )
+
+            assert result == mock_lifecycle
+            mock_lifecycle_cls.assert_called_once_with(
+                idle_timeout=600,
+                model_name="test-model",
+                batch_size=16,
+            )
+
+    def test_create_daemon_lifecycle_defaults(self):
+        """Should create DaemonLifecycle with default parameters."""
+        with patch(
+            "ember.adapters.daemon.lifecycle.DaemonLifecycle"
+        ) as mock_lifecycle_cls:
+            mock_lifecycle = MagicMock()
+            mock_lifecycle_cls.return_value = mock_lifecycle
+
+            factory = DaemonFactory()
+            result = factory.create_daemon_lifecycle()
+
+            assert result == mock_lifecycle
+            mock_lifecycle_cls.assert_called_once_with(
+                idle_timeout=900,
+                model_name=None,
+                batch_size=32,
+            )
+
+
+class TestConfigFactory:
+    """Tests for ConfigFactory class."""
+
+    def test_create_config_provider(self):
+        """Should create TomlConfigProvider instance."""
+        with patch(
+            "ember.adapters.config.toml_config_provider.TomlConfigProvider"
+        ) as mock_provider_cls:
+            mock_provider = MagicMock()
+            mock_provider_cls.return_value = mock_provider
+
+            factory = ConfigFactory()
+            result = factory.create_config_provider()
+
+            assert result == mock_provider
+            mock_provider_cls.assert_called_once()
+
+    def test_create_db_initializer(self):
+        """Should create SqliteDatabaseInitializer instance."""
+        with patch(
+            "ember.adapters.sqlite.initializer.SqliteDatabaseInitializer"
+        ) as mock_init_cls:
+            mock_init = MagicMock()
+            mock_init_cls.return_value = mock_init
+
+            factory = ConfigFactory()
+            result = factory.create_db_initializer()
+
+            assert result == mock_init
+            mock_init_cls.assert_called_once()
+
+
+class TestFactoryIntegration:
+    """Integration tests for factory classes working together."""
+
+    def test_factory_module_imports_cleanly(self):
+        """Verify factory module can be imported without side effects."""
+        import importlib
+        import sys
+
+        # Remove cached module if exists
+        module_name = "ember.adapters.factory"
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+
+        # Should import without errors
+        module = importlib.import_module(module_name)
+
+        # Verify all expected classes are present
+        assert hasattr(module, "EmbedderFactory")
+        assert hasattr(module, "UseCaseFactory")
+        assert hasattr(module, "RepositoryFactory")
+        assert hasattr(module, "DaemonFactory")
+        assert hasattr(module, "ConfigFactory")


### PR DESCRIPTION
## Summary

- Create `ember/adapters/factory.py` module with factory classes that centralize adapter instantiation
- Update CLI to use factories instead of direct adapter imports
- Add comprehensive unit tests for all factory classes

## Changes

### New Factory Classes

- **EmbedderFactory**: Handles daemon vs direct mode embedder creation
- **UseCaseFactory**: Creates `IndexingUseCase` and `SearchUseCase` with all dependencies  
- **RepositoryFactory**: Creates lightweight repo instances (GitAdapter, MetaRepository, ChunkRepository)
- **DaemonFactory**: Creates `DaemonLifecycle` for daemon commands
- **ConfigFactory**: Creates config providers and database initializers

### CLI Updates

The following CLI functions now use factories instead of direct adapter imports:
- `_create_embedder()` → `EmbedderFactory`
- `_create_search_usecase()` → `UseCaseFactory`
- `_create_indexing_usecase()` → `UseCaseFactory` + `EmbedderFactory`
- `ensure_synced()` → `RepositoryFactory` for staleness checks
- `_quick_check_unchanged()` → `RepositoryFactory`
- All daemon commands → `DaemonFactory`
- All config commands → `ConfigFactory`
- `init` command → `ConfigFactory`
- `status` command → `ConfigFactory` + `RepositoryFactory`

### Architecture Benefits

1. **Clean Architecture Compliance**: CLI layer no longer directly imports 9+ adapter classes
2. **Testability**: Factories can be mocked instead of individual adapters
3. **Lazy Loading**: All factory methods use lazy imports to avoid loading heavy dependencies until needed
4. **Separation of Concerns**: Better separation between presentation layer (CLI) and infrastructure (adapters)

## Test Plan

- [x] All existing tests pass (1056 passed)
- [x] 14 new unit tests for factory classes
- [x] Linter passes

Implements #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)