### PR TITLE
fix: use model-aware timeouts for daemon startup (#385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Daemon startup timeout (20s) despite cached model on Apple Silicon** (#385)
+  - Model loading on Apple Silicon can take 15-25s for the Jina model (1.6GB), leaving no margin for the previous 20-second timeout
+  - Implemented model-aware timeouts: Jina gets 45s, smaller models (MiniLM, BGE-small) get 20s
+  - Added fast cache detection using `huggingface_hub.try_to_load_from_cache` instead of loading the full model just to check if it's cached
+  - The `is_model_cached()` function now completes in milliseconds instead of 10-15 seconds
+
 - **`ember status` always reports "Out of date" after sync** (#382)
   - The `state.json` file was never updated after initialization, causing `ember status` to always report the index as stale
   - Investigation revealed `state.json` was dead code: the SQLite `meta` table has always been the true source of truth for tracking sync state


### PR DESCRIPTION
## Summary

- Fixes daemon startup timeout (20s) despite cached model - model loading takes too long on Apple Silicon
- Implements model-aware timeouts based on model size (Jina 45s, others 20s)
- Adds fast cache detection using `huggingface_hub.try_to_load_from_cache`

## Changes

### Timeout Configuration (`ember/adapters/daemon/timeouts.py`)
- Renamed `READY_WAIT` to `READY_WAIT_DEFAULT` (30s for unknown models)
- Added `MODEL_LOAD_TIMES` dict with model-specific timeouts:
  - Jina: 45s (1.6GB, needs `trust_remote_code`)
  - MiniLM: 20s (~100MB)
  - BGE-small: 20s (~130MB)
- Added `get_model_timeout()` classmethod for timeout lookup

### Lifecycle (`ember/adapters/daemon/lifecycle.py`)
- Updated `_get_startup_timeout()` to resolve model name and use model-specific timeouts
- Now imports `resolve_model_name` to map preset names to canonical IDs

### Fast Cache Detection (`ember/adapters/local_models/registry.py`)
- `is_model_cached()` now uses `huggingface_hub.try_to_load_from_cache` for fast cache inspection
- Falls back to loading the model only if the fast path fails
- Completes in milliseconds instead of 10-15 seconds

## Test Plan

- [x] All 1251 tests pass
- [x] Ruff linter passes
- [x] New tests for `DaemonTimeouts.get_model_timeout()`
- [x] Updated tests for model-specific timeout behavior
- [x] Tests for fast cache detection path

Fixes #385

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>