### PR TITLE
refactor: centralize daemon timeout configuration (#356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Centralized daemon timeout configuration** (#356)
+  - Created `DaemonTimeouts` class with all timeout values in one place
+  - No more hardcoded timeout values scattered across daemon code
+  - Each timeout has comprehensive documentation explaining its purpose
+  - Easy to tune for different environments (e.g., slower systems)
+  - Timeouts covered: socket operations, daemon ready wait, SIGTERM/SIGKILL waits, server accept, health checks
+
 ### Added
 - **Regex pattern validation for RedactionConfig** (#355)
   - `RedactionConfig.patterns` are now validated at config load time

--- a/ember/adapters/daemon/server.py
+++ b/ember/adapters/daemon/server.py
@@ -22,6 +22,7 @@ from ember.adapters.daemon.protocol import (
     receive_message,
     send_message,
 )
+from ember.adapters.daemon.timeouts import DaemonTimeouts
 
 if TYPE_CHECKING:
     from ember.ports.embedders import Embedder
@@ -108,7 +109,7 @@ class DaemonServer:
         self.server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.server_socket.bind(str(self.socket_path))
         self.server_socket.listen(5)
-        self.server_socket.settimeout(1.0)  # Allow periodic timeout checks
+        self.server_socket.settimeout(DaemonTimeouts.SERVER_ACCEPT)
 
         logger.info(f"Listening on {self.socket_path}")
 

--- a/ember/adapters/daemon/timeouts.py
+++ b/ember/adapters/daemon/timeouts.py
@@ -1,0 +1,147 @@
+"""Centralized timeout configuration for daemon operations.
+
+All daemon-related timeout values are defined here to:
+1. Provide a single source of truth for tuning
+2. Document the purpose of each timeout value
+3. Enable easy adjustment for different environments (e.g., slower systems)
+"""
+
+
+class DaemonTimeouts:
+    """Centralized timeout configuration for daemon operations.
+
+    All values are in seconds unless otherwise noted.
+
+    Groups:
+        SOCKET_*: Client socket operation timeouts
+        READY_*: Waiting for daemon to become ready after startup
+        SIGTERM_*: Graceful shutdown timeouts
+        SIGKILL_*: Force kill timeouts
+        SERVER_*: Server-side timeouts
+        HEALTH_*: Health check timeouts
+    """
+
+    # =========================================================================
+    # Socket Operation Timeouts
+    # =========================================================================
+
+    SOCKET_OPERATION: float = 5.0
+    """Timeout for client socket operations (connect, send, receive).
+
+    This value should be long enough to handle:
+    - Initial connection establishment
+    - Large batch embedding requests
+    - Network/IPC latency on loaded systems
+
+    If embeddings are timing out, consider increasing this value.
+    """
+
+    # =========================================================================
+    # Daemon Ready Wait Timeouts
+    # =========================================================================
+
+    READY_WAIT: float = 20.0
+    """Maximum time to wait for daemon to become ready after startup.
+
+    This timeout covers:
+    - Model loading (typically 2-5s for Jina models)
+    - Socket creation and binding
+    - Any startup initialization
+
+    On slower systems or with larger models, this may need to be increased.
+    The daemon will log its actual startup time for tuning reference.
+    """
+
+    READY_CHECK_INTERVAL: float = 0.5
+    """Interval between health checks when waiting for daemon ready.
+
+    Controls how frequently we poll the daemon during startup.
+    Lower values detect readiness faster but consume more CPU.
+    0.5s provides a good balance between responsiveness and efficiency.
+    """
+
+    # =========================================================================
+    # Graceful Shutdown (SIGTERM) Timeouts
+    # =========================================================================
+
+    SIGTERM_WAIT: int = 10
+    """Time to wait for graceful shutdown after SIGTERM.
+
+    Gives the daemon time to:
+    - Finish any in-progress embedding requests
+    - Clean up resources (release model, close socket)
+    - Write any final logs
+
+    If the daemon doesn't stop within this time, SIGKILL is sent.
+    """
+
+    # =========================================================================
+    # Force Kill (SIGKILL) Timeouts
+    # =========================================================================
+
+    SIGKILL_WAIT: float = 2.5
+    """Time to wait after sending SIGKILL.
+
+    SIGKILL cannot be caught or ignored, so this is primarily to allow
+    the OS to clean up the process. In practice, death should be nearly
+    instant. If a process survives SIGKILL, something is seriously wrong
+    (kernel issue, zombie, etc.).
+    """
+
+    DEATH_CHECK_INTERVAL: float = 0.5
+    """Interval between checks when waiting for process death.
+
+    Used when waiting for a process to die after SIGTERM or SIGKILL.
+    0.5s provides reasonable responsiveness without excessive polling.
+    """
+
+    # =========================================================================
+    # Server-Side Timeouts
+    # =========================================================================
+
+    SERVER_ACCEPT: float = 1.0
+    """Timeout for server accept() calls.
+
+    The server uses non-blocking accept with this timeout to allow
+    periodic checks for:
+    - Idle timeout (auto-shutdown when inactive)
+    - Shutdown signals (SIGTERM/SIGINT)
+
+    Lower values make the server more responsive to shutdown but
+    increase CPU usage due to more frequent wakeups.
+    """
+
+    # =========================================================================
+    # Health Check Timeouts
+    # =========================================================================
+
+    HEALTH_CHECK: float = 2.0
+    """Timeout for daemon health check requests.
+
+    Used by is_daemon_running() and get_daemon_pid() to verify
+    the daemon is responsive. This is shorter than SOCKET_OPERATION
+    because health checks should be fast (no model inference).
+
+    If health checks are timing out on a busy system, this may need
+    to be increased, but first check if the daemon is overloaded.
+    """
+
+    # =========================================================================
+    # Startup Failure Detection
+    # =========================================================================
+
+    STARTUP_FAILURE_LOOP_WAIT: float = 0.1
+    """Interval for cleanup loop when terminating unresponsive startup.
+
+    When a daemon starts but doesn't become responsive within READY_WAIT,
+    we try to terminate it gracefully. This controls how long we wait
+    between checks (10 iterations = 1.0s total).
+    """
+
+    STARTUP_FAILURE_LOOP_COUNT: int = 10
+    """Number of iterations for startup failure cleanup loop.
+
+    Combined with STARTUP_FAILURE_LOOP_WAIT, this defines the total
+    time spent trying to gracefully terminate an unresponsive daemon
+    before falling back to SIGKILL.
+    """

--- a/tests/unit/adapters/test_daemon_lifecycle.py
+++ b/tests/unit/adapters/test_daemon_lifecycle.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ember.adapters.daemon.lifecycle import DaemonLifecycle
+from ember.adapters.daemon.timeouts import DaemonTimeouts
 
 
 class TestTokenizersParallelismEnvVar:
@@ -245,7 +246,9 @@ class TestStopHelperMethods:
             result = lifecycle._stop_with_sigkill(12345)
 
             assert result is True
-            mock_signal.assert_called_once_with(12345, signal.SIGKILL, 2.5)
+            mock_signal.assert_called_once_with(
+                12345, signal.SIGKILL, DaemonTimeouts.SIGKILL_WAIT
+            )
 
     def test_stop_with_sigkill_returns_false_when_process_survives(
         self, lifecycle: DaemonLifecycle

--- a/tests/unit/adapters/test_daemon_timeouts.py
+++ b/tests/unit/adapters/test_daemon_timeouts.py
@@ -1,0 +1,83 @@
+"""Unit tests for daemon timeout configuration."""
+
+from ember.adapters.daemon.timeouts import DaemonTimeouts
+
+
+class TestDaemonTimeoutsValues:
+    """Tests for DaemonTimeouts configuration values."""
+
+    def test_socket_operation_timeout_is_positive(self) -> None:
+        """Socket operation timeout must be positive."""
+        assert DaemonTimeouts.SOCKET_OPERATION > 0
+
+    def test_ready_wait_timeout_is_positive(self) -> None:
+        """Ready wait timeout must be positive."""
+        assert DaemonTimeouts.READY_WAIT > 0
+
+    def test_ready_check_interval_is_positive(self) -> None:
+        """Ready check interval must be positive."""
+        assert DaemonTimeouts.READY_CHECK_INTERVAL > 0
+
+    def test_ready_check_interval_less_than_ready_wait(self) -> None:
+        """Check interval should be less than total wait time."""
+        assert DaemonTimeouts.READY_CHECK_INTERVAL < DaemonTimeouts.READY_WAIT
+
+    def test_sigterm_wait_is_positive(self) -> None:
+        """SIGTERM wait timeout must be positive."""
+        assert DaemonTimeouts.SIGTERM_WAIT > 0
+
+    def test_sigkill_wait_is_positive(self) -> None:
+        """SIGKILL wait timeout must be positive."""
+        assert DaemonTimeouts.SIGKILL_WAIT > 0
+
+    def test_death_check_interval_is_positive(self) -> None:
+        """Death check interval must be positive."""
+        assert DaemonTimeouts.DEATH_CHECK_INTERVAL > 0
+
+    def test_server_accept_timeout_is_positive(self) -> None:
+        """Server accept timeout must be positive."""
+        assert DaemonTimeouts.SERVER_ACCEPT > 0
+
+    def test_health_check_timeout_is_positive(self) -> None:
+        """Health check timeout must be positive."""
+        assert DaemonTimeouts.HEALTH_CHECK > 0
+
+    def test_health_check_shorter_than_socket_operation(self) -> None:
+        """Health checks should be quicker than general socket ops."""
+        # Health checks don't involve model inference, so should be faster
+        assert DaemonTimeouts.HEALTH_CHECK <= DaemonTimeouts.SOCKET_OPERATION
+
+    def test_startup_failure_loop_values_are_positive(self) -> None:
+        """Startup failure loop values must be positive."""
+        assert DaemonTimeouts.STARTUP_FAILURE_LOOP_WAIT > 0
+        assert DaemonTimeouts.STARTUP_FAILURE_LOOP_COUNT > 0
+
+
+class TestDaemonTimeoutsDocumentation:
+    """Tests to verify timeout values are documented."""
+
+    def test_class_has_substantial_documentation(self) -> None:
+        """DaemonTimeouts class should have substantial documentation."""
+        class_doc = DaemonTimeouts.__doc__
+        assert class_doc is not None
+        # Verify the class has substantial documentation
+        assert len(class_doc) > 100
+
+    def test_timeout_values_are_class_attributes(self) -> None:
+        """Timeout values should be accessible as class attributes."""
+        expected_timeouts = [
+            "SOCKET_OPERATION",
+            "READY_WAIT",
+            "READY_CHECK_INTERVAL",
+            "SIGTERM_WAIT",
+            "SIGKILL_WAIT",
+            "DEATH_CHECK_INTERVAL",
+            "SERVER_ACCEPT",
+            "HEALTH_CHECK",
+            "STARTUP_FAILURE_LOOP_WAIT",
+            "STARTUP_FAILURE_LOOP_COUNT",
+        ]
+        for attr in expected_timeouts:
+            assert hasattr(DaemonTimeouts, attr), f"Missing timeout: {attr}"
+            value = getattr(DaemonTimeouts, attr)
+            assert isinstance(value, (int, float)), f"{attr} should be numeric"


### PR DESCRIPTION
## Summary
- Created `DaemonTimeouts` class to centralize all daemon timeout values
- Replaced hardcoded timeout values across daemon code with configuration constants
- Added comprehensive documentation explaining the purpose of each timeout

## Changes
- **New file:** `ember/adapters/daemon/timeouts.py` - Centralized timeout configuration class
- **Updated:** `ember/adapters/daemon/lifecycle.py` - Uses DaemonTimeouts constants
- **Updated:** `ember/adapters/daemon/client.py` - Uses DaemonTimeouts constants  
- **Updated:** `ember/adapters/daemon/server.py` - Uses DaemonTimeouts constants
- **New tests:** `tests/unit/adapters/test_daemon_timeouts.py` - 13 new tests

## Timeouts Centralized
| Timeout | Value | Purpose |
|---------|-------|---------|
| SOCKET_OPERATION | 5.0s | Client socket operations |
| READY_WAIT | 20.0s | Wait for daemon ready after startup |
| READY_CHECK_INTERVAL | 0.5s | Interval between ready checks |
| SIGTERM_WAIT | 10s | Graceful shutdown timeout |
| SIGKILL_WAIT | 2.5s | Force kill timeout |
| DEATH_CHECK_INTERVAL | 0.5s | Interval for death checks |
| SERVER_ACCEPT | 1.0s | Server accept timeout |
| HEALTH_CHECK | 2.0s | Health check timeout |

Implements #356

## Test Plan
- [x] All 1206 tests pass
- [x] Linter passes (ruff check .)
- [x] New timeout configuration tests added (13 tests)
- [x] Existing daemon tests updated to use constants

🤖 Generated with [Claude Code](https://claude.ai/code)