### PR TITLE
fix: catch PATH and --in conflict during argument parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added comprehensive unit tests for extracted services (40+ new tests)
 
 ### Fixed
+- **PATH and --in conflict now caught during argument parsing with helpful examples** (#397)
+  - Previously, using both PATH and --in options in `find` or `search` raised a domain error at runtime
+  - Now raises Click UsageError (exit code 2) immediately during argument parsing
+  - Error message includes examples of correct usage:
+    ```
+    Cannot use both PATH and --in. Choose one:
+      ember find 'query' src/
+      ember find 'query' --in '*.py'
+    ```
+  - Help text updated to say "Mutually exclusive with PATH" instead of "Cannot be used with PATH argument"
+
 - **Global config preserved when local config has parse error** (#396)
   - Previously, when local `.ember/config.toml` failed to parse, global config was discarded
   - Now preserves global config settings and warns with accurate message "Using global configuration"

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -45,6 +45,58 @@ from ember.domain.exceptions import EmberDomainError
 from ember.version import __version__
 
 
+def _make_path_in_exclusive_callback(command_name: str, in_param_name: str = "path_filter"):
+    """Create a callback that validates PATH and --in are mutually exclusive.
+
+    This validates the constraint early during argument parsing, providing a
+    Click UsageError with helpful examples instead of a domain error at runtime.
+
+    Args:
+        command_name: Name of the command (e.g., "find", "search") for error message.
+        in_param_name: The parameter name for the --in option in ctx.params.
+
+    Returns:
+        A Click callback function for the path argument.
+    """
+    def callback(ctx: click.Context, param: click.Parameter, value: str | None) -> str | None:
+        # Check if --in filter was already provided
+        in_filter = ctx.params.get(in_param_name)
+        if value is not None and in_filter is not None:
+            raise click.UsageError(
+                f"Cannot use both PATH and --in. Choose one:\n"
+                f"  ember {command_name} 'query' {value}\n"
+                f"  ember {command_name} 'query' --in '{in_filter}'"
+            )
+        return value
+    return callback
+
+
+def _make_in_filter_exclusive_callback(command_name: str, path_param_name: str = "path"):
+    """Create a callback that validates --in and PATH are mutually exclusive.
+
+    This validates the constraint early during argument parsing, providing a
+    Click UsageError with helpful examples instead of a domain error at runtime.
+
+    Args:
+        command_name: Name of the command (e.g., "find", "search") for error message.
+        path_param_name: The parameter name for the PATH argument in ctx.params.
+
+    Returns:
+        A Click callback function for the --in option.
+    """
+    def callback(ctx: click.Context, param: click.Parameter, value: str | None) -> str | None:
+        # Check if PATH argument was already provided
+        path_value = ctx.params.get(path_param_name)
+        if value is not None and path_value is not None:
+            raise click.UsageError(
+                f"Cannot use both PATH and --in. Choose one:\n"
+                f"  ember {command_name} 'query' {path_value}\n"
+                f"  ember {command_name} 'query' --in '{value}'"
+            )
+        return value
+    return callback
+
+
 def handle_cli_errors(command_name: str):
     """Decorator to handle common CLI errors.
 
@@ -930,7 +982,13 @@ def sync(
 
 @cli.command()
 @click.argument("query", type=str)
-@click.argument("path", type=str, required=False, default=None)
+@click.argument(
+    "path",
+    type=str,
+    required=False,
+    default=None,
+    callback=_make_path_in_exclusive_callback("find"),
+)
 @click.option(
     "--topk",
     "-k",
@@ -948,7 +1006,9 @@ def sync(
     "--in",
     "path_filter",
     type=str,
-    help="Filter results by path glob (e.g., '*.py'). Cannot be used with PATH argument.",
+    callback=_make_in_filter_exclusive_callback("find"),
+    is_eager=True,
+    help="Filter results by path glob (e.g., '*.py'). Mutually exclusive with PATH.",
 )
 @click.option(
     "--lang",
@@ -1053,12 +1113,20 @@ def find(
 
 
 @cli.command()
-@click.argument("path", type=str, required=False, default=None)
+@click.argument(
+    "path",
+    type=str,
+    required=False,
+    default=None,
+    callback=_make_path_in_exclusive_callback("search", in_param_name="file_pattern"),
+)
 @click.option(
     "--in",
     "file_pattern",
     type=str,
-    help="Filter by glob pattern (e.g., '*.py'). Cannot be used with PATH argument.",
+    callback=_make_in_filter_exclusive_callback("search"),
+    is_eager=True,
+    help="Filter by glob pattern (e.g., '*.py'). Mutually exclusive with PATH.",
 )
 @click.option(
     "--lang",

--- a/tests/integration/test_cli_commands.py
+++ b/tests/integration/test_cli_commands.py
@@ -452,7 +452,11 @@ class TestFindCommand:
     def test_find_path_and_in_filter_mutually_exclusive(
         self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
     ) -> None:
-        """Test that PATH argument and --in filter are mutually exclusive."""
+        """Test that PATH argument and --in filter are mutually exclusive.
+
+        The error should be raised during argument parsing (UsageError with
+        exit code 2), not during execution, and should include usage examples.
+        """
         monkeypatch.chdir(git_repo_isolated)
         # Init
         runner.invoke(cli, ["init"], catch_exceptions=False)
@@ -464,11 +468,15 @@ class TestFindCommand:
             catch_exceptions=False
         )
 
-        # Should fail with error about mutually exclusive options
-        assert_command_failed(result, context="PATH and --in together")
+        # Should fail with Click UsageError (exit code 2), not domain error (exit code 1)
+        assert_command_failed(result, expected_code=2, context="PATH and --in together")
+        # Should show helpful error message
         assert_output_matches(
-            result, r"mutually exclusive|cannot use both", flags=__import__("re").IGNORECASE
+            result, r"cannot use both", flags=__import__("re").IGNORECASE
         )
+        # Should include usage examples (Issue #397)
+        assert_output_contains(result, "ember find")
+        assert_output_matches(result, r"--in|PATH")
 
 
 class TestSearchCommand:
@@ -477,7 +485,11 @@ class TestSearchCommand:
     def test_search_path_and_in_filter_mutually_exclusive(
         self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
     ) -> None:
-        """Test that PATH argument and --in flag are mutually exclusive."""
+        """Test that PATH argument and --in flag are mutually exclusive.
+
+        The error should be raised during argument parsing (UsageError with
+        exit code 2), not during execution, and should include usage examples.
+        """
         monkeypatch.chdir(git_repo_isolated)
         # Init
         runner.invoke(cli, ["init"], catch_exceptions=False)
@@ -489,11 +501,15 @@ class TestSearchCommand:
             catch_exceptions=False
         )
 
-        # Should fail with error about mutually exclusive options
-        assert_command_failed(result, context="search PATH and --in together")
+        # Should fail with Click UsageError (exit code 2), not domain error (exit code 1)
+        assert_command_failed(result, expected_code=2, context="search PATH and --in together")
+        # Should show helpful error message
         assert_output_matches(
-            result, r"mutually exclusive|cannot use both", flags=__import__("re").IGNORECASE
+            result, r"cannot use both", flags=__import__("re").IGNORECASE
         )
+        # Should include usage examples (Issue #397)
+        assert_output_contains(result, "ember search")
+        assert_output_matches(result, r"--in|PATH")
 
     def test_search_accepts_path_argument(
         self, runner: CliRunner, git_repo_isolated: Path, monkeypatch


### PR DESCRIPTION
## Summary
- Catch PATH and --in mutual exclusivity during argument parsing instead of runtime
- Error message now includes helpful usage examples showing both valid options
- Exit code changed from 1 (domain error) to 2 (Click UsageError)
- Help text updated to "Mutually exclusive with PATH" for clarity

Closes #397

## Test Plan
- [x] Tests verify exit code 2 (Click UsageError) instead of 1
- [x] Tests verify error message contains "ember find" and "ember search" examples
- [x] All 58 CLI integration tests pass
- [x] Full test suite passes (1378 passed)
- [x] Lints pass on modified files