### PR TITLE
fix: accept unbounded BM25 scores from SQLite FTS5 (#377)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **BM25 score validation incorrectly assumed normalized 0-1 range** (#377)
+  - `ember find` was failing with validation errors because BM25 scores from SQLite FTS5 are raw, unbounded positive values
+  - Changed `SearchExplanation.bm25_score` validation to only require non-negative values (≥0) instead of normalized range (0.0-1.0)
+  - The `fused_score` (from RRF) remains normalized and is used for ranking; raw BM25 scores are preserved for debugging
+
 ### Changed
 - **Moved business logic out of CLI into use cases** (#362)
   - Path normalization in `core/path_utils.py` now raises domain exceptions instead of CLI exceptions

--- a/ember/domain/entities.py
+++ b/ember/domain/entities.py
@@ -439,11 +439,12 @@ class SearchExplanation:
 
     Attributes:
         fused_score: Combined score from reciprocal rank fusion (0.0-1.0).
-        bm25_score: BM25 full-text search score (0.0-1.0).
+        bm25_score: Raw BM25 full-text search score from FTS5 (non-negative, unbounded).
         vector_score: Semantic vector similarity score (0.0-1.0).
 
     Raises:
-        ValueError: If any score is outside the valid range [0.0, 1.0].
+        ValueError: If fused_score or vector_score is outside [0.0, 1.0],
+            or if bm25_score is negative.
     """
 
     fused_score: float
@@ -456,9 +457,9 @@ class SearchExplanation:
             raise ValueError(
                 f"fused_score must be between 0.0 and 1.0, got: {self.fused_score}"
             )
-        if not 0.0 <= self.bm25_score <= 1.0:
+        if self.bm25_score < 0.0:
             raise ValueError(
-                f"bm25_score must be between 0.0 and 1.0, got: {self.bm25_score}"
+                f"bm25_score must be non-negative, got: {self.bm25_score}"
             )
         if not 0.0 <= self.vector_score <= 1.0:
             raise ValueError(

--- a/tests/unit/domain/test_entities.py
+++ b/tests/unit/domain/test_entities.py
@@ -1030,13 +1030,14 @@ class TestSearchExplanationScoreValidation:
 
     def test_negative_bm25_score_raises_error(self):
         """Test that negative bm25_score raises ValueError."""
-        with pytest.raises(ValueError, match="bm25_score must be between"):
+        with pytest.raises(ValueError, match="bm25_score must be non-negative"):
             SearchExplanation(fused_score=0.5, bm25_score=-0.1)
 
-    def test_bm25_score_above_one_raises_error(self):
-        """Test that bm25_score > 1.0 raises ValueError."""
-        with pytest.raises(ValueError, match="bm25_score must be between"):
-            SearchExplanation(fused_score=0.5, bm25_score=1.1)
+    def test_bm25_score_above_one_valid(self):
+        """Test that bm25_score > 1.0 is valid (raw FTS5 scores are unbounded)."""
+        # BM25 scores from SQLite FTS5 are raw, unbounded positive values
+        explanation = SearchExplanation(fused_score=0.5, bm25_score=10.378)
+        assert explanation.bm25_score == 10.378
 
     def test_negative_vector_score_raises_error(self):
         """Test that negative vector_score raises ValueError."""


### PR DESCRIPTION
## Summary
- Fix `ember find` failing with "bm25_score must be between 0.0 and 1.0" validation error
- BM25 scores from SQLite FTS5 are raw, unbounded positive values, not normalized 0.0-1.0
- Changed `SearchExplanation.bm25_score` validation to only require non-negative values

Fixes #377

## Changes
- `ember/domain/entities.py`: Changed bm25_score validation from `0.0 <= score <= 1.0` to `score >= 0.0`
- Updated docstring to clarify bm25_score is a raw FTS5 score (unbounded positive)
- `tests/unit/domain/test_entities.py`: Updated tests to verify unbounded BM25 scores are accepted
- `CHANGELOG.md`: Added entry under "Fixed" section

## Test plan
- [x] All 1265 tests pass
- [x] Linter passes (`ruff check .`)
- [x] Verified `SearchExplanation(bm25_score=10.378)` now accepted (previously failed)
- [x] Verified negative bm25_score still rejected