### PR TITLE
refactor: standardize exception handling pattern across use cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Standardized exception handling pattern across use cases** (#358)
+  - All use cases now follow the same error handling contract:
+    - `KeyboardInterrupt`/`SystemExit` are always re-raised
+    - All other exceptions are caught and converted to error responses
+    - Responses include `success: bool` and `error: str | None` fields
+  - Created `ember.core.use_case_errors` module with shared error handling utilities:
+    - `EmberError` base exception class for domain errors
+    - `format_error_message()` for consistent error message formatting
+    - `log_use_case_error()` for consistent error logging
+  - `ModelMismatchError` now extends `EmberError`
+  - `InitResponse` now includes `success`, `error`, and `already_exists` fields
+  - `InitUseCase` returns error responses instead of raising exceptions
+  - Simplified error handling code in use cases by using shared utilities
+
 ### Added
 - **Error path test coverage for core components** (#357)
   - Tests for ChunkStorageService error logging (embedding failures, rollback messages)

--- a/ember/core/config/init_usecase.py
+++ b/ember/core/config/init_usecase.py
@@ -4,9 +4,11 @@ This use case handles the creation of a new .ember/ directory with all
 necessary files: config.toml, index.db, and state.json.
 """
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 
+from ember.core.use_case_errors import format_error_message, log_use_case_error
 from ember.ports.database import DatabaseInitializer
 from ember.shared.config_io import (
     create_global_config_file,
@@ -14,6 +16,8 @@ from ember.shared.config_io import (
     get_global_config_path,
 )
 from ember.shared.state_io import create_initial_state
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -36,22 +40,28 @@ class InitResponse:
     """Response from init operation.
 
     Attributes:
-        ember_dir: Path to created .ember/ directory
-        config_path: Path to created config.toml
-        db_path: Path to created index.db
-        state_path: Path to created state.json
-        was_reinitialized: True if existing .ember/ was replaced
-        global_config_created: True if global config was created (first run)
-        global_config_path: Path to global config file (may or may not exist)
+        ember_dir: Path to created .ember/ directory (or None on failure).
+        config_path: Path to created config.toml (or None on failure).
+        db_path: Path to created index.db (or None on failure).
+        state_path: Path to created state.json (or None on failure).
+        was_reinitialized: True if existing .ember/ was replaced.
+        global_config_created: True if global config was created (first run).
+        global_config_path: Path to global config file (may or may not exist).
+        success: Whether initialization succeeded.
+        error: Error message if initialization failed.
+        already_exists: True if failed because .ember/ already exists.
     """
 
-    ember_dir: Path
-    config_path: Path
-    db_path: Path
-    state_path: Path
+    ember_dir: Path | None
+    config_path: Path | None
+    db_path: Path | None
+    state_path: Path | None
     was_reinitialized: bool
     global_config_created: bool = False
     global_config_path: Path | None = None
+    success: bool = True
+    error: str | None = None
+    already_exists: bool = False
 
 
 class InitUseCase:
@@ -71,6 +81,31 @@ class InitUseCase:
         self._db_initializer = db_initializer
         self.version = version
 
+    def _create_error_response(
+        self, error: str, already_exists: bool = False
+    ) -> InitResponse:
+        """Create a standardized error response.
+
+        Args:
+            error: Error message.
+            already_exists: True if error is because .ember/ already exists.
+
+        Returns:
+            InitResponse with success=False.
+        """
+        return InitResponse(
+            ember_dir=None,
+            config_path=None,
+            db_path=None,
+            state_path=None,
+            was_reinitialized=False,
+            global_config_created=False,
+            global_config_path=None,
+            success=False,
+            error=error,
+            already_exists=already_exists,
+        )
+
     def execute(self, request: InitRequest) -> InitResponse:
         """Execute the init operation.
 
@@ -82,15 +117,16 @@ class InitUseCase:
         On first run (no global config exists), also creates:
         - ~/.config/ember/config.toml (global config with hardware-specific defaults)
 
+        Error handling contract:
+            - KeyboardInterrupt/SystemExit are re-raised (user wants to exit)
+            - All other exceptions are caught and converted to error responses
+            - See ember.core.use_case_errors for the error handling pattern
+
         Args:
             request: Init request with repo root and options
 
         Returns:
-            InitResponse with paths to created files
-
-        Raises:
-            FileExistsError: If .ember/ exists and force=False
-            IOError: If file creation fails
+            InitResponse with paths to created files, or error information.
         """
         ember_dir = request.repo_root / ".ember"
         config_path = ember_dir / "config.toml"
@@ -98,37 +134,50 @@ class InitUseCase:
         state_path = ember_dir / "state.json"
         global_config_path = get_global_config_path()
 
-        # Check if .ember/ already exists
-        was_reinitialized = False
-        if ember_dir.exists():
-            if not request.force:
-                raise FileExistsError(f"Directory {ember_dir} already exists")
-            was_reinitialized = True
+        try:
+            # Check if .ember/ already exists
+            was_reinitialized = False
+            if ember_dir.exists():
+                if not request.force:
+                    return self._create_error_response(
+                        f"Directory {ember_dir} already exists. "
+                        "Use --force to reinitialize.",
+                        already_exists=True,
+                    )
+                was_reinitialized = True
 
-        # Create global config if it doesn't exist (first run)
-        global_config_created = False
-        if not global_config_path.exists():
-            create_global_config_file(global_config_path, model=request.model)
-            global_config_created = True
+            # Create global config if it doesn't exist (first run)
+            global_config_created = False
+            if not global_config_path.exists():
+                create_global_config_file(global_config_path, model=request.model)
+                global_config_created = True
 
-        # Create .ember/ directory
-        ember_dir.mkdir(parents=True, exist_ok=True)
+            # Create .ember/ directory
+            ember_dir.mkdir(parents=True, exist_ok=True)
 
-        # Create minimal project config (settings inherit from global)
-        create_minimal_project_config(config_path)
+            # Create minimal project config (settings inherit from global)
+            create_minimal_project_config(config_path)
 
-        # Initialize database with schema
-        self._db_initializer.init_database(db_path)
+            # Initialize database with schema
+            self._db_initializer.init_database(db_path)
 
-        # Create initial state.json
-        create_initial_state(state_path, version=self.version)
+            # Create initial state.json
+            create_initial_state(state_path, version=self.version)
 
-        return InitResponse(
-            ember_dir=ember_dir,
-            config_path=config_path,
-            db_path=db_path,
-            state_path=state_path,
-            was_reinitialized=was_reinitialized,
-            global_config_created=global_config_created,
-            global_config_path=global_config_path,
-        )
+            return InitResponse(
+                ember_dir=ember_dir,
+                config_path=config_path,
+                db_path=db_path,
+                state_path=state_path,
+                was_reinitialized=was_reinitialized,
+                global_config_created=global_config_created,
+                global_config_path=global_config_path,
+                success=True,
+                error=None,
+                already_exists=False,
+            )
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as e:
+            log_use_case_error(e, "initialization")
+            return self._create_error_response(format_error_message(e, "initialization"))

--- a/ember/core/use_case_errors.py
+++ b/ember/core/use_case_errors.py
@@ -1,0 +1,98 @@
+"""Use case error handling utilities.
+
+Provides consistent exception handling across all use cases. All use cases
+should return error responses rather than raising exceptions (except for
+KeyboardInterrupt/SystemExit).
+
+Design principles:
+1. KeyboardInterrupt and SystemExit are always re-raised (never caught)
+2. EmberError subclasses are domain errors with user-friendly messages
+3. Unexpected exceptions are logged and converted to generic error messages
+4. All use cases return responses with success/error fields
+
+Error handling contract:
+    Use cases catch exceptions internally and return error responses.
+    This provides a consistent API for callers - they check response.success
+    rather than catching multiple exception types.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class EmberError(Exception):
+    """Base exception for all ember domain errors.
+
+    Subclass this for specific error types. The error message should be
+    user-friendly since it may be displayed directly to users.
+
+    Attributes:
+        message: User-friendly error message.
+    """
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+def format_error_message(exception: Exception, operation_name: str) -> str:
+    """Format an exception into a user-friendly error message.
+
+    This function provides consistent error message formatting across all
+    use cases. It handles different exception types appropriately:
+    - EmberError: Uses the error's message directly
+    - OSError: Adds context about permissions/disk space
+    - ValueError/RuntimeError: Includes exception message with operation context
+    - Other exceptions: Returns a generic "internal error" message
+
+    Args:
+        exception: The exception that was caught.
+        operation_name: Name of the operation for error messages (e.g., "indexing").
+
+    Returns:
+        User-friendly error message string.
+
+    Example:
+        try:
+            result = self._do_work()
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as e:
+            error_msg = format_error_message(e, "indexing")
+            return self._create_error_response(error_msg)
+    """
+    if isinstance(exception, EmberError):
+        return exception.message
+    elif isinstance(exception, OSError):
+        return (
+            f"I/O error: {exception}. "
+            "Check file permissions, disk space, and filesystem access."
+        )
+    elif isinstance(exception, (ValueError, RuntimeError)):
+        return f"{operation_name.capitalize()} error: {exception}"
+    else:
+        return f"Internal error during {operation_name}. Check logs for details."
+
+
+def log_use_case_error(exception: Exception, operation_name: str) -> None:
+    """Log an exception from a use case with appropriate severity.
+
+    This function provides consistent error logging across all use cases.
+    It uses appropriate log levels based on exception type:
+    - EmberError: ERROR level (expected domain errors)
+    - OSError/ValueError/RuntimeError: ERROR level
+    - Other exceptions: EXCEPTION level (includes traceback)
+
+    Args:
+        exception: The exception that was caught.
+        operation_name: Name of the operation for log messages.
+    """
+    if isinstance(exception, EmberError):
+        logger.error(str(exception))
+    elif isinstance(exception, OSError):
+        logger.error(f"I/O error during {operation_name}: {exception}")
+    elif isinstance(exception, (ValueError, RuntimeError)):
+        logger.error(f"Error during {operation_name}: {exception}")
+    else:
+        logger.exception(f"Unexpected error during {operation_name}")

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -180,11 +180,14 @@ def test_init_fails_if_ember_dir_exists(tmp_path: Path, db_initializer: SqliteDa
         # First init
         use_case = InitUseCase(db_initializer=db_initializer, version="0.1.0")
         request = InitRequest(repo_root=tmp_path, force=False)
-        use_case.execute(request)
+        response = use_case.execute(request)
+        assert response.success
 
-        # Second init without force should fail
-        with pytest.raises(FileExistsError, match="already exists"):
-            use_case.execute(request)
+        # Second init without force should return error response
+        response2 = use_case.execute(request)
+        assert not response2.success
+        assert response2.already_exists
+        assert "already exists" in (response2.error or "")
 
 
 def test_init_force_reinitializes(tmp_path: Path, db_initializer: SqliteDatabaseInitializer) -> None:

--- a/tests/unit/core/test_use_case_errors.py
+++ b/tests/unit/core/test_use_case_errors.py
@@ -1,0 +1,154 @@
+"""Tests for use case error handling utilities."""
+
+import logging
+
+import pytest
+
+from ember.core.use_case_errors import (
+    EmberError,
+    format_error_message,
+    log_use_case_error,
+)
+
+
+class TestEmberError:
+    """Tests for EmberError base exception class."""
+
+    def test_message_stored_on_exception(self) -> None:
+        """EmberError stores the message attribute."""
+        error = EmberError("Test error message")
+        assert error.message == "Test error message"
+
+    def test_message_used_as_str(self) -> None:
+        """EmberError message is used for str()."""
+        error = EmberError("Test error message")
+        assert str(error) == "Test error message"
+
+    def test_can_be_raised_and_caught(self) -> None:
+        """EmberError can be raised and caught as Exception."""
+        with pytest.raises(EmberError) as exc_info:
+            raise EmberError("Test error")
+        assert exc_info.value.message == "Test error"
+
+
+class TestFormatErrorMessage:
+    """Tests for format_error_message utility function."""
+
+    def test_ember_error_uses_message_directly(self) -> None:
+        """EmberError subclasses use their message directly."""
+        error = EmberError("User-friendly message")
+        result = format_error_message(error, "operation")
+        assert result == "User-friendly message"
+
+    def test_oserror_adds_context(self) -> None:
+        """OSError gets additional context about permissions/disk space."""
+        error = OSError("Permission denied")
+        result = format_error_message(error, "indexing")
+        assert "I/O error: Permission denied" in result
+        assert "permissions" in result
+        assert "disk space" in result
+
+    def test_valueerror_includes_operation_name(self) -> None:
+        """ValueError includes the operation name in the message."""
+        error = ValueError("Invalid value")
+        result = format_error_message(error, "validation")
+        assert "Validation error: Invalid value" in result
+
+    def test_runtimeerror_includes_operation_name(self) -> None:
+        """RuntimeError includes the operation name in the message."""
+        error = RuntimeError("Something went wrong")
+        result = format_error_message(error, "processing")
+        assert "Processing error: Something went wrong" in result
+
+    def test_generic_exception_returns_internal_error(self) -> None:
+        """Unknown exceptions return a generic internal error message."""
+        error = TypeError("type error details")
+        result = format_error_message(error, "indexing")
+        assert "Internal error during indexing" in result
+        assert "type error details" not in result  # Don't expose internals
+
+    def test_operation_name_capitalized(self) -> None:
+        """Operation name is capitalized in error messages."""
+        error = ValueError("test")
+        result = format_error_message(error, "status check")
+        assert "Status check error" in result
+
+
+class TestLogUseCaseError:
+    """Tests for log_use_case_error utility function."""
+
+    def test_ember_error_logged_at_error_level(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """EmberError is logged at ERROR level."""
+        error = EmberError("Domain error")
+        with caplog.at_level(logging.ERROR):
+            log_use_case_error(error, "operation")
+        assert "Domain error" in caplog.text
+
+    def test_oserror_logged_at_error_level(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """OSError is logged at ERROR level with operation context."""
+        error = OSError("Permission denied")
+        with caplog.at_level(logging.ERROR):
+            log_use_case_error(error, "indexing")
+        assert "I/O error during indexing" in caplog.text
+        assert "Permission denied" in caplog.text
+
+    def test_valueerror_logged_at_error_level(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """ValueError is logged at ERROR level."""
+        error = ValueError("Invalid value")
+        with caplog.at_level(logging.ERROR):
+            log_use_case_error(error, "validation")
+        assert "validation" in caplog.text
+        assert "Invalid value" in caplog.text
+
+    def test_runtimeerror_logged_at_error_level(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """RuntimeError is logged at ERROR level."""
+        error = RuntimeError("Runtime issue")
+        with caplog.at_level(logging.ERROR):
+            log_use_case_error(error, "processing")
+        assert "processing" in caplog.text
+        assert "Runtime issue" in caplog.text
+
+    def test_generic_exception_logged_with_traceback(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Unknown exceptions are logged with traceback (exception level)."""
+        error = TypeError("unexpected type")
+        with caplog.at_level(logging.ERROR):
+            log_use_case_error(error, "indexing")
+        assert "Unexpected error during indexing" in caplog.text
+
+
+class TestEmberErrorSubclass:
+    """Tests for creating EmberError subclasses."""
+
+    def test_custom_subclass_works_with_format(self) -> None:
+        """Custom EmberError subclasses work with format_error_message."""
+
+        class CustomError(EmberError):
+            def __init__(self, detail: str) -> None:
+                super().__init__(f"Custom: {detail}")
+                self.detail = detail
+
+        error = CustomError("specific detail")
+        result = format_error_message(error, "operation")
+        assert result == "Custom: specific detail"
+
+    def test_custom_subclass_preserves_attributes(self) -> None:
+        """Custom EmberError subclasses can have additional attributes."""
+
+        class DetailedError(EmberError):
+            def __init__(self, message: str, code: int) -> None:
+                super().__init__(message)
+                self.code = code
+
+        error = DetailedError("Error with code", code=42)
+        assert error.message == "Error with code"
+        assert error.code == 42


### PR DESCRIPTION
## Summary

- All use cases now follow the same error handling contract documented in `ember.core.use_case_errors`
- Created shared error handling utilities (`EmberError`, `format_error_message`, `log_use_case_error`)
- `InitUseCase` now returns error responses instead of raising exceptions
- Updated CLI to check `response.success` instead of catching exceptions

## Details

This refactoring addresses the inconsistency where different use cases used different exception handling strategies:
- `IndexingUseCase` caught specific exceptions and returned error responses
- `StatusUseCase` caught all exceptions broadly
- `InitUseCase` raised exceptions directly

Now all use cases:
1. Re-raise `KeyboardInterrupt` and `SystemExit` (user wants to exit)
2. Catch all other exceptions and convert to error responses
3. Include `success: bool` and `error: str | None` fields in responses

## Files Changed

- `ember/core/use_case_errors.py` - New module with shared utilities
- `ember/core/indexing/index_usecase.py` - Simplified error handling
- `ember/core/status/status_usecase.py` - Added consistent error handling
- `ember/core/config/init_usecase.py` - Returns responses instead of raising
- `ember/entrypoints/cli.py` - Updated init command handling
- `tests/unit/core/test_use_case_errors.py` - New tests
- `tests/integration/test_init.py` - Updated test expectations

Implements #358

## Test plan

- [x] All existing tests pass (1239 passed)
- [x] New tests for error handling utilities added
- [x] Linter passes