### PR TITLE
refactor: consolidate model info into single registry source of truth (#332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Consolidated model registry to single source of truth** (#332)
+  - Created `ModelSpec` dataclass containing all model metadata (id, presets, dim, params, memory, max_seq_length, description)
+  - `MODEL_REGISTRY` is now the single source of truth for all supported embedding models
+  - `MODEL_PRESETS` and `SUPPORTED_MODELS` are now derived from `MODEL_REGISTRY` (no duplication)
+  - `get_model_info()` now uses registry lookup instead of hardcoded if/elif chain
+  - Adding a new embedding model now requires changes in only one place
 - **Moved anemic domain logic from core to entities** (#331)
   - Added `Chunk.generate_preview()` method for creating content previews
   - Added `Chunk.matches_language()` method for language filtering


### PR DESCRIPTION
## Summary

- Created `ModelSpec` dataclass as single source of truth for embedding model metadata
- `MODEL_REGISTRY` now contains all model information in one place
- `MODEL_PRESETS` and `SUPPORTED_MODELS` are derived from registry (no more duplication)
- `get_model_info()` uses simple registry lookup instead of if/elif chain
- Adding a new embedding model now requires changes in only one place

Implements #332

## Acceptance Criteria

- [x] Single ModelSpec for each model
- [x] MODEL_PRESETS derived from registry
- [x] SUPPORTED_MODELS derived from registry  
- [x] get_model_info() uses registry lookup
- [x] Adding new model requires change in one place only

## Test Plan

- [x] All 43 model registry tests pass (34 original + 9 new)
- [x] Full test suite passes (1140 tests)
- [x] Linter passes
- [x] New tests verify registry is the single source of truth

---
🤖 Generated with [Claude Code](https://claude.ai/code)