### PR TITLE
refactor: create unified language registry to eliminate duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Created unified language registry to eliminate duplication** (#389)
+  - Language/extension mappings were previously defined in three separate locations with overlapping but inconsistent data
+  - Created `ember/core/languages.py` as single source of truth for all language mappings
+  - Refactored `file_preprocessor.py`, `colors.py`, and `file_filter.py` to use the new registry
+  - Adding new language support now requires changes to only one file
+  - Added 28 new tests for registry consistency and helper functions
+
 - **Made search retrieval parameters configurable** (#388)
   - Extracted magic numbers (5x multiplier, 100 min pool, k=60) to documented module constants in `search_usecase.py`
   - Added `rrf_k`, `retrieval_pool_multiplier`, and `min_retrieval_pool` to `SearchConfig` for advanced tuning

--- a/ember/core/indexing/file_filter.py
+++ b/ember/core/indexing/file_filter.py
@@ -1,64 +1,13 @@
 """File filtering service for selecting indexable code files.
 
 Filters files based on:
-- Code file extensions (whitelist approach)
+- Code file extensions (whitelist approach via language registry)
 - Glob pattern matching for path filters
 """
 
 from pathlib import Path
 
-# Code file extensions to index (whitelist approach)
-# Only source code files are indexed - data, config, docs, and binary files are skipped
-CODE_FILE_EXTENSIONS = frozenset(
-    {
-        # Python
-        ".py",
-        ".pyi",
-        # JavaScript/TypeScript
-        ".js",
-        ".jsx",
-        ".ts",
-        ".tsx",
-        ".mjs",
-        ".cjs",
-        # Go
-        ".go",
-        # Rust
-        ".rs",
-        # Java/JVM
-        ".java",
-        ".kt",
-        ".scala",
-        # C/C++
-        ".c",
-        ".cpp",
-        ".cc",
-        ".cxx",
-        ".h",
-        ".hpp",
-        ".hh",
-        ".hxx",
-        # C#
-        ".cs",
-        # Ruby
-        ".rb",
-        # PHP
-        ".php",
-        # Swift
-        ".swift",
-        # Shell
-        ".sh",
-        ".bash",
-        ".zsh",
-        # Web frameworks
-        ".vue",
-        ".svelte",
-        # Other
-        ".sql",
-        ".proto",
-        ".graphql",
-    }
-)
+from ember.core.languages import is_code_file as _is_code_file_by_suffix
 
 
 class FileFilterService:
@@ -78,8 +27,7 @@ class FileFilterService:
         Returns:
             True if file should be indexed, False otherwise.
         """
-        suffix = file_path.suffix.lower()
-        return suffix in CODE_FILE_EXTENSIONS
+        return _is_code_file_by_suffix(file_path.suffix)
 
     def filter_code_files(self, files: list[Path]) -> list[Path]:
         """Filter list to only include code files.

--- a/ember/core/indexing/file_preprocessor.py
+++ b/ember/core/indexing/file_preprocessor.py
@@ -9,46 +9,8 @@ from pathlib import Path
 
 import blake3
 
+from ember.core.languages import get_semantic_language
 from ember.ports.fs import FileSystem
-
-# Language extension mapping
-EXTENSION_TO_LANGUAGE: dict[str, str] = {
-    ".py": "py",
-    ".pyi": "py",
-    ".ts": "ts",
-    ".tsx": "ts",
-    ".js": "js",
-    ".jsx": "js",
-    ".mjs": "js",
-    ".cjs": "js",
-    ".go": "go",
-    ".rs": "rs",
-    ".java": "java",
-    ".kt": "java",
-    ".scala": "java",
-    ".c": "c",
-    ".h": "c",
-    ".cpp": "cpp",
-    ".cc": "cpp",
-    ".cxx": "cpp",
-    ".hpp": "cpp",
-    ".hh": "cpp",
-    ".hxx": "cpp",
-    ".cs": "cs",
-    ".rb": "rb",
-    ".php": "php",
-    ".swift": "swift",
-    ".sh": "sh",
-    ".bash": "sh",
-    ".zsh": "sh",
-    ".vue": "vue",
-    ".svelte": "svelte",
-    ".sql": "sql",
-    ".proto": "proto",
-    ".graphql": "graphql",
-    ".md": "txt",
-    ".txt": "txt",
-}
 
 
 @dataclass(frozen=True)
@@ -157,5 +119,4 @@ class FilePreprocessor:
         Returns:
             Language code (py, ts, go, rs, txt, etc.).
         """
-        suffix = file_path.suffix.lower()
-        return EXTENSION_TO_LANGUAGE.get(suffix, "txt")
+        return get_semantic_language(file_path.suffix)

--- a/ember/core/languages.py
+++ b/ember/core/languages.py
@@ -1,0 +1,148 @@
+"""Unified language registry for all Ember components.
+
+Single source of truth for language/extension mappings used by:
+- File preprocessing (semantic language codes)
+- Syntax highlighting (Pygments lexer names)
+- File filtering (code file detection)
+
+To add a new language, add a single entry to LANGUAGE_REGISTRY.
+"""
+
+from dataclasses import dataclass
+from typing import Final
+
+
+@dataclass(frozen=True)
+class LanguageInfo:
+    """Information about a programming language.
+
+    Attributes:
+        semantic: Language code for semantic processing (e.g., "py", "ts").
+            Used by tree-sitter and chunking.
+        lexer: Pygments lexer name for syntax highlighting (e.g., "python").
+        is_code: Whether this extension represents indexable source code.
+    """
+
+    semantic: str
+    lexer: str
+    is_code: bool = True
+
+
+# Master registry mapping file extensions to language info.
+# This is the SINGLE SOURCE OF TRUTH for all language mappings.
+LANGUAGE_REGISTRY: Final[dict[str, LanguageInfo]] = {
+    # Python
+    ".py": LanguageInfo(semantic="py", lexer="python"),
+    ".pyi": LanguageInfo(semantic="py", lexer="python"),
+    # JavaScript/TypeScript
+    ".js": LanguageInfo(semantic="js", lexer="javascript"),
+    ".jsx": LanguageInfo(semantic="js", lexer="javascript"),
+    ".mjs": LanguageInfo(semantic="js", lexer="javascript"),
+    ".cjs": LanguageInfo(semantic="js", lexer="javascript"),
+    ".ts": LanguageInfo(semantic="ts", lexer="typescript"),
+    ".tsx": LanguageInfo(semantic="ts", lexer="typescript"),
+    # Go
+    ".go": LanguageInfo(semantic="go", lexer="go"),
+    # Rust
+    ".rs": LanguageInfo(semantic="rs", lexer="rust"),
+    # Java/JVM
+    ".java": LanguageInfo(semantic="java", lexer="java"),
+    ".kt": LanguageInfo(semantic="java", lexer="kotlin"),
+    ".scala": LanguageInfo(semantic="java", lexer="scala"),
+    # C/C++
+    ".c": LanguageInfo(semantic="c", lexer="c"),
+    ".h": LanguageInfo(semantic="c", lexer="c"),
+    ".cpp": LanguageInfo(semantic="cpp", lexer="cpp"),
+    ".cc": LanguageInfo(semantic="cpp", lexer="cpp"),
+    ".cxx": LanguageInfo(semantic="cpp", lexer="cpp"),
+    ".hpp": LanguageInfo(semantic="cpp", lexer="cpp"),
+    ".hh": LanguageInfo(semantic="cpp", lexer="cpp"),
+    ".hxx": LanguageInfo(semantic="cpp", lexer="cpp"),
+    # C#
+    ".cs": LanguageInfo(semantic="cs", lexer="csharp"),
+    # Ruby
+    ".rb": LanguageInfo(semantic="rb", lexer="ruby"),
+    # PHP
+    ".php": LanguageInfo(semantic="php", lexer="php"),
+    # Swift
+    ".swift": LanguageInfo(semantic="swift", lexer="swift"),
+    # Shell
+    ".sh": LanguageInfo(semantic="sh", lexer="bash"),
+    ".bash": LanguageInfo(semantic="sh", lexer="bash"),
+    ".zsh": LanguageInfo(semantic="sh", lexer="bash"),
+    # Web frameworks
+    ".vue": LanguageInfo(semantic="vue", lexer="vue"),
+    ".svelte": LanguageInfo(semantic="svelte", lexer="html"),
+    # Query/Schema languages
+    ".sql": LanguageInfo(semantic="sql", lexer="sql"),
+    ".proto": LanguageInfo(semantic="proto", lexer="protobuf"),
+    ".graphql": LanguageInfo(semantic="graphql", lexer="graphql"),
+    # Data/Config (highlighted but not indexed as code)
+    ".yaml": LanguageInfo(semantic="txt", lexer="yaml", is_code=False),
+    ".yml": LanguageInfo(semantic="txt", lexer="yaml", is_code=False),
+    ".json": LanguageInfo(semantic="txt", lexer="json", is_code=False),
+    ".toml": LanguageInfo(semantic="txt", lexer="toml", is_code=False),
+    # Documentation (highlighted but not indexed as code)
+    ".md": LanguageInfo(semantic="txt", lexer="markdown", is_code=False),
+    ".txt": LanguageInfo(semantic="txt", lexer="text", is_code=False),
+}
+
+# Default for unknown extensions
+_DEFAULT_LANGUAGE = LanguageInfo(semantic="txt", lexer="text", is_code=False)
+
+
+def get_semantic_language(suffix: str) -> str:
+    """Get the semantic language code for a file extension.
+
+    Used by file preprocessing and chunking to identify language
+    for tree-sitter parsing.
+
+    Args:
+        suffix: File extension with leading dot (e.g., ".py").
+
+    Returns:
+        Language code (e.g., "py", "ts", "go"). Defaults to "txt".
+    """
+    suffix = suffix.lower()
+    return LANGUAGE_REGISTRY.get(suffix, _DEFAULT_LANGUAGE).semantic
+
+
+def get_lexer_name(suffix: str) -> str:
+    """Get the Pygments lexer name for a file extension.
+
+    Used by syntax highlighting to determine the appropriate lexer.
+
+    Args:
+        suffix: File extension with leading dot (e.g., ".py").
+
+    Returns:
+        Pygments lexer name (e.g., "python", "typescript"). Defaults to "text".
+    """
+    suffix = suffix.lower()
+    return LANGUAGE_REGISTRY.get(suffix, _DEFAULT_LANGUAGE).lexer
+
+
+def is_code_file(suffix: str) -> bool:
+    """Check if a file extension represents indexable source code.
+
+    Used by file filtering to determine which files to index.
+    Config, data, and documentation files return False.
+
+    Args:
+        suffix: File extension with leading dot (e.g., ".py").
+
+    Returns:
+        True if the extension represents indexable source code.
+    """
+    suffix = suffix.lower()
+    info = LANGUAGE_REGISTRY.get(suffix)
+    return info.is_code if info else False
+
+
+def get_code_file_extensions() -> frozenset[str]:
+    """Get all file extensions that represent indexable source code.
+
+    Returns:
+        Frozenset of extensions (e.g., {".py", ".ts", ".go", ...}).
+    """
+    return frozenset(ext for ext, info in LANGUAGE_REGISTRY.items() if info.is_code)

--- a/ember/core/presentation/colors.py
+++ b/ember/core/presentation/colors.py
@@ -7,6 +7,8 @@ and all output modes. Supports both click-style colors and prompt_toolkit styles
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
+from ember.core.languages import get_lexer_name
+
 if TYPE_CHECKING:
     from pygments.lexer import Lexer
     from pygments.token import _TokenType
@@ -34,31 +36,6 @@ class AnsiCodes:
     CYAN = "\x1b[96m"
     WHITE = "\x1b[97m"
 
-
-# File extension to Pygments lexer name mapping
-EXTENSION_TO_LEXER: dict[str, str] = {
-    ".py": "python",
-    ".js": "javascript",
-    ".ts": "typescript",
-    ".tsx": "typescript",
-    ".jsx": "javascript",
-    ".go": "go",
-    ".rs": "rust",
-    ".java": "java",
-    ".c": "c",
-    ".cpp": "cpp",
-    ".cc": "cpp",
-    ".cxx": "cpp",
-    ".cs": "csharp",
-    ".rb": "ruby",
-    ".sh": "bash",
-    ".yaml": "yaml",
-    ".yml": "yaml",
-    ".json": "json",
-    ".toml": "toml",
-    ".md": "markdown",
-    ".sql": "sql",
-}
 
 
 class EmberColors:
@@ -296,7 +273,7 @@ def _get_lexer(language: str | None, file_path: Path | None) -> "Lexer":
 
     lexer_name = language
     if not lexer_name and file_path:
-        lexer_name = EXTENSION_TO_LEXER.get(file_path.suffix, "text")
+        lexer_name = get_lexer_name(file_path.suffix)
 
     try:
         return get_lexer_by_name(lexer_name or "text")

--- a/tests/unit/core/test_file_filter.py
+++ b/tests/unit/core/test_file_filter.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 import pytest
 
-from ember.core.indexing.file_filter import CODE_FILE_EXTENSIONS, FileFilterService
+from ember.core.indexing.file_filter import FileFilterService
+from ember.core.languages import get_code_file_extensions
 
 
 @pytest.fixture
@@ -193,13 +194,15 @@ class TestApplyPathFilters:
 
 
 class TestCodeFileExtensions:
-    """Tests for the CODE_FILE_EXTENSIONS constant."""
+    """Tests for code file extensions via language registry."""
 
     def test_contains_common_languages(self) -> None:
-        """Constant contains extensions for common languages."""
+        """Registry contains extensions for common languages."""
         common = {".py", ".js", ".ts", ".go", ".rs", ".java", ".c", ".cpp", ".rb"}
-        assert common.issubset(CODE_FILE_EXTENSIONS)
+        code_extensions = get_code_file_extensions()
+        assert common.issubset(code_extensions)
 
     def test_is_frozenset(self) -> None:
-        """Constant is a frozenset for immutability and fast lookups."""
-        assert isinstance(CODE_FILE_EXTENSIONS, frozenset)
+        """Code extensions are returned as frozenset for immutability and fast lookups."""
+        code_extensions = get_code_file_extensions()
+        assert isinstance(code_extensions, frozenset)

--- a/tests/unit/core/test_file_preprocessor.py
+++ b/tests/unit/core/test_file_preprocessor.py
@@ -9,10 +9,10 @@ from unittest.mock import Mock
 import pytest
 
 from ember.core.indexing.file_preprocessor import (
-    EXTENSION_TO_LANGUAGE,
     FilePreprocessor,
     PreprocessedFile,
 )
+from ember.core.languages import LANGUAGE_REGISTRY
 
 
 @pytest.fixture
@@ -179,7 +179,7 @@ class TestFilePreprocessorLanguageDetection:
     """Tests for language detection from file extensions."""
 
     def test_extension_mapping_covers_common_languages(self) -> None:
-        """EXTENSION_TO_LANGUAGE should cover all common code extensions."""
+        """LANGUAGE_REGISTRY should cover all common code extensions."""
         expected_extensions = {
             ".py", ".pyi",  # Python
             ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",  # JavaScript/TypeScript
@@ -194,7 +194,7 @@ class TestFilePreprocessorLanguageDetection:
             ".sh", ".bash", ".zsh",  # Shell
         }
         for ext in expected_extensions:
-            assert ext in EXTENSION_TO_LANGUAGE, f"Missing extension: {ext}"
+            assert ext in LANGUAGE_REGISTRY, f"Missing extension: {ext}"
 
     def test_detect_language_is_case_insensitive(
         self, preprocessor: FilePreprocessor, mock_fs: Mock

--- a/tests/unit/core/test_languages.py
+++ b/tests/unit/core/test_languages.py
@@ -1,0 +1,249 @@
+"""Tests for the unified language registry.
+
+Verifies that the language registry provides consistent mappings
+for semantic language codes, Pygments lexer names, and code file detection.
+"""
+
+import pytest
+
+from ember.core.languages import (
+    LANGUAGE_REGISTRY,
+    LanguageInfo,
+    get_code_file_extensions,
+    get_lexer_name,
+    get_semantic_language,
+    is_code_file,
+)
+
+
+class TestLanguageInfo:
+    """Tests for the LanguageInfo dataclass."""
+
+    def test_language_info_is_frozen(self) -> None:
+        """LanguageInfo should be immutable."""
+        info = LanguageInfo(semantic="py", lexer="python")
+        with pytest.raises(AttributeError):
+            info.semantic = "changed"  # type: ignore[misc]
+
+    def test_language_info_defaults(self) -> None:
+        """LanguageInfo should default is_code to True."""
+        info = LanguageInfo(semantic="py", lexer="python")
+        assert info.is_code is True
+
+    def test_language_info_explicit_is_code(self) -> None:
+        """LanguageInfo should accept explicit is_code value."""
+        info = LanguageInfo(semantic="txt", lexer="yaml", is_code=False)
+        assert info.is_code is False
+
+
+class TestLanguageRegistry:
+    """Tests for the LANGUAGE_REGISTRY dictionary."""
+
+    def test_registry_is_not_empty(self) -> None:
+        """Registry should contain language entries."""
+        assert len(LANGUAGE_REGISTRY) > 0
+
+    def test_all_entries_have_valid_structure(self) -> None:
+        """All registry entries should be valid LanguageInfo instances."""
+        for ext, info in LANGUAGE_REGISTRY.items():
+            assert isinstance(ext, str), f"Extension should be string: {ext}"
+            assert ext.startswith("."), f"Extension should start with dot: {ext}"
+            assert isinstance(info, LanguageInfo), f"Value should be LanguageInfo: {ext}"
+            assert len(info.semantic) > 0, f"Semantic should not be empty: {ext}"
+            assert len(info.lexer) > 0, f"Lexer should not be empty: {ext}"
+
+    def test_python_extensions(self) -> None:
+        """Python extensions should map correctly."""
+        assert LANGUAGE_REGISTRY[".py"].semantic == "py"
+        assert LANGUAGE_REGISTRY[".py"].lexer == "python"
+        assert LANGUAGE_REGISTRY[".py"].is_code is True
+        assert LANGUAGE_REGISTRY[".pyi"].semantic == "py"
+
+    def test_javascript_extensions(self) -> None:
+        """JavaScript/TypeScript extensions should map correctly."""
+        # JavaScript
+        assert LANGUAGE_REGISTRY[".js"].semantic == "js"
+        assert LANGUAGE_REGISTRY[".js"].lexer == "javascript"
+        assert LANGUAGE_REGISTRY[".jsx"].semantic == "js"
+        assert LANGUAGE_REGISTRY[".mjs"].semantic == "js"
+        assert LANGUAGE_REGISTRY[".cjs"].semantic == "js"
+        # TypeScript
+        assert LANGUAGE_REGISTRY[".ts"].semantic == "ts"
+        assert LANGUAGE_REGISTRY[".ts"].lexer == "typescript"
+        assert LANGUAGE_REGISTRY[".tsx"].semantic == "ts"
+
+    def test_systems_languages(self) -> None:
+        """Systems languages should map correctly."""
+        # Go
+        assert LANGUAGE_REGISTRY[".go"].semantic == "go"
+        assert LANGUAGE_REGISTRY[".go"].lexer == "go"
+        # Rust
+        assert LANGUAGE_REGISTRY[".rs"].semantic == "rs"
+        assert LANGUAGE_REGISTRY[".rs"].lexer == "rust"
+        # C
+        assert LANGUAGE_REGISTRY[".c"].semantic == "c"
+        assert LANGUAGE_REGISTRY[".h"].semantic == "c"
+        # C++
+        assert LANGUAGE_REGISTRY[".cpp"].semantic == "cpp"
+        assert LANGUAGE_REGISTRY[".hpp"].semantic == "cpp"
+
+    def test_config_files_not_code(self) -> None:
+        """Config/data files should not be marked as code."""
+        assert LANGUAGE_REGISTRY[".yaml"].is_code is False
+        assert LANGUAGE_REGISTRY[".yml"].is_code is False
+        assert LANGUAGE_REGISTRY[".json"].is_code is False
+        assert LANGUAGE_REGISTRY[".toml"].is_code is False
+        assert LANGUAGE_REGISTRY[".md"].is_code is False
+
+    def test_config_files_have_lexers(self) -> None:
+        """Config/data files should still have lexers for highlighting."""
+        assert LANGUAGE_REGISTRY[".yaml"].lexer == "yaml"
+        assert LANGUAGE_REGISTRY[".json"].lexer == "json"
+        assert LANGUAGE_REGISTRY[".toml"].lexer == "toml"
+        assert LANGUAGE_REGISTRY[".md"].lexer == "markdown"
+
+
+class TestGetSemanticLanguage:
+    """Tests for get_semantic_language function."""
+
+    def test_known_extension(self) -> None:
+        """Known extensions should return correct semantic code."""
+        assert get_semantic_language(".py") == "py"
+        assert get_semantic_language(".ts") == "ts"
+        assert get_semantic_language(".go") == "go"
+        assert get_semantic_language(".rs") == "rs"
+
+    def test_unknown_extension_returns_txt(self) -> None:
+        """Unknown extensions should return 'txt'."""
+        assert get_semantic_language(".xyz") == "txt"
+        assert get_semantic_language(".unknown") == "txt"
+        assert get_semantic_language("") == "txt"
+
+    def test_case_insensitive(self) -> None:
+        """Extension lookup should be case-insensitive."""
+        assert get_semantic_language(".PY") == "py"
+        assert get_semantic_language(".Ts") == "ts"
+        assert get_semantic_language(".GO") == "go"
+
+
+class TestGetLexerName:
+    """Tests for get_lexer_name function."""
+
+    def test_known_extension(self) -> None:
+        """Known extensions should return correct lexer name."""
+        assert get_lexer_name(".py") == "python"
+        assert get_lexer_name(".ts") == "typescript"
+        assert get_lexer_name(".go") == "go"
+        assert get_lexer_name(".rs") == "rust"
+
+    def test_unknown_extension_returns_text(self) -> None:
+        """Unknown extensions should return 'text'."""
+        assert get_lexer_name(".xyz") == "text"
+        assert get_lexer_name(".unknown") == "text"
+        assert get_lexer_name("") == "text"
+
+    def test_case_insensitive(self) -> None:
+        """Extension lookup should be case-insensitive."""
+        assert get_lexer_name(".PY") == "python"
+        assert get_lexer_name(".Ts") == "typescript"
+        assert get_lexer_name(".GO") == "go"
+
+
+class TestIsCodeFile:
+    """Tests for is_code_file function."""
+
+    def test_code_files_return_true(self) -> None:
+        """Code file extensions should return True."""
+        assert is_code_file(".py") is True
+        assert is_code_file(".ts") is True
+        assert is_code_file(".go") is True
+        assert is_code_file(".rs") is True
+        assert is_code_file(".java") is True
+
+    def test_config_files_return_false(self) -> None:
+        """Config/data file extensions should return False."""
+        assert is_code_file(".yaml") is False
+        assert is_code_file(".yml") is False
+        assert is_code_file(".json") is False
+        assert is_code_file(".toml") is False
+        assert is_code_file(".md") is False
+
+    def test_unknown_extension_returns_false(self) -> None:
+        """Unknown extensions should return False."""
+        assert is_code_file(".xyz") is False
+        assert is_code_file(".unknown") is False
+        assert is_code_file("") is False
+
+    def test_case_insensitive(self) -> None:
+        """Extension lookup should be case-insensitive."""
+        assert is_code_file(".PY") is True
+        assert is_code_file(".Ts") is True
+        assert is_code_file(".YAML") is False
+
+
+class TestGetCodeFileExtensions:
+    """Tests for get_code_file_extensions function."""
+
+    def test_returns_frozenset(self) -> None:
+        """Should return an immutable frozenset."""
+        result = get_code_file_extensions()
+        assert isinstance(result, frozenset)
+
+    def test_contains_code_extensions(self) -> None:
+        """Should contain all code file extensions."""
+        result = get_code_file_extensions()
+        assert ".py" in result
+        assert ".ts" in result
+        assert ".go" in result
+        assert ".rs" in result
+        assert ".java" in result
+
+    def test_excludes_config_extensions(self) -> None:
+        """Should not contain config/data file extensions."""
+        result = get_code_file_extensions()
+        assert ".yaml" not in result
+        assert ".yml" not in result
+        assert ".json" not in result
+        assert ".toml" not in result
+        assert ".md" not in result
+
+    def test_consistency_with_is_code_file(self) -> None:
+        """get_code_file_extensions should match is_code_file for all registry entries."""
+        code_extensions = get_code_file_extensions()
+        for ext in LANGUAGE_REGISTRY:
+            if is_code_file(ext):
+                assert ext in code_extensions, f"{ext} should be in code extensions"
+            else:
+                assert ext not in code_extensions, f"{ext} should not be in code extensions"
+
+
+class TestRegistryConsistency:
+    """Tests to ensure the registry is internally consistent."""
+
+    def test_all_code_extensions_have_semantic(self) -> None:
+        """All code file extensions should have semantic language codes."""
+        for ext, info in LANGUAGE_REGISTRY.items():
+            if info.is_code:
+                assert info.semantic != "txt", f"Code file {ext} should have specific semantic code"
+
+    def test_cpp_family_consistency(self) -> None:
+        """C++ extensions should all map to same semantic code."""
+        cpp_extensions = [".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx"]
+        semantics = {LANGUAGE_REGISTRY[ext].semantic for ext in cpp_extensions}
+        assert len(semantics) == 1, f"C++ extensions should all have same semantic: {semantics}"
+        assert "cpp" in semantics
+
+    def test_shell_family_consistency(self) -> None:
+        """Shell extensions should all map to same semantic code."""
+        shell_extensions = [".sh", ".bash", ".zsh"]
+        semantics = {LANGUAGE_REGISTRY[ext].semantic for ext in shell_extensions}
+        assert len(semantics) == 1, f"Shell extensions should all have same semantic: {semantics}"
+        assert "sh" in semantics
+
+    def test_yaml_family_consistency(self) -> None:
+        """YAML extensions should all map to same semantic code."""
+        yaml_extensions = [".yaml", ".yml"]
+        for ext in yaml_extensions:
+            assert LANGUAGE_REGISTRY[ext].semantic == "txt"
+            assert LANGUAGE_REGISTRY[ext].lexer == "yaml"
+            assert LANGUAGE_REGISTRY[ext].is_code is False


### PR DESCRIPTION
## Summary

- Create a single source of truth for language/extension mappings that were previously duplicated across three files
- Add `ember/core/languages.py` with a unified `LANGUAGE_REGISTRY` that centralizes all language metadata
- Refactor consumers to use the new registry helper functions

Implements #389

## Changes

### New Files
- `ember/core/languages.py` - Unified language registry with helper functions:
  - `get_semantic_language(suffix)` - For tree-sitter/chunking
  - `get_lexer_name(suffix)` - For Pygments syntax highlighting
  - `is_code_file(suffix)` - For file filtering
  - `get_code_file_extensions()` - For getting all code file extensions

### Refactored Files
- `ember/core/indexing/file_preprocessor.py` - Uses `get_semantic_language()`
- `ember/core/presentation/colors.py` - Uses `get_lexer_name()`
- `ember/core/indexing/file_filter.py` - Uses `is_code_file()`

### Tests
- Added 28 comprehensive tests for the language registry
- Updated existing tests to use new registry imports

## Benefits

1. **DRY**: Language mappings now defined in only one place
2. **Maintainability**: Adding new language support requires changes to only one file
3. **Consistency**: Tests verify all registry entries have valid structure
4. **Type Safety**: Using frozen dataclass with explicit typing

## Test plan

- [x] All 1333 tests pass
- [x] Linter passes on modified files
- [x] New language registry tests verify consistency
- [x] Registry consistency tests ensure:
  - All entries have valid LanguageInfo structure
  - C++, shell, and YAML extension families are consistent
  - Code files have non-"txt" semantic codes

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>