### PR TITLE
refactor: move anemic domain logic from core to entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Moved anemic domain logic from core to entities** (#331)
+  - Added `Chunk.generate_preview()` method for creating content previews
+  - Added `Chunk.matches_language()` method for language filtering
+  - Added `SearchExplanation.effective_score` property for primary ranking score
+  - Simplified `SearchUseCase` to pure orchestration (removed `_apply_filters`, `_get_score`, `_generate_preview`)
+  - Domain entities now encapsulate their own business rules
 - **Reduced test brittleness in CLI tests** (#330)
   - Created `tests/helpers/cli_assertions.py` with reusable assertion helpers
   - `assert_command_success()` / `assert_command_failed()`: Exit code assertions with context


### PR DESCRIPTION
## Summary

Move business logic from `SearchUseCase` (core layer) to domain entities, following Clean Architecture principles where domain entities encapsulate their own business rules.

- Add `Chunk.generate_preview()` method for creating content previews
- Add `Chunk.matches_language()` method for language filtering  
- Add `SearchExplanation.effective_score` property for primary ranking score
- Simplify `SearchUseCase` to pure orchestration (removed `_apply_filters`, `_get_score`, `_generate_preview`)

This reduces `SearchUseCase` from 266 to 203 lines and makes domain logic independently testable.

Implements #331

## Test plan

- [x] All existing tests pass (1131 tests)
- [x] New domain method tests added (15 tests)
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>