### PR TITLE
feat: add validation to domain entities (#322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Domain entity validation** (#322)
+  - `Chunk` validates `content_hash` and `file_hash` are 64-char lowercase hex blake3 hashes
+  - `Chunk` validates `tree_sha` is empty or 40-char lowercase hex git SHA
+  - `Chunk` validates `lang` is a supported language code from `SUPPORTED_LANGUAGES`
+  - `Chunk` validates `content` is not empty/whitespace
+  - `SearchExplanation` validates all scores are in range [0.0, 1.0]
+  - `RepoState` validates initialized state (non-empty tree_sha) requires model_fingerprint
+
 ### Changed
 - **Extracted SQLite base repository class to reduce duplication** (#321)
   - Created `SQLiteBaseRepository` base class with thread-safe connection management

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,6 +197,7 @@ def sample_chunk() -> Chunk:
     Returns:
         A Chunk instance with test data.
     """
+    content = 'def test_function():\n    return "hello"'
     return Chunk(
         id="test_chunk_123",
         project_id="test_project",
@@ -205,10 +206,10 @@ def sample_chunk() -> Chunk:
         symbol="test_function",
         start_line=10,
         end_line=20,
-        content='def test_function():\n    return "hello"',
-        content_hash=Chunk.compute_content_hash('def test_function():\n    return "hello"'),
-        file_hash="abc123",
-        tree_sha="def456",
+        content=content,
+        content_hash=Chunk.compute_content_hash(content),
+        file_hash=Chunk.compute_content_hash("file content"),  # Valid blake3 hash
+        tree_sha="a" * 40,  # Valid git SHA
         rev="HEAD",
     )
 
@@ -225,6 +226,7 @@ def sample_chunks() -> list[Chunk]:
         # Start lines at 1 (1-indexed) to satisfy validation
         start_line = (i * 10) + 1
         end_line = start_line + 10
+        content = f"def function_{i}():\n    pass"
         chunk = Chunk(
             id=f"chunk_{i}",
             project_id="test_project",
@@ -233,10 +235,10 @@ def sample_chunks() -> list[Chunk]:
             symbol=f"function_{i}",
             start_line=start_line,
             end_line=end_line,
-            content=f"def function_{i}():\n    pass",
-            content_hash=Chunk.compute_content_hash(f"def function_{i}():\n    pass"),
-            file_hash=f"hash_{i}",
-            tree_sha="tree_sha_test",
+            content=content,
+            content_hash=Chunk.compute_content_hash(content),
+            file_hash=Chunk.compute_content_hash(f"file_{i}_content"),  # Valid blake3 hash
+            tree_sha="b" * 40,  # Valid git SHA
             rev="HEAD",
         )
         chunks.append(chunk)

--- a/tests/integration/test_chunk_repository.py
+++ b/tests/integration/test_chunk_repository.py
@@ -28,6 +28,7 @@ def chunk_repo(db_path: Path) -> SQLiteChunkRepository:
 @pytest.fixture
 def sample_chunk() -> Chunk:
     """Create a sample chunk for testing."""
+    content = "def my_function():\n    pass"
     return Chunk(
         id="a1b2c3d4e5f6789012345678901234567890123456789012345678901234abcd",
         project_id="test_project",
@@ -36,10 +37,10 @@ def sample_chunk() -> Chunk:
         symbol="my_function",
         start_line=10,
         end_line=20,
-        content="def my_function():\n    pass",
-        content_hash="hash123",
-        file_hash="file_hash123",
-        tree_sha="tree123",
+        content=content,
+        content_hash=Chunk.compute_content_hash(content),
+        file_hash=Chunk.compute_content_hash("file1"),
+        tree_sha="a" * 40,
         rev="HEAD",
     )
 
@@ -47,6 +48,7 @@ def sample_chunk() -> Chunk:
 @pytest.fixture
 def another_chunk() -> Chunk:
     """Create another sample chunk with a different ID."""
+    content = "def helper_function():\n    return True"
     return Chunk(
         id="b9876543210fedcba0987654321098765432109876543210987654321098765",
         project_id="test_project",
@@ -55,10 +57,10 @@ def another_chunk() -> Chunk:
         symbol="helper_function",
         start_line=5,
         end_line=15,
-        content="def helper_function():\n    return True",
-        content_hash="hash456",
-        file_hash="file_hash456",
-        tree_sha="tree456",
+        content=content,
+        content_hash=Chunk.compute_content_hash(content),
+        file_hash=Chunk.compute_content_hash("file2"),
+        tree_sha="b" * 40,
         rev="HEAD",
     )
 

--- a/tests/integration/test_missing_chunks_bug.py
+++ b/tests/integration/test_missing_chunks_bug.py
@@ -42,10 +42,10 @@ def test_fts_returns_stored_chunk_ids(db_path: Path) -> None:
         end_line=3,
         content=content,
         symbol="test_function",
-        lang="python",
+        lang="py",
         content_hash=content_hash,
         file_hash=content_hash,
-        tree_sha="abc123",
+        tree_sha="a" * 40,
         rev="worktree",
     )
     chunk_repo.add(chunk)
@@ -92,10 +92,10 @@ def test_vector_search_returns_stored_chunk_ids(db_path: Path) -> None:
         end_line=3,
         content=content,
         symbol="test_function",
-        lang="python",
+        lang="py",
         content_hash=content_hash,
         file_hash=content_hash,
-        tree_sha="abc123",
+        tree_sha="b" * 40,
         rev="worktree",
     )
     chunk_repo.add(chunk)
@@ -157,10 +157,10 @@ def test_search_no_missing_chunks_warning(
             end_line=end,
             content=content,
             symbol=symbol,
-            lang="python",
+            lang="py",
             content_hash=content_hash,
             file_hash=content_hash,
-            tree_sha="abc123",
+            tree_sha="c" * 40,
             rev="worktree",
         )
         chunk_repo.add(chunk)

--- a/tests/integration/test_search_usecase.py
+++ b/tests/integration/test_search_usecase.py
@@ -31,7 +31,7 @@ def sample_chunks() -> list[Chunk]:
             "end_line": 3,
             "content": "def add(a, b):\n    return a + b",
             "symbol": "add",
-            "lang": "python",
+            "lang": "py",
         },
         {
             "project_id": "test",
@@ -40,7 +40,7 @@ def sample_chunks() -> list[Chunk]:
             "end_line": 7,
             "content": "def multiply(a, b):\n    return a * b",
             "symbol": "multiply",
-            "lang": "python",
+            "lang": "py",
         },
         {
             "project_id": "test",
@@ -49,7 +49,7 @@ def sample_chunks() -> list[Chunk]:
             "end_line": 5,
             "content": "function greet(name: string): string {\n  return `Hello, ${name}!`;\n}",
             "symbol": "greet",
-            "lang": "typescript",
+            "lang": "ts",
         },
         {
             "project_id": "test",
@@ -58,7 +58,7 @@ def sample_chunks() -> list[Chunk]:
             "end_line": 11,
             "content": "function farewell(name: string): string {\n  return `Goodbye, ${name}!`;\n}",
             "symbol": "farewell",
-            "lang": "typescript",
+            "lang": "ts",
         },
     ]
 
@@ -82,7 +82,7 @@ def sample_chunks() -> list[Chunk]:
             content=data["content"],
             content_hash=content_hash,
             file_hash=file_hash,
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             rev="worktree",
         )
         chunks.append(chunk)
@@ -525,6 +525,8 @@ def test_missing_chunks_logged(db_path: Path, caplog: pytest.LogCaptureFixture) 
 
     # Create a mock chunk repository that returns None for some chunks
     chunk_repo = MagicMock()
+    content1 = "def test1(): pass"
+    content2 = "def test2(): pass"
     real_chunks = {
         "chunk_1": Chunk(
             id="chunk_1",
@@ -532,12 +534,12 @@ def test_missing_chunks_logged(db_path: Path, caplog: pytest.LogCaptureFixture) 
             path=Path("test.py"),
             start_line=1,
             end_line=3,
-            content="def test1(): pass",
+            content=content1,
             symbol="test1",
-            lang="python",
-            content_hash="hash1",
-            file_hash="file_hash1",
-            tree_sha="abc123",
+            lang="py",
+            content_hash=Chunk.compute_content_hash(content1),
+            file_hash=Chunk.compute_content_hash("file1"),
+            tree_sha="a" * 40,
             rev="worktree",
         ),
         "chunk_2": Chunk(
@@ -546,12 +548,12 @@ def test_missing_chunks_logged(db_path: Path, caplog: pytest.LogCaptureFixture) 
             path=Path("test.py"),
             start_line=5,
             end_line=7,
-            content="def test2(): pass",
+            content=content2,
             symbol="test2",
-            lang="python",
-            content_hash="hash2",
-            file_hash="file_hash2",
-            tree_sha="abc123",
+            lang="py",
+            content_hash=Chunk.compute_content_hash(content2),
+            file_hash=Chunk.compute_content_hash("file2"),
+            tree_sha="a" * 40,
             rev="worktree",
         ),
     }

--- a/tests/integration/test_sqlite_thread_safety.py
+++ b/tests/integration/test_sqlite_thread_safety.py
@@ -42,8 +42,8 @@ def sample_chunk() -> Chunk:
         end_line=1,
         content=content,
         content_hash=Chunk.compute_content_hash(content),
-        file_hash="file-hash",
-        tree_sha="tree-sha",
+        file_hash=Chunk.compute_content_hash("file content"),
+        tree_sha="a" * 40,
         rev="worktree",
     )
 

--- a/tests/unit/adapters/test_search_ui.py
+++ b/tests/unit/adapters/test_search_ui.py
@@ -57,8 +57,8 @@ def sample_python_chunk() -> Chunk:
         end_line=4,
         content=content,
         content_hash=Chunk.compute_content_hash(content),
-        file_hash="file_hash_123",
-        tree_sha="abc123",
+        file_hash=Chunk.compute_content_hash("file content 1"),
+        tree_sha="a" * 40,
         rev="worktree",
     )
 
@@ -186,8 +186,8 @@ class TestInteractiveSearchUIPreviewHighlighting:
             end_line=4,
             content=content,
             content_hash=Chunk.compute_content_hash(content),
-            file_hash="file_hash_456",
-            tree_sha="def456",
+            file_hash=Chunk.compute_content_hash("file content 2"),
+            tree_sha="b" * 40,
             rev="worktree",
         )
         ts_result = SearchResult(chunk=ts_chunk, score=0.90, rank=1)
@@ -286,8 +286,8 @@ class TestInteractiveSearchSession:
             end_line=5,
             content="test content",
             content_hash=Chunk.compute_content_hash("test content"),
-            file_hash="test_hash",
-            tree_sha="abc123",
+            file_hash=Chunk.compute_content_hash("file content 3"),
+            tree_sha="c" * 40,
             rev="worktree",
         )
         session.update_results([SearchResult(chunk=chunk, score=0.9, rank=1)], 100.0)
@@ -579,8 +579,8 @@ class TestInteractiveSearchUIResultsListColorSeparation:
             end_line=10,
             content=content2,
             content_hash=Chunk.compute_content_hash(content2),
-            file_hash="file_hash_789",
-            tree_sha="xyz789",
+            file_hash=Chunk.compute_content_hash("file content 4"),
+            tree_sha="d" * 40,
             rev="worktree",
         )
         result2 = SearchResult(chunk=chunk2, score=0.85, rank=2)
@@ -626,8 +626,8 @@ class TestInteractiveSearchUIResultsListColorSeparation:
             end_line=1,
             content=content,
             content_hash=Chunk.compute_content_hash(content),
-            file_hash="file_hash_nosym",
-            tree_sha="nosym123",
+            file_hash=Chunk.compute_content_hash("file content 5"),
+            tree_sha="e" * 40,
             rev="worktree",
         )
         result = SearchResult(chunk=chunk, score=0.75, rank=1)

--- a/tests/unit/adapters/test_vector_repository.py
+++ b/tests/unit/adapters/test_vector_repository.py
@@ -118,10 +118,10 @@ def test_dimension_validation_accepts_correct_dimension(tmp_path: Path) -> None:
         end_line=10,
         content=content,
         content_hash=Chunk.compute_content_hash(content),
-        file_hash="file123",
-        lang="python",
+        file_hash=Chunk.compute_content_hash("file1"),
+        lang="py",
         symbol=None,
-        tree_sha="abc123",
+        tree_sha="a" * 40,
         rev="worktree",
     )
     chunk_repo.add(chunk)
@@ -143,7 +143,7 @@ def test_dimension_validation_rejects_wrong_dimension(tmp_path: Path) -> None:
     chunk_repo = SQLiteChunkRepository(db_path)
 
     # Create a test chunk with all required fields
-    content = "test content"
+    content = "test content 2"
     chunk = Chunk(
         id=Chunk.compute_id("test_proj", Path("test.py"), 1, 10),
         project_id="test_proj",
@@ -152,10 +152,10 @@ def test_dimension_validation_rejects_wrong_dimension(tmp_path: Path) -> None:
         end_line=10,
         content=content,
         content_hash=Chunk.compute_content_hash(content),
-        file_hash="file123",
-        lang="python",
+        file_hash=Chunk.compute_content_hash("file2"),
+        lang="py",
         symbol=None,
-        tree_sha="abc123",
+        tree_sha="b" * 40,
         rev="worktree",
     )
     chunk_repo.add(chunk)
@@ -184,7 +184,7 @@ def test_dimension_validation_skipped_when_not_configured(tmp_path: Path) -> Non
     chunk_repo = SQLiteChunkRepository(db_path)
 
     # Create a test chunk with all required fields
-    content = "test content"
+    content = "test content 3"
     chunk = Chunk(
         id=Chunk.compute_id("test_proj", Path("test.py"), 1, 10),
         project_id="test_proj",
@@ -193,10 +193,10 @@ def test_dimension_validation_skipped_when_not_configured(tmp_path: Path) -> Non
         end_line=10,
         content=content,
         content_hash=Chunk.compute_content_hash(content),
-        file_hash="file123",
-        lang="python",
+        file_hash=Chunk.compute_content_hash("file3"),
+        lang="py",
         symbol=None,
-        tree_sha="abc123",
+        tree_sha="c" * 40,
         rev="worktree",
     )
     chunk_repo.add(chunk)

--- a/tests/unit/core/test_indexing_usecase.py
+++ b/tests/unit/core/test_indexing_usecase.py
@@ -63,7 +63,7 @@ class TestGetFilesToIndexFullReindex:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             path_filters=[],
             force_reindex=True,
         )
@@ -84,7 +84,7 @@ class TestGetFilesToIndexFullReindex:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             path_filters=[],
             force_reindex=False,
         )
@@ -100,12 +100,13 @@ class TestGetFilesToIndexNoChanges:
     def test_same_tree_sha_returns_empty_list(self, mock_deps: dict) -> None:
         """When tree_sha matches last_tree_sha, return empty list."""
         usecase = IndexingUseCase(**mock_deps)
-        mock_deps["meta_repo"].get.return_value = "abc123"
+        same_sha = "a" * 40
+        mock_deps["meta_repo"].get.return_value = same_sha
         repo_root = Path("/repo")
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="abc123",
+            tree_sha=same_sha,
             path_filters=[],
             force_reindex=False,
         )
@@ -122,7 +123,9 @@ class TestGetFilesToIndexIncremental:
     def test_incremental_returns_added_files(self, mock_deps: dict) -> None:
         """Incremental sync returns added files."""
         usecase = IndexingUseCase(**mock_deps)
-        mock_deps["meta_repo"].get.return_value = "old123"
+        old_sha = "c" * 40
+        new_sha = "d" * 40
+        mock_deps["meta_repo"].get.return_value = old_sha
         mock_deps["vcs"].diff_files.return_value = [
             ("added", "new_file.py"),
         ]
@@ -130,7 +133,7 @@ class TestGetFilesToIndexIncremental:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="new456",
+            tree_sha=new_sha,
             path_filters=[],
             force_reindex=False,
         )
@@ -139,7 +142,7 @@ class TestGetFilesToIndexIncremental:
         assert len(files) == 1
         assert files[0] == repo_root / "new_file.py"
         mock_deps["vcs"].diff_files.assert_called_once_with(
-            from_sha="old123", to_sha="new456"
+            from_sha=old_sha, to_sha=new_sha
         )
 
     def test_incremental_returns_modified_files(self, mock_deps: dict) -> None:
@@ -153,7 +156,7 @@ class TestGetFilesToIndexIncremental:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="new456",
+            tree_sha="b" * 40,
             path_filters=[],
             force_reindex=False,
         )
@@ -173,7 +176,7 @@ class TestGetFilesToIndexIncremental:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="new456",
+            tree_sha="b" * 40,
             path_filters=[],
             force_reindex=False,
         )
@@ -194,7 +197,7 @@ class TestGetFilesToIndexIncremental:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="new456",
+            tree_sha="b" * 40,
             path_filters=[],
             force_reindex=False,
         )
@@ -217,7 +220,7 @@ class TestGetFilesToIndexIncremental:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="new456",
+            tree_sha="b" * 40,
             path_filters=[],
             force_reindex=False,
         )
@@ -248,7 +251,7 @@ class TestGetFilesToIndexCodeFileFilter:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             path_filters=[],
             force_reindex=False,
         )
@@ -285,7 +288,7 @@ class TestGetFilesToIndexCodeFileFilter:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             path_filters=[],
             force_reindex=False,
         )
@@ -311,7 +314,7 @@ class TestGetFilesToIndexPathFilters:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             path_filters=["src/*.py"],
             force_reindex=False,
         )
@@ -332,7 +335,7 @@ class TestGetFilesToIndexPathFilters:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             path_filters=["src/*.py", "tests/*.py"],
             force_reindex=False,
         )
@@ -358,7 +361,7 @@ class TestGetFilesToIndexPathFilters:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             path_filters=["**/*.py"],  # ** matches any path, *.py matches filename
             force_reindex=False,
         )
@@ -379,7 +382,7 @@ class TestGetFilesToIndexPathFilters:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             path_filters=["nonexistent/*.py"],
             force_reindex=False,
         )
@@ -400,7 +403,7 @@ class TestGetFilesToIndexPathFilters:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             path_filters=[],
             force_reindex=False,
         )
@@ -427,7 +430,7 @@ class TestGetFilesToIndexCombined:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="new456",
+            tree_sha="b" * 40,
             path_filters=["src/*.py"],
             force_reindex=False,
         )
@@ -449,7 +452,7 @@ class TestGetFilesToIndexCombined:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             path_filters=["tests/*.py"],  # Direct match with tests directory
             force_reindex=True,
         )
@@ -471,7 +474,7 @@ class TestGetFilesToIndexCombined:
 
         files, is_incremental = usecase._get_files_to_index(
             repo_root=repo_root,
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             path_filters=[],
             force_reindex=False,
         )
@@ -594,7 +597,7 @@ class TestIndexFileErrorHandling:
         result = usecase._index_file(
             file_path=Path("/repo/test.py"),
             repo_root=Path("/repo"),
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             sync_mode="worktree",
         )
 
@@ -615,7 +618,7 @@ class TestIndexFileErrorHandling:
         result = usecase._index_file(
             file_path=Path("/repo/test.py"),
             repo_root=Path("/repo"),
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             sync_mode="worktree",
         )
 
@@ -635,7 +638,7 @@ class TestIndexFileErrorHandling:
         result = usecase._index_file(
             file_path=Path("/repo/test.py"),
             repo_root=Path("/repo"),
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             sync_mode="worktree",
         )
 
@@ -657,7 +660,7 @@ class TestIndexFileErrorHandling:
         result = usecase._index_file(
             file_path=Path("/repo/test.py"),
             repo_root=Path("/repo"),
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             sync_mode="worktree",
         )
 
@@ -676,7 +679,7 @@ class TestIndexFileErrorHandling:
         result = usecase._index_file(
             file_path=Path("/repo/test.py"),
             repo_root=Path("/repo"),
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             sync_mode="worktree",
         )
 
@@ -693,7 +696,7 @@ class TestIndexFileErrorHandling:
         result = usecase._index_file(
             file_path=Path("/repo/test.py"),
             repo_root=Path("/repo"),
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             sync_mode="worktree",
         )
 
@@ -717,7 +720,7 @@ class TestIndexFileErrorHandling:
         result = usecase._index_file(
             file_path=Path("/repo/test.py"),
             repo_root=Path("/repo"),
-            tree_sha="abc123",
+            tree_sha="a" * 40,
             sync_mode="worktree",
         )
 


### PR DESCRIPTION
## Summary
- Add comprehensive validation to domain entities (`Chunk`, `SearchExplanation`, `RepoState`) for data integrity
- Validates hash formats, language codes, score ranges, and state invariants
- Updated test fixtures across the codebase to use valid data

## Changes
- `Chunk` validates:
  - `content_hash` and `file_hash` are 64-char lowercase hex blake3 hashes
  - `tree_sha` is empty or 40-char lowercase hex git SHA
  - `lang` is a supported language code from `SUPPORTED_LANGUAGES`
  - `content` is not empty or whitespace-only

- `SearchExplanation` validates:
  - All scores (`fused_score`, `bm25_score`, `vector_score`) are in range [0.0, 1.0]

- `RepoState` validates:
  - Initialized state (non-empty `tree_sha`) requires `model_fingerprint`

## Test plan
- [x] All 30 new validation tests pass
- [x] Updated 12 test files with valid hashes and language codes
- [x] Full test suite passes (1102 passed, 1 flaky threading test)
- [x] Linter passes

Implements #322