### PR TITLE
architecture: clarify search port contracts for sync-based implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Clarified search port contracts for sync-based implementations** (#359)
+  - `TextSearch` and `VectorSearch` ports now document two valid implementation patterns:
+    - Push-based: `add()` inserts data immediately
+    - Sync-based: `add()` is a no-op, data flows via triggers or external sync
+  - Added `sync()` method to both protocols for explicit synchronization
+  - Updated `SQLiteFTS` and `SqliteVecAdapter` class/method docstrings to document their sync-based pattern
+  - Added comprehensive tests verifying the documented behavior
+  - This clarifies the contract and prevents confusion about no-op `add()` methods
+
 - **Standardized exception handling pattern across use cases** (#358)
   - All use cases now follow the same error handling contract:
     - `KeyboardInterrupt`/`SystemExit` are always re-raised

--- a/ember/adapters/fts/sqlite_fts.py
+++ b/ember/adapters/fts/sqlite_fts.py
@@ -1,4 +1,9 @@
-"""SQLite FTS5 adapter implementing TextSearch protocol for full-text search."""
+"""SQLite FTS5 adapter implementing TextSearch protocol for full-text search.
+
+This is a sync-based implementation that uses database triggers to keep the
+FTS5 index in sync with the chunks table. The add() method is a no-op since
+data flows through triggers automatically.
+"""
 
 from pathlib import Path
 
@@ -8,9 +13,16 @@ from ember.adapters.sqlite.base_repository import SQLiteBaseRepository
 class SQLiteFTS(SQLiteBaseRepository):
     """SQLite FTS5 implementation of TextSearch for BM25-style full-text search.
 
+    Implementation pattern: Sync-based (trigger-driven)
+
     This adapter uses the FTS5 virtual table 'chunk_text' which is automatically
-    kept in sync with the 'chunks' table via triggers. Therefore, the add() method
-    is a no-op - chunks are indexed automatically when added to chunks table.
+    kept in sync with the 'chunks' table via database triggers. This means:
+
+    - add(): No-op - chunks are indexed automatically when added to chunks table
+    - sync(): No-op - triggers keep the index in sync automatically
+
+    The trigger-based approach ensures the FTS index is always up-to-date without
+    requiring explicit sync calls.
     """
 
     def __init__(self, db_path: Path) -> None:
@@ -33,6 +45,16 @@ class SQLiteFTS(SQLiteBaseRepository):
             metadata: Additional metadata (unused).
         """
         # No-op: FTS5 table is automatically synced via triggers
+        pass
+
+    def sync(self) -> None:
+        """Synchronize the FTS index with the chunks table.
+
+        This is a no-op because the FTS5 table uses database triggers that
+        automatically keep it in sync with the chunks table. The index is
+        always up-to-date without explicit sync calls.
+        """
+        # No-op: triggers keep the FTS index in sync automatically
         pass
 
     def query(

--- a/ember/ports/search.py
+++ b/ember/ports/search.py
@@ -1,16 +1,41 @@
 """Search port interfaces for text and vector retrieval.
 
 Defines abstract interfaces for full-text search (FTS), vector search, reranking, and fusion.
+
+Note on implementation patterns:
+    Search backends may use one of two approaches for data ingestion:
+
+    1. **Push-based**: Data is explicitly added via add() calls. The add() method
+       immediately indexes the data.
+
+    2. **Sync-based**: Data is synced from another source (e.g., database triggers
+       or a separate repository). The add() method is a no-op, and sync() pulls
+       data from the source.
+
+    Both patterns are valid. Sync-based implementations are common when the search
+    index needs to stay in sync with a primary data store via database triggers.
 """
 
 from typing import Protocol
 
 
 class TextSearch(Protocol):
-    """Full-text search interface (e.g., BM25, FTS5)."""
+    """Full-text search interface (e.g., BM25, FTS5).
+
+    Implementations may use push-based (add() inserts) or sync-based (add() is no-op,
+    data comes from triggers/external sync) patterns. Check the specific implementation
+    documentation for details.
+    """
 
     def add(self, chunk_id: str, text: str, metadata: dict[str, str]) -> None:
         """Add a document to the text search index.
+
+        Note: This method may be a no-op for sync-based implementations that use
+        database triggers or external sync mechanisms. Such implementations keep
+        the search index in sync with a primary data store automatically.
+
+        For sync-based implementations, data added to the primary store will be
+        searchable after the next sync (which may be automatic or manual).
 
         Args:
             chunk_id: Unique identifier for the chunk.
@@ -34,12 +59,36 @@ class TextSearch(Protocol):
         """
         ...
 
+    def sync(self) -> None:
+        """Synchronize the search index with the primary data store.
+
+        For sync-based implementations, this pulls any pending changes from the
+        primary data store into the search index. For push-based implementations,
+        this is typically a no-op since data is already indexed on add().
+
+        Implementations should be idempotent - calling sync() multiple times
+        without data changes should have no effect.
+        """
+        ...
+
 
 class VectorSearch(Protocol):
-    """Vector similarity search interface (e.g., FAISS, sqlite-vss)."""
+    """Vector similarity search interface (e.g., FAISS, sqlite-vss).
+
+    Implementations may use push-based (add() inserts) or sync-based (add() is no-op,
+    data comes from a separate repository) patterns. Check the specific implementation
+    documentation for details.
+    """
 
     def add(self, chunk_id: str, vector: list[float]) -> None:
         """Add a vector to the index.
+
+        Note: This method may be a no-op for sync-based implementations that sync
+        vectors from a separate repository (e.g., VectorRepository). Such implementations
+        keep the search index in sync with the vector store automatically.
+
+        For sync-based implementations, vectors added to the primary store will be
+        searchable after the next sync (which may be automatic or manual).
 
         Args:
             chunk_id: Unique identifier for the chunk.
@@ -62,6 +111,18 @@ class VectorSearch(Protocol):
 
         Returns:
             List of (chunk_id, distance) tuples, sorted by distance (ascending).
+        """
+        ...
+
+    def sync(self) -> None:
+        """Synchronize the vector index with the primary data store.
+
+        For sync-based implementations, this pulls any pending vectors from the
+        primary data store into the search index. For push-based implementations,
+        this is typically a no-op since vectors are already indexed on add().
+
+        Implementations should be idempotent - calling sync() multiple times
+        without data changes should have no effect.
         """
         ...
 

--- a/tests/unit/adapters/test_search_port_contracts.py
+++ b/tests/unit/adapters/test_search_port_contracts.py
@@ -1,0 +1,248 @@
+"""Tests for search port contract compliance.
+
+Verifies that TextSearch and VectorSearch implementations correctly implement
+the documented contract semantics, including sync() behavior for sync-based
+implementations.
+
+Issue #359: VSS and FTS ports have no-op add() methods
+"""
+
+from pathlib import Path
+
+import pytest
+
+from ember.adapters.fts.sqlite_fts import SQLiteFTS
+from ember.adapters.sqlite.schema import init_database
+from ember.adapters.vss.sqlite_vec_adapter import SqliteVecAdapter
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    """Create an initialized database."""
+    path = tmp_path / "test.db"
+    init_database(path)
+    return path
+
+
+class TestSQLiteFTSContract:
+    """Tests for SQLiteFTS TextSearch port compliance."""
+
+    def test_add_is_no_op_for_trigger_based_fts(self, db_path: Path) -> None:
+        """Test that add() is a no-op for trigger-based FTS implementation.
+
+        The SQLiteFTS adapter uses database triggers to keep the FTS5 index
+        in sync with the chunks table. Therefore add() should be a no-op
+        and not raise any errors.
+        """
+        fts = SQLiteFTS(db_path)
+
+        # add() should be a silent no-op
+        fts.add("chunk-1", "test content", {"path": "test.py", "lang": "python"})
+
+        # Should not raise, should not affect query results
+        results = fts.query("nonexistent")
+        assert results == []
+
+        fts.close()
+
+    def test_sync_is_no_op_for_trigger_based_fts(self, db_path: Path) -> None:
+        """Test that sync() is a no-op for trigger-based FTS implementation.
+
+        Since database triggers automatically keep the FTS5 index in sync,
+        sync() should be a no-op that can be called safely without side effects.
+        """
+        fts = SQLiteFTS(db_path)
+
+        # sync() should be a silent no-op
+        fts.sync()
+
+        # Multiple calls should be fine (idempotent)
+        fts.sync()
+        fts.sync()
+
+        fts.close()
+
+    def test_fts_query_works_without_explicit_add(self, db_path: Path) -> None:
+        """Test that FTS query works when data comes through triggers.
+
+        When chunks are inserted directly into the chunks table, the FTS5
+        triggers should automatically index them for search.
+        """
+        import time
+
+        fts = SQLiteFTS(db_path)
+
+        # Insert a chunk directly into the chunks table (bypassing add())
+        conn = fts._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO chunks (
+                project_id, path, start_line, end_line, content, chunk_id, lang,
+                content_hash, file_hash, created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "proj1",
+                "test.py",
+                1,
+                10,
+                "def hello_world(): pass",
+                "proj1:test.py:1-10",
+                "python",
+                "abc123",
+                "def456",
+                time.time(),
+            ),
+        )
+        conn.commit()
+
+        # The FTS trigger should have indexed this chunk
+        results = fts.query("hello_world")
+        assert len(results) == 1
+        assert results[0][0] == "proj1:test.py:1-10"
+
+        fts.close()
+
+
+class TestSqliteVecAdapterContract:
+    """Tests for SqliteVecAdapter VectorSearch port compliance."""
+
+    def test_add_is_no_op_for_sync_based_vec(self, db_path: Path) -> None:
+        """Test that add() is a no-op for sync-based vector implementation.
+
+        The SqliteVecAdapter syncs vectors from VectorRepository, so add()
+        should be a no-op and not raise any errors.
+        """
+        vec = SqliteVecAdapter(db_path, vector_dim=384)
+
+        # add() should be a silent no-op
+        vec.add("chunk-1", [0.1] * 384)
+
+        # Should not affect query results (no vectors actually added)
+        results = vec.query([0.1] * 384, topk=10)
+        assert results == []
+
+        vec.close()
+
+    def test_sync_pulls_from_vectors_table(self, db_path: Path) -> None:
+        """Test that sync() pulls vectors from the vectors table.
+
+        When vectors are added to the vectors table via VectorRepository,
+        calling sync() (or sync_if_needed) should make them searchable.
+        """
+        import struct
+        import time
+
+        vec = SqliteVecAdapter(db_path, vector_dim=384)
+
+        # First verify no results
+        results = vec.query([0.1] * 384, topk=10)
+        assert results == []
+
+        # Insert a chunk and vector directly (simulating VectorRepository behavior)
+        conn = vec._get_connection()
+        cursor = conn.cursor()
+
+        # Insert chunk with all required fields
+        cursor.execute(
+            """
+            INSERT INTO chunks (
+                project_id, path, start_line, end_line, content, chunk_id, lang,
+                content_hash, file_hash, created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "proj1",
+                "test.py",
+                1,
+                10,
+                "test content",
+                "proj1:test.py:1-10",
+                "python",
+                "abc123",
+                "def456",
+                time.time(),
+            ),
+        )
+        chunk_id = cursor.lastrowid
+
+        # Insert vector
+        embedding = [0.5] * 384
+        embedding_blob = struct.pack(f"{384}f", *embedding)
+        cursor.execute(
+            "INSERT INTO vectors (chunk_id, embedding, dim, model_fingerprint) VALUES (?, ?, ?, ?)",
+            (chunk_id, embedding_blob, 384, "test-model-fp"),
+        )
+        conn.commit()
+
+        # Mark dirty and sync
+        vec.mark_dirty()
+        vec.sync()
+
+        # Now the vector should be searchable
+        results = vec.query([0.5] * 384, topk=10)
+        assert len(results) == 1
+        assert results[0][0] == "proj1:test.py:1-10"
+
+        vec.close()
+
+    def test_sync_is_idempotent(self, db_path: Path) -> None:
+        """Test that sync() is idempotent - multiple calls are safe.
+
+        Calling sync() multiple times without data changes should have no
+        effect after the first sync.
+        """
+        vec = SqliteVecAdapter(db_path, vector_dim=384)
+
+        # Multiple sync calls should be fine
+        vec.sync()
+        vec.sync()
+        vec.sync()
+
+        # Should still work for queries
+        results = vec.query([0.1] * 384, topk=10)
+        assert results == []
+
+        vec.close()
+
+    def test_sync_if_needed_returns_correct_status(self, db_path: Path) -> None:
+        """Test that sync_if_needed() returns whether sync was performed."""
+        vec = SqliteVecAdapter(db_path, vector_dim=384)
+
+        # First call after init should sync (dirty by default)
+        # Actually on init it already syncs, so it should be False
+        result = vec.sync_if_needed()
+        assert result is False  # Already synced during __init__
+
+        # Mark dirty and try again
+        vec.mark_dirty()
+        result = vec.sync_if_needed()
+        assert result is True  # Should sync
+
+        # Second call should not sync
+        result = vec.sync_if_needed()
+        assert result is False  # Already synced
+
+        vec.close()
+
+    def test_sync_via_protocol_method(self, db_path: Path) -> None:
+        """Test that the sync() protocol method works correctly.
+
+        The sync() method should wrap sync_if_needed() for protocol compliance.
+        """
+        vec = SqliteVecAdapter(db_path, vector_dim=384)
+
+        # sync() should not raise
+        vec.sync()
+
+        # Mark dirty, then sync via protocol method
+        vec.mark_dirty()
+        vec.sync()
+
+        # Calling again should be fine (idempotent)
+        vec.sync()
+
+        vec.close()


### PR DESCRIPTION
## Summary

Clarifies the TextSearch and VectorSearch port interfaces to document two valid implementation patterns and adds an explicit `sync()` method to the protocols.

- `TextSearch` and `VectorSearch` ports now document push-based vs sync-based patterns
- Added `sync()` method to both protocols for explicit synchronization
- Updated `SQLiteFTS` and `SqliteVecAdapter` documentation and implementations
- Added comprehensive tests verifying the documented behavior

## Details

The issue was that both `SqliteVecAdapter` and `SQLiteFTS` implement `add()` methods as no-ops because they rely on SQLite triggers/sync mechanisms. This could violate the Liskov Substitution Principle - code expecting the VSS/FTS port to actually add data on `add()` calls would be surprised.

This PR implements **Option 1** from the issue: clarify the contract and add explicit `sync()` method.

Changes:
1. **Port interfaces** (`ember/ports/search.py`):
   - Added module-level documentation explaining push-based vs sync-based patterns
   - Updated `TextSearch` and `VectorSearch` class docstrings
   - Updated `add()` method docstrings to explain they may be no-ops
   - Added `sync()` method to both protocols

2. **SQLiteFTS** (`ember/adapters/fts/sqlite_fts.py`):
   - Updated module and class docstrings to document trigger-based pattern
   - Added `sync()` method (no-op since triggers handle sync)

3. **SqliteVecAdapter** (`ember/adapters/vss/sqlite_vec_adapter.py`):
   - Updated module and class docstrings to document sync-from-repository pattern
   - Added `sync()` method that wraps existing `sync_if_needed()`

4. **Tests** (`tests/unit/adapters/test_search_port_contracts.py`):
   - Tests for SQLiteFTS contract compliance
   - Tests for SqliteVecAdapter contract compliance
   - Verifies add() no-op behavior
   - Verifies sync() behavior
   - Verifies idempotency

## Success Criteria

- [x] Port interface documentation clarifies `add()` semantics
- [x] Alternative implementations can either use `add()` directly or `sync()`
- [x] Tests verify the documented behavior
- [x] No silent data loss possible from misunderstanding the contract

Implements #359