### PR TITLE
feat: add validation for glob patterns in IndexConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Glob pattern validation for IndexConfig** (#354)
+  - `IndexConfig.include` and `IndexConfig.ignore` patterns are now validated at config load time
+  - Reuses existing `PathFilter` validation (empty patterns, malformed `//` segments)
+  - Invalid patterns raise `ValueError` with clear message identifying which pattern failed
+  - Users get immediate feedback instead of delayed failure during indexing
 - **DisplayConfig validation for theme names** (#333)
   - `DisplayConfig` now validates theme against valid Pygments themes plus "ansi"
   - Invalid themes raise `ValueError` with helpful error message

--- a/ember/domain/config.py
+++ b/ember/domain/config.py
@@ -10,6 +10,8 @@ from typing import Literal
 
 from pygments.styles import get_all_styles
 
+from ember.domain.value_objects import PathFilter
+
 # Valid Pygments themes plus "ansi" for terminal-native colors
 VALID_THEMES: frozenset[str] = frozenset(get_all_styles()) | {"ansi"}
 
@@ -93,6 +95,19 @@ class IndexConfig:
             )
         if self.batch_size <= 0:
             raise ValueError(f"batch_size must be positive, got {self.batch_size}")
+
+        # Validate glob patterns early to fail fast
+        for pattern in self.include:
+            try:
+                PathFilter(pattern)
+            except ValueError as e:
+                raise ValueError(f"Invalid glob in include: {e}") from e
+
+        for pattern in self.ignore:
+            try:
+                PathFilter(pattern)
+            except ValueError as e:
+                raise ValueError(f"Invalid glob in ignore: {e}") from e
 
     @staticmethod
     def from_partial(


### PR DESCRIPTION
## Summary

- Validates `IndexConfig.include` and `IndexConfig.ignore` glob patterns at config load time
- Reuses existing `PathFilter` validation from `value_objects.py`
- Invalid patterns raise `ValueError` with clear message identifying which pattern failed

## Changes

- Added `PathFilter` import to `ember/domain/config.py`
- Added glob pattern validation in `IndexConfig.__post_init__` for both include and ignore lists
- Added 9 tests covering valid patterns, empty patterns, malformed `//` segments, and `from_partial` validation

Implements #354

## Test Plan

- [x] All 1153 tests pass
- [x] Linter passes (`ruff check .`)
- [x] New tests verify:
  - Valid include/ignore patterns are accepted
  - Empty patterns in include/ignore are rejected
  - Invalid `//` patterns in include/ignore are rejected
  - `from_partial` validates glob patterns

🤖 Generated with [Claude Code](https://claude.ai/code)