### PR TITLE
refactor: add DisplayConfig validation for theme names (#333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **DisplayConfig validation for theme names** (#333)
+  - `DisplayConfig` now validates theme against valid Pygments themes plus "ansi"
+  - Invalid themes raise `ValueError` with helpful error message
+  - Consistent with validation pattern used by all other config classes
+
 ### Changed
 - **Consolidated model registry to single source of truth** (#332)
   - Created `ModelSpec` dataclass containing all model metadata (id, presets, dim, params, memory, max_seq_length, description)

--- a/ember/domain/config.py
+++ b/ember/domain/config.py
@@ -8,6 +8,11 @@ models that represent validated configuration state.
 from dataclasses import dataclass, field
 from typing import Literal
 
+from pygments.styles import get_all_styles
+
+# Valid Pygments themes plus "ansi" for terminal-native colors
+VALID_THEMES: frozenset[str] = frozenset(get_all_styles()) | {"ansi"}
+
 
 @dataclass(frozen=True)
 class IndexConfig:
@@ -256,11 +261,22 @@ class DisplayConfig:
         theme: Syntax highlighting theme (default: "ansi" for terminal colors)
               Use "ansi" to respect terminal color scheme, or specific theme names
               like "monokai", "github-dark", etc. for fixed colors
+
+    Raises:
+        ValueError: If theme is not a valid Pygments theme or "ansi".
     """
 
     syntax_highlighting: bool = True
     color_scheme: Literal["auto", "always", "never"] = "auto"
     theme: str = "ansi"
+
+    def __post_init__(self) -> None:
+        """Validate display config after initialization."""
+        if self.theme not in VALID_THEMES:
+            raise ValueError(
+                f"Unknown theme '{self.theme}'. Valid themes: ansi, monokai, "
+                f"github-dark, dracula, solarized-dark, etc."
+            )
 
     @staticmethod
     def from_partial(base: "DisplayConfig", partial: dict) -> "DisplayConfig":

--- a/tests/unit/adapters/test_toml_config_provider.py
+++ b/tests/unit/adapters/test_toml_config_provider.py
@@ -314,20 +314,21 @@ patterns = []
     def test_load_config_with_unicode(
         self, provider: TomlConfigProvider, tmp_path: Path
     ) -> None:
-        """Test config with unicode characters."""
+        """Test config with unicode characters in string fields."""
         ember_dir = tmp_path / ".ember"
         ember_dir.mkdir()
         config_file = ember_dir / "config.toml"
         config_file.write_text(
             """
-[display]
-theme = "日本語テーマ"
+[index]
+ignore = ["日本語ディレクトリ/", "中文文件夹/"]
 """
         )
 
         result = provider.load(ember_dir)
 
-        assert result.display.theme == "日本語テーマ"
+        assert "日本語ディレクトリ/" in result.index.ignore
+        assert "中文文件夹/" in result.index.ignore
 
     def test_load_config_with_special_characters_in_patterns(
         self, provider: TomlConfigProvider, tmp_path: Path

--- a/tests/unit/domain/test_config.py
+++ b/tests/unit/domain/test_config.py
@@ -196,7 +196,7 @@ class TestModelConfigValidation:
 
 
 # =============================================================================
-# DisplayConfig validation tests (no validation needed, just literal types)
+# DisplayConfig validation tests
 # =============================================================================
 
 
@@ -218,6 +218,22 @@ class TestDisplayConfigValidation:
         assert config.syntax_highlighting is False
         assert config.color_scheme == "always"
         assert config.theme == "monokai"
+
+    def test_display_config_valid_pygments_themes(self):
+        """Test that common Pygments themes are accepted."""
+        for theme in ["ansi", "monokai", "github-dark", "dracula", "solarized-dark"]:
+            config = DisplayConfig(theme=theme)
+            assert config.theme == theme
+
+    def test_display_config_invalid_theme_raises_error(self):
+        """Test that invalid theme raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown theme 'invalid-theme'"):
+            DisplayConfig(theme="invalid-theme")
+
+    def test_display_config_empty_theme_raises_error(self):
+        """Test that empty theme raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown theme ''"):
+            DisplayConfig(theme="")
 
 
 # =============================================================================
@@ -357,6 +373,12 @@ class TestDisplayConfigFromPartial:
 
         assert result.syntax_highlighting is True  # Unchanged
         assert result.theme == "github-dark"
+
+    def test_from_partial_validates_result(self):
+        """Test that merged config is validated."""
+        base = DisplayConfig()
+        with pytest.raises(ValueError, match="Unknown theme"):
+            DisplayConfig.from_partial(base, {"theme": "not-a-real-theme"})
 
 
 class TestEmberConfigFromPartial:


### PR DESCRIPTION
## Summary
- Add `__post_init__` validation to `DisplayConfig` to match the pattern used by all other config classes
- Theme names are validated against Pygments available styles plus "ansi" for terminal-native colors
- Invalid theme names raise `ValueError` with a helpful error message

## Changes
- Added `VALID_THEMES` constant using `pygments.styles.get_all_styles()` plus "ansi"
- Added `__post_init__` method to `DisplayConfig` that validates the theme field
- Added tests for valid and invalid theme validation in `test_config.py`
- Added test for `from_partial` validation
- Updated unicode test in `test_toml_config_provider.py` to test unicode in ignore patterns instead of invalid theme

## Test Plan
- [x] All 1144 tests pass
- [x] Linter passes (`ruff check .`)
- [x] Valid Pygments themes (monokai, github-dark, dracula, etc.) are accepted
- [x] "ansi" theme is accepted (default terminal colors)
- [x] Invalid themes raise `ValueError`

Implements #333