### PR TITLE
refactor: extract IndexConfig validation into helper methods (#390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Reduced IndexConfig.__post_init__ cyclomatic complexity from 11 to 1** (#390)
+  - Extracted numeric parameter validation into `_validate_numeric_params()` method (CC=7)
+  - Extracted glob pattern validation into reusable `_validate_glob_patterns()` method (CC=3)
+  - Validation logic is now independently testable and easier to maintain
+
 - **Created unified language registry to eliminate duplication** (#389)
   - Language/extension mappings were previously defined in three separate locations with overlapping but inconsistent data
   - Created `ember/core/languages.py` as single source of truth for all language mappings


### PR DESCRIPTION
## Summary

- Reduce cyclomatic complexity of `IndexConfig.__post_init__` from 11 to 1
- Extract numeric parameter validation into `_validate_numeric_params()` method (CC=7)
- Extract glob pattern validation into reusable `_validate_glob_patterns()` method (CC=3)

Closes #390

## Test Plan

- [x] All existing 78 config domain tests pass
- [x] Full test suite passes (1333 tests)
- [x] Linter passes (`ruff check`)
- [x] Cyclomatic complexity verified via AST analysis

## Complexity Analysis

| Method | Before | After |
|--------|--------|-------|
| `__post_init__` | CC=11 | CC=1 |
| `_validate_numeric_params` | N/A | CC=7 |
| `_validate_glob_patterns` | N/A | CC=3 |

🤖 Generated with [Claude Code](https://claude.ai/code)