### PR TITLE
refactor: make search retrieval parameters configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Made search retrieval parameters configurable** (#388)
+  - Extracted magic numbers (5x multiplier, 100 min pool, k=60) to documented module constants in `search_usecase.py`
+  - Added `rrf_k`, `retrieval_pool_multiplier`, and `min_retrieval_pool` to `SearchConfig` for advanced tuning
+  - These parameters control hybrid search quality vs speed tradeoff
+  - Documented rationale for each default value (RRF k=60 per SIGIR 2009 paper)
+
 - **Refactored IndexingUseCase to improve maintainability** (#387)
   - Extracted file detection logic into `FileDetectionService` (git-based change detection)
   - Extracted file filtering logic into `FileFilterService` (code file extension and glob pattern filtering)

--- a/ember/domain/config.py
+++ b/ember/domain/config.py
@@ -143,19 +143,40 @@ class SearchConfig:
         topk: Default number of results to return
         rerank: Whether to enable cross-encoder reranking
         filters: Default filters to apply (key=value pairs)
+        rrf_k: Reciprocal Rank Fusion constant (default 60). Higher values
+               reduce influence of top-ranked items in fusion scoring.
+        retrieval_pool_multiplier: Multiplier for retrieval pool size vs topk
+               (default 5). Higher values = better fusion quality, slower retrieval.
+        min_retrieval_pool: Minimum retrieval pool size (default 100).
+               Ensures enough candidates for fusion even with small topk.
 
     Raises:
-        ValueError: If topk is not positive.
+        ValueError: If topk, rrf_k, retrieval_pool_multiplier, or
+                   min_retrieval_pool is not positive.
     """
 
     topk: int = 20
     rerank: bool = False
     filters: list[str] = field(default_factory=list)
+    rrf_k: int = 60
+    retrieval_pool_multiplier: int = 5
+    min_retrieval_pool: int = 100
 
     def __post_init__(self) -> None:
         """Validate search config after initialization."""
         if self.topk <= 0:
             raise ValueError(f"topk must be positive, got {self.topk}")
+        if self.rrf_k <= 0:
+            raise ValueError(f"rrf_k must be positive, got {self.rrf_k}")
+        if self.retrieval_pool_multiplier <= 0:
+            raise ValueError(
+                f"retrieval_pool_multiplier must be positive, "
+                f"got {self.retrieval_pool_multiplier}"
+            )
+        if self.min_retrieval_pool <= 0:
+            raise ValueError(
+                f"min_retrieval_pool must be positive, got {self.min_retrieval_pool}"
+            )
 
     @staticmethod
     def from_partial(base: "SearchConfig", partial: dict) -> "SearchConfig":
@@ -172,6 +193,13 @@ class SearchConfig:
             topk=partial.get("topk", base.topk),
             rerank=partial.get("rerank", base.rerank),
             filters=partial.get("filters", base.filters),
+            rrf_k=partial.get("rrf_k", base.rrf_k),
+            retrieval_pool_multiplier=partial.get(
+                "retrieval_pool_multiplier", base.retrieval_pool_multiplier
+            ),
+            min_retrieval_pool=partial.get(
+                "min_retrieval_pool", base.min_retrieval_pool
+            ),
         )
 
 

--- a/tests/unit/core/test_search_usecase.py
+++ b/tests/unit/core/test_search_usecase.py
@@ -1,0 +1,192 @@
+"""Unit tests for SearchUseCase retrieval parameter configuration."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ember.core.retrieval.search_usecase import (
+    DEFAULT_RRF_K,
+    MIN_RETRIEVAL_POOL,
+    RETRIEVAL_POOL_MULTIPLIER,
+    SearchUseCase,
+)
+from ember.domain.entities import Query
+
+
+@pytest.fixture
+def mock_dependencies():
+    """Create mock dependencies for SearchUseCase."""
+    text_search = MagicMock()
+    vector_search = MagicMock()
+    chunk_repo = MagicMock()
+    embedder = MagicMock()
+
+    # Configure embedder to return a dummy embedding
+    embedder.embed_texts.return_value = [[0.1, 0.2, 0.3]]
+
+    # Configure searches to return empty results
+    text_search.query.return_value = []
+    vector_search.query.return_value = []
+
+    return {
+        "text_search": text_search,
+        "vector_search": vector_search,
+        "chunk_repo": chunk_repo,
+        "embedder": embedder,
+    }
+
+
+class TestSearchUseCaseModuleConstants:
+    """Tests for module-level constants documentation."""
+
+    def test_retrieval_pool_multiplier_default(self):
+        """Verify RETRIEVAL_POOL_MULTIPLIER has expected default value."""
+        assert RETRIEVAL_POOL_MULTIPLIER == 5
+
+    def test_min_retrieval_pool_default(self):
+        """Verify MIN_RETRIEVAL_POOL has expected default value."""
+        assert MIN_RETRIEVAL_POOL == 100
+
+    def test_default_rrf_k(self):
+        """Verify DEFAULT_RRF_K has expected default value."""
+        assert DEFAULT_RRF_K == 60
+
+
+class TestSearchUseCaseInitialization:
+    """Tests for SearchUseCase constructor with configurable parameters."""
+
+    def test_default_parameters(self, mock_dependencies):
+        """Test SearchUseCase uses module constants as defaults."""
+        use_case = SearchUseCase(**mock_dependencies)
+
+        assert use_case.rrf_k == DEFAULT_RRF_K
+        assert use_case.retrieval_pool_multiplier == RETRIEVAL_POOL_MULTIPLIER
+        assert use_case.min_retrieval_pool == MIN_RETRIEVAL_POOL
+
+    def test_custom_rrf_k(self, mock_dependencies):
+        """Test SearchUseCase accepts custom rrf_k."""
+        use_case = SearchUseCase(**mock_dependencies, rrf_k=30)
+
+        assert use_case.rrf_k == 30
+
+    def test_custom_retrieval_pool_multiplier(self, mock_dependencies):
+        """Test SearchUseCase accepts custom retrieval_pool_multiplier."""
+        use_case = SearchUseCase(**mock_dependencies, retrieval_pool_multiplier=10)
+
+        assert use_case.retrieval_pool_multiplier == 10
+
+    def test_custom_min_retrieval_pool(self, mock_dependencies):
+        """Test SearchUseCase accepts custom min_retrieval_pool."""
+        use_case = SearchUseCase(**mock_dependencies, min_retrieval_pool=200)
+
+        assert use_case.min_retrieval_pool == 200
+
+    def test_all_custom_parameters(self, mock_dependencies):
+        """Test SearchUseCase with all custom retrieval parameters."""
+        use_case = SearchUseCase(
+            **mock_dependencies,
+            rrf_k=30,
+            retrieval_pool_multiplier=10,
+            min_retrieval_pool=50,
+        )
+
+        assert use_case.rrf_k == 30
+        assert use_case.retrieval_pool_multiplier == 10
+        assert use_case.min_retrieval_pool == 50
+
+
+class TestRetrievalPoolCalculation:
+    """Tests for retrieval pool size calculation during search."""
+
+    def test_retrieval_pool_uses_multiplier(self, mock_dependencies):
+        """Test that retrieval pool uses configured multiplier."""
+        use_case = SearchUseCase(
+            **mock_dependencies, retrieval_pool_multiplier=3, min_retrieval_pool=10
+        )
+        query = Query(text="test query", topk=50)
+
+        use_case.search(query)
+
+        # Expected pool: max(50 * 3, 10) = 150
+        mock_dependencies["text_search"].query.assert_called_once()
+        call_args = mock_dependencies["text_search"].query.call_args
+        assert call_args.kwargs["topk"] == 150
+
+    def test_retrieval_pool_respects_minimum(self, mock_dependencies):
+        """Test that retrieval pool respects minimum when multiplier is too small."""
+        use_case = SearchUseCase(
+            **mock_dependencies, retrieval_pool_multiplier=2, min_retrieval_pool=100
+        )
+        query = Query(text="test query", topk=10)
+
+        use_case.search(query)
+
+        # Expected pool: max(10 * 2, 100) = 100 (min wins)
+        mock_dependencies["text_search"].query.assert_called_once()
+        call_args = mock_dependencies["text_search"].query.call_args
+        assert call_args.kwargs["topk"] == 100
+
+    def test_retrieval_pool_with_default_params(self, mock_dependencies):
+        """Test retrieval pool calculation with default parameters."""
+        use_case = SearchUseCase(**mock_dependencies)
+        query = Query(text="test query", topk=5)
+
+        use_case.search(query)
+
+        # Expected pool: max(5 * 5, 100) = 100 (min wins)
+        call_args = mock_dependencies["text_search"].query.call_args
+        assert call_args.kwargs["topk"] == 100
+
+    def test_retrieval_pool_large_topk(self, mock_dependencies):
+        """Test retrieval pool with large topk where multiplier wins."""
+        use_case = SearchUseCase(**mock_dependencies)
+        query = Query(text="test query", topk=30)
+
+        use_case.search(query)
+
+        # Expected pool: max(30 * 5, 100) = 150 (multiplier wins)
+        call_args = mock_dependencies["text_search"].query.call_args
+        assert call_args.kwargs["topk"] == 150
+
+
+class TestRRFFusionWithCustomK:
+    """Tests for RRF fusion with different k values."""
+
+    def test_rrf_uses_configured_k(self, mock_dependencies):
+        """Test that RRF fusion uses the configured k value."""
+        use_case = SearchUseCase(**mock_dependencies, rrf_k=30)
+
+        # Create test result lists
+        list1 = [("A", 1.0), ("B", 0.5)]
+        list2 = [("B", 1.0), ("A", 0.5)]
+
+        fused = use_case._reciprocal_rank_fusion([list1, list2], k=use_case.rrf_k)
+
+        # With k=30:
+        # A: 1/(30+1) + 1/(30+2) ≈ 0.0323 + 0.0313 = 0.0636
+        # B: 1/(30+2) + 1/(30+1) ≈ 0.0313 + 0.0323 = 0.0636
+        scores = dict(fused)
+        assert abs(scores["A"] - scores["B"]) < 0.001
+
+    def test_rrf_higher_k_reduces_top_rank_influence(self, mock_dependencies):
+        """Test that higher k values reduce influence of top-ranked items."""
+        use_case_low_k = SearchUseCase(**mock_dependencies, rrf_k=10)
+        use_case_high_k = SearchUseCase(**mock_dependencies, rrf_k=100)
+
+        # A is ranked 1st in one list, B is ranked 10th
+        list1 = [(f"item_{i}", 1.0) for i in range(10)]  # A=item_0 ranked 1st
+        list1[0] = ("A", 1.0)
+        list1[9] = ("B", 0.1)
+
+        fused_low_k = use_case_low_k._reciprocal_rank_fusion([list1], k=10)
+        fused_high_k = use_case_high_k._reciprocal_rank_fusion([list1], k=100)
+
+        scores_low_k = dict(fused_low_k)
+        scores_high_k = dict(fused_high_k)
+
+        # Ratio of A to B score should be smaller with higher k
+        # (because higher k diminishes the advantage of top ranks)
+        ratio_low_k = scores_low_k["A"] / scores_low_k["B"]
+        ratio_high_k = scores_high_k["A"] / scores_high_k["B"]
+
+        assert ratio_low_k > ratio_high_k


### PR DESCRIPTION
## Summary

- Extracted hardcoded "magic numbers" from SearchUseCase to documented module constants
- Added `rrf_k`, `retrieval_pool_multiplier`, and `min_retrieval_pool` to SearchConfig for advanced tuning
- Added comprehensive unit tests for new configurable parameters

## Changes

**Module Constants (search_usecase.py):**
- `RETRIEVAL_POOL_MULTIPLIER = 5` - multiplier for retrieval pool size vs topk
- `MIN_RETRIEVAL_POOL = 100` - minimum candidates for RRF fusion
- `DEFAULT_RRF_K = 60` - RRF constant (per SIGIR 2009 paper)

**SearchUseCase Constructor:**
- Added `rrf_k`, `retrieval_pool_multiplier`, `min_retrieval_pool` parameters
- Uses configurable instance variables instead of hardcoded values

**SearchConfig (domain/config.py):**
- Added `rrf_k: int = 60`
- Added `retrieval_pool_multiplier: int = 5`
- Added `min_retrieval_pool: int = 100`
- Added validation (all must be positive)
- Updated `from_partial` to support new fields

**Tests:**
- New `tests/unit/core/test_search_usecase.py` with 14 tests
- Extended `tests/unit/domain/test_config.py` with 11 new tests

## Test Plan

- [x] All 1099 unit tests pass
- [x] Linter passes (`ruff check .`)
- [x] Verified retrieval pool calculation uses configurable multiplier and minimum
- [x] Verified RRF fusion uses configurable k value

Closes #388