### PR TITLE
refactor: make Query dataclass immutable with frozen=True (#391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Made Query dataclass immutable with frozen=True** (#391)
+  - Query is now a frozen dataclass, preventing modification after creation
+  - Added `Query.from_strings()` factory method for creating queries from CLI inputs
+  - Direct construction with value objects (PathFilter, LanguageFilter) still works
+  - Query instances are now hashable and can be used in sets/dicts
+
 - **Reduced IndexConfig.__post_init__ cyclomatic complexity from 11 to 1** (#390)
   - Extracted numeric parameter validation into `_validate_numeric_params()` method (CC=7)
   - Extracted glob pattern validation into reusable `_validate_glob_patterns()` method (CC=3)

--- a/ember/adapters/tui/search_ui.py
+++ b/ember/adapters/tui/search_ui.py
@@ -299,7 +299,7 @@ class InteractiveSearchUI:
                 start_time = time.time()
 
                 # Create query object
-                query = Query(
+                query = Query.from_strings(
                     text=self.session.query_text,
                     topk=self.topk,
                     path_filter=self.path_filter,

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -967,7 +967,7 @@ def find(
     from ember.domain.entities import Query
 
     # Create query object
-    query_obj = Query(
+    query_obj = Query.from_strings(
         text=query,
         topk=deps.topk,
         path_filter=path_filter,


### PR DESCRIPTION
## Summary

- Make `Query` dataclass immutable by adding `frozen=True`
- Add `Query.from_strings()` factory method for creating queries from CLI string inputs
- Update all call sites (CLI, TUI) to use the new factory method

## Changes

- **ember/domain/entities.py**: 
  - Added `frozen=True` to Query dataclass
  - Added `from_strings()` class method that converts string filters to value objects
  - Removed `_normalize_path_filter` and `_normalize_lang_filter` methods
  - Updated docstrings to document the new immutable design

- **ember/entrypoints/cli.py**: Changed `Query(...)` to `Query.from_strings(...)`

- **ember/adapters/tui/search_ui.py**: Changed `Query(...)` to `Query.from_strings(...)`

- **tests/unit/domain/test_entities.py**: 
  - Added `TestQueryImmutability` class (tests frozen behavior, hashability)
  - Added `TestQueryFromStrings` class (tests factory method)
  - Added `TestQueryDirectConstruction` class (tests value object construction)
  - Removed obsolete `_normalize_*` method tests

## Test Plan

- [x] All 1343 tests pass
- [x] Linter passes (ember/ directory)
- [x] New tests cover immutability and factory method

Implements #391

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>