### PR TITLE
fix: prevent daemon startup timeout on fresh install (#378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Daemon startup fails on fresh install during model download** (#378)
+  - On first run, embedding models must be downloaded from HuggingFace (Jina ~1.6GB, MiniLM ~100MB)
+  - The 20-second daemon startup timeout was not sufficient for model download
+  - Now pre-downloads the model during `ember init` when users expect setup time
+  - Added dynamic timeout: uses 120s for first-run (uncached model), 20s for cached
+  - Added `is_model_cached()` helper to detect if model download will be needed
+
 - **BM25 score validation incorrectly assumed normalized 0-1 range** (#377)
   - `ember find` was failing with validation errors because BM25 scores from SQLite FTS5 are raw, unbounded positive values
   - Changed `SearchExplanation.bm25_score` validation to only require non-negative values (≥0) instead of normalized range (0.0-1.0)

--- a/ember/adapters/daemon/timeouts.py
+++ b/ember/adapters/daemon/timeouts.py
@@ -44,12 +44,26 @@ class DaemonTimeouts:
     """Maximum time to wait for daemon to become ready after startup.
 
     This timeout covers:
-    - Model loading (typically 2-5s for Jina models)
+    - Model loading (typically 2-5s for Jina models from cache)
     - Socket creation and binding
     - Any startup initialization
 
-    On slower systems or with larger models, this may need to be increased.
+    This is the timeout used when the model is already cached locally.
+    For first-time startup requiring model download, use READY_WAIT_FIRST_RUN.
     The daemon will log its actual startup time for tuning reference.
+    """
+
+    READY_WAIT_FIRST_RUN: float = 120.0
+    """Maximum time to wait when model needs to be downloaded.
+
+    On first run (or if model cache is cleared), the embedding model must be
+    downloaded from HuggingFace. This can take significant time:
+    - Jina model (~1.6GB): 30-120s depending on network
+    - MiniLM (~100MB): 5-30s
+    - BGE-small (~130MB): 5-30s
+
+    This longer timeout prevents startup failures on fresh installs.
+    Once cached, subsequent startups use READY_WAIT.
     """
 
     READY_CHECK_INTERVAL: float = 0.5

--- a/ember/adapters/local_models/__init__.py
+++ b/ember/adapters/local_models/__init__.py
@@ -9,6 +9,7 @@ from ember.adapters.local_models.registry import (
     SUPPORTED_MODELS,
     create_embedder,
     get_model_info,
+    is_model_cached,
     list_available_models,
     resolve_model_name,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "SUPPORTED_MODELS",
     "create_embedder",
     "get_model_info",
+    "is_model_cached",
     "list_available_models",
     "resolve_model_name",
 ]


### PR DESCRIPTION
## Summary

Fixes #378 - Daemon startup fails on fresh install during model download.

- Pre-downloads embedding model during `ember init` when users expect setup time
- Uses dynamic timeout: 120s for first-run (uncached model), 20s for cached
- Adds `is_model_cached()` helper to detect if model download will be needed

## Problem

On first run, embedding models must be downloaded from HuggingFace:
- Jina model: ~1.6GB
- MiniLM model: ~100MB
- BGE-small model: ~130MB

The 20-second daemon startup timeout was not sufficient for model download over slow networks.

## Solution

Two-pronged approach:
1. **Pre-download during init**: Model is downloaded during `ember init` when users expect setup time
2. **Dynamic timeout fallback**: If model isn't cached (e.g., init was interrupted, cache cleared), daemon startup uses 120s timeout instead of 20s

## Changes

- `ember/adapters/local_models/registry.py`: Added `is_model_cached()` function
- `ember/adapters/daemon/timeouts.py`: Added `READY_WAIT_FIRST_RUN = 120.0` constant
- `ember/adapters/daemon/lifecycle.py`: Added `_get_startup_timeout()` for dynamic timeout
- `ember/entrypoints/cli.py`: Added `_ensure_model_downloaded()` called during init

## Test plan

- [x] All 1279 tests pass
- [x] Linter passes
- [x] Added unit tests for `is_model_cached()` (8 tests)
- [x] Added unit tests for `_get_startup_timeout()` (6 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)