### PR TITLE
fix: add transaction rollback to SqliteVecAdapter._sync_vectors()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Tests now resilient to cosmetic changes (emoji, wording, formatting)
 
 ### Fixed
+- **Transaction rollback in SqliteVecAdapter._sync_vectors()** (#351)
+  - Both vec_chunks and vec_chunk_mapping inserts are now wrapped in try/except with rollback
+  - Prevents orphaned vectors if mapping insert fails after vec_chunks insert succeeds
+  - Releases database lock on failure, allowing subsequent operations to proceed
 - **Complete transaction rollback in ChunkStorageService** (#329)
   - Embeddings are now generated before any database writes (prevents orphaned chunks if embedding fails)
   - Rollback now deletes both chunks AND vectors (previously only deleted chunks)


### PR DESCRIPTION
## Summary

- Wraps both `vec_chunks` and `vec_chunk_mapping` batch inserts in try/except with explicit rollback
- Prevents orphaned vectors when mapping insert fails after vec_chunks insert succeeds
- Releases database lock on failure, allowing subsequent operations to proceed

## Problem

The `_sync_vectors()` method performed batch inserts without transaction protection. If the mapping insert failed after `vec_chunks` insert succeeded:
1. Orphaned vectors would exist in `vec_chunks` without corresponding mappings
2. The database lock would be held, causing subsequent adapter operations to fail with "database is locked"

## Solution

Added try/except wrapper around both inserts with explicit `conn.rollback()` on failure:

```python
try:
    cursor.executemany("INSERT INTO vec_chunks...", vec_data)
    cursor.executemany("INSERT INTO vec_chunk_mapping...", mapping_data)
    conn.commit()
except Exception:
    conn.rollback()
    raise
```

## Test Plan

- [x] Added regression test `test_sync_vectors_rollback_releases_lock_on_failure`
- [x] All 14 sqlite_vec adapter tests pass
- [x] Full test suite passes (1145 tests)
- [x] Linter passes

Fixes #351