### PR TITLE
dx: reduce test brittleness from string-based output assertions (#360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Reduced test brittleness from string-based output assertions** (#360)
+  - Added new semantic assertion helpers to `tests/helpers/cli_assertions.py`:
+    - `assert_has_line_numbers()`: Detects line number formats (colon, pipe, Rich)
+    - `assert_has_rank_indicators()`: Detects result ranking formats ([1], #1, etc.)
+    - `assert_has_separator()`: Validates separator characters in output
+    - `assert_result_list_format()`: High-level result format validation
+  - Migrated ~20 brittle assertions in integration tests to semantic helpers
+  - Tests now resilient to cosmetic output changes (spacing, bracket styles)
+  - Updated module docstring with complete helper reference
+
 - **Clarified search port contracts for sync-based implementations** (#359)
   - `TextSearch` and `VectorSearch` ports now document two valid implementation patterns:
     - Push-based: `add()` inserts data immediately

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -5,8 +5,12 @@ from tests.helpers.cli_assertions import (
     assert_command_success,
     assert_error_message,
     assert_files_created,
+    assert_has_line_numbers,
+    assert_has_rank_indicators,
+    assert_has_separator,
     assert_output_contains,
     assert_output_matches,
+    assert_result_list_format,
     assert_success_indicator,
 )
 
@@ -18,4 +22,8 @@ __all__ = [
     "assert_error_message",
     "assert_success_indicator",
     "assert_files_created",
+    "assert_has_line_numbers",
+    "assert_has_rank_indicators",
+    "assert_has_separator",
+    "assert_result_list_format",
 ]

--- a/tests/integration/test_cli_commands.py
+++ b/tests/integration/test_cli_commands.py
@@ -23,8 +23,10 @@ from tests.helpers import (
     assert_command_success,
     assert_error_message,
     assert_files_created,
+    assert_has_separator,
     assert_output_contains,
     assert_output_matches,
+    assert_result_list_format,
     assert_success_indicator,
 )
 
@@ -363,12 +365,12 @@ class TestFindCommand:
         assert_command_success(result, context="find --context")
 
         # If results were found, verify context format (semantic check)
-        if "No results" not in result.output and result.output.strip() != "":
-            # Should have line numbers or pipe separator for context display
-            lines = [line for line in result.output.split('\n') if line.strip() and not line.startswith('[')]
-            has_line_numbers = any(line.strip() and line[0:5].strip().isdigit() for line in lines) if lines else False
-            has_pipe = "|" in result.output
-            assert has_line_numbers or has_pipe, "Expected line number format in context output"
+        assert_result_list_format(
+            result,
+            expect_line_numbers=True,
+            expect_ranks=False,
+            context="find --context output",
+        )
 
     def test_find_with_context_json_output(
         self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
@@ -574,7 +576,7 @@ class TestCatCommand:
 
         assert_command_success(result, context="cat --context")
         # Should show line numbers (semantic check for context format)
-        assert "|" in result.output  # Line number separator
+        assert_has_separator(result, "|", context="cat --context line separator")
 
     def test_cat_fails_without_prior_search(self, runner: CliRunner, git_repo_isolated: Path, monkeypatch) -> None:
         """Test that cat fails if no search was performed."""


### PR DESCRIPTION
## Summary

- Added semantic assertion helpers to reduce test brittleness from exact string matching on CLI output
- Migrated ~20 brittle assertions in integration tests to use the new helpers
- Tests now validate behavior rather than presentation, making them resilient to cosmetic changes

## Changes

**New helpers in `tests/helpers/cli_assertions.py`:**
- `assert_has_line_numbers()`: Detects various line number formats (colon, pipe, Rich style)
- `assert_has_rank_indicators()`: Detects result ranking formats ([1], #1, (1), etc.)
- `assert_has_separator()`: Validates separator characters in output
- `assert_result_list_format()`: High-level result format validation combining the above

**Updated tests:**
- `test_find_context_syntax_highlighting.py`: Replaced 8 brittle assertions
- `test_cat_syntax_highlighting.py`: Replaced 8 brittle assertions
- `test_cli_commands.py`: Replaced 2 brittle assertions

## Test plan

- [x] All 1247 tests pass
- [x] Linter passes
- [x] CHANGELOG.md updated

Resolves #360