### PR TITLE
refactor: extract duplicate _get_context into shared context_utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Extracted duplicate `_get_context` implementations into shared utility** (#394)
+  - Created `context_utils.py` with `ContextData`, `ContextLine`, and `get_context_for_result()`
+  - `JsonResultFormatter` and `ResultPresenter` now use the shared utility
+  - Added 16 unit tests for the new context extraction utility
+  - No changes to output format - existing behavior preserved
+
 ### Improved
 - **Sync errors now provide targeted, actionable hints** (#400)
   - Database corruption errors now suggest `ember sync --reindex` to rebuild the index

--- a/ember/core/presentation/__init__.py
+++ b/ember/core/presentation/__init__.py
@@ -5,10 +5,16 @@ Components:
 - JsonResultFormatter: JSON serialization
 - CompactPreviewRenderer: Compact previews without context
 - ContextRenderer: Results with surrounding context lines
+- ContextData, ContextLine: Shared context extraction utilities
 """
 
 from ember.core.presentation.compact_renderer import CompactPreviewRenderer
 from ember.core.presentation.context_renderer import ContextRenderer
+from ember.core.presentation.context_utils import (
+    ContextData,
+    ContextLine,
+    get_context_for_result,
+)
 from ember.core.presentation.json_formatter import JsonResultFormatter
 from ember.core.presentation.result_presenter import ResultPresenter
 
@@ -17,4 +23,7 @@ __all__ = [
     "JsonResultFormatter",
     "CompactPreviewRenderer",
     "ContextRenderer",
+    "ContextData",
+    "ContextLine",
+    "get_context_for_result",
 ]

--- a/ember/core/presentation/context_utils.py
+++ b/ember/core/presentation/context_utils.py
@@ -1,0 +1,151 @@
+"""Shared utilities for extracting context lines around search results.
+
+This module provides a single implementation of context extraction logic
+used by multiple presentation components (JsonResultFormatter, ResultPresenter).
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+
+class FileSystemReader(Protocol):
+    """Protocol for file system read operations."""
+
+    def read_text_lines(self, path: Path) -> list[str] | None:
+        """Read file and return lines.
+
+        Args:
+            path: Path to file to read.
+
+        Returns:
+            List of lines, or None if file doesn't exist or can't be read.
+        """
+        ...
+
+
+@dataclass
+class ContextLine:
+    """A single line of context with its line number.
+
+    Attributes:
+        line: 1-based line number in the file.
+        content: The text content of the line.
+    """
+
+    line: int
+    content: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization.
+
+        Returns:
+            Dictionary with 'line' and 'content' keys.
+        """
+        return {"line": self.line, "content": self.content}
+
+
+@dataclass
+class ContextData:
+    """Context lines partitioned around a search result chunk.
+
+    Attributes:
+        before: Lines before the chunk.
+        chunk: Lines within the chunk.
+        after: Lines after the chunk.
+        start_line: First line number in the context range (1-based).
+        end_line: Last line number in the context range (1-based).
+    """
+
+    before: list[ContextLine]
+    chunk: list[ContextLine]
+    after: list[ContextLine]
+    start_line: int
+    end_line: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization.
+
+        Returns:
+            Dictionary with 'before', 'chunk', 'after', 'start_line', 'end_line' keys.
+        """
+        return {
+            "before": [line.to_dict() for line in self.before],
+            "chunk": [line.to_dict() for line in self.chunk],
+            "after": [line.to_dict() for line in self.after],
+            "start_line": self.start_line,
+            "end_line": self.end_line,
+        }
+
+
+def get_context_for_result(
+    result: Any,
+    context_lines: int,
+    repo_root: Path,
+    fs: FileSystemReader | None = None,
+    file_reader: Callable[[Path], list[str] | None] | None = None,
+) -> ContextData | None:
+    """Extract context lines around a search result.
+
+    Reads the file containing the search result and partitions lines into
+    before/chunk/after segments based on the chunk's line range.
+
+    Args:
+        result: SearchResult object with a chunk attribute containing path,
+                start_line, and end_line.
+        context_lines: Number of lines of context to include before and after
+                       the chunk.
+        repo_root: Repository root path for resolving relative file paths.
+        fs: FileSystem port for reading file contents. Required if file_reader
+            is not provided.
+        file_reader: Optional custom function to read file lines. If provided,
+                     takes precedence over fs. Should return list of lines or None.
+
+    Returns:
+        ContextData with partitioned lines, or None if file not readable.
+
+    Raises:
+        ValueError: If neither fs nor file_reader is provided.
+    """
+    # Determine how to read the file
+    if file_reader is not None:
+        file_lines = file_reader(repo_root / result.chunk.path)
+    elif fs is not None:
+        file_lines = fs.read_text_lines(repo_root / result.chunk.path)
+    else:
+        raise ValueError("Either fs or file_reader must be provided")
+
+    if file_lines is None:
+        return None
+
+    start_line = result.chunk.start_line
+    end_line = result.chunk.end_line
+
+    # Calculate context range (1-based line numbers)
+    context_start = max(1, start_line - context_lines)
+    context_end = min(len(file_lines), end_line + context_lines)
+
+    # Collect context lines
+    before_lines: list[ContextLine] = []
+    chunk_lines: list[ContextLine] = []
+    after_lines: list[ContextLine] = []
+
+    for line_num in range(context_start, context_end + 1):
+        line_content = file_lines[line_num - 1]  # Convert to 0-based
+        context_line = ContextLine(line=line_num, content=line_content)
+
+        if line_num < start_line:
+            before_lines.append(context_line)
+        elif line_num > end_line:
+            after_lines.append(context_line)
+        else:
+            chunk_lines.append(context_line)
+
+    return ContextData(
+        before=before_lines,
+        chunk=chunk_lines,
+        after=after_lines,
+        start_line=context_start,
+        end_line=context_end,
+    )

--- a/ember/core/presentation/json_formatter.py
+++ b/ember/core/presentation/json_formatter.py
@@ -8,6 +8,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from ember.core.presentation.context_utils import get_context_for_result
 from ember.ports.fs import FileSystem
 
 
@@ -109,37 +110,14 @@ class JsonResultFormatter:
         Returns:
             Dictionary with context information, or None if file not readable.
         """
-        file_path = repo_root / result.chunk.path
-        file_lines = self._fs.read_text_lines(file_path)
+        context_data = get_context_for_result(
+            result=result,
+            context_lines=context,
+            repo_root=repo_root,
+            fs=self._fs,
+        )
 
-        if file_lines is None:
+        if context_data is None:
             return None
 
-        start_line = result.chunk.start_line
-        end_line = result.chunk.end_line
-
-        # Calculate context range (1-based line numbers)
-        context_start = max(1, start_line - context)
-        context_end = min(len(file_lines), end_line + context)
-
-        # Collect context lines
-        before_lines = []
-        chunk_lines = []
-        after_lines = []
-
-        for line_num in range(context_start, context_end + 1):
-            line_content = file_lines[line_num - 1]  # Convert to 0-based
-            if line_num < start_line:
-                before_lines.append({"line": line_num, "content": line_content})
-            elif line_num > end_line:
-                after_lines.append({"line": line_num, "content": line_content})
-            else:
-                chunk_lines.append({"line": line_num, "content": line_content})
-
-        return {
-            "before": before_lines,
-            "chunk": chunk_lines,
-            "after": after_lines,
-            "start_line": context_start,
-            "end_line": context_end,
-        }
+        return context_data.to_dict()

--- a/ember/core/presentation/result_presenter.py
+++ b/ember/core/presentation/result_presenter.py
@@ -15,6 +15,7 @@ import click
 from ember.core.presentation.colors import EmberColors
 from ember.core.presentation.compact_renderer import CompactPreviewRenderer
 from ember.core.presentation.context_renderer import ContextRenderer
+from ember.core.presentation.context_utils import get_context_for_result
 from ember.core.presentation.json_formatter import JsonResultFormatter
 from ember.ports.fs import FileSystem
 
@@ -221,7 +222,7 @@ class ResultPresenter:
     ) -> dict[str, Any] | None:
         """Get context lines for a search result.
 
-        Delegates to JsonResultFormatter.
+        Uses shared context_utils for extraction.
 
         Args:
             result: SearchResult object.
@@ -231,4 +232,14 @@ class ResultPresenter:
         Returns:
             Dictionary with context information, or None if file not readable.
         """
-        return self._json_formatter._get_context(result, context, repo_root)
+        context_data = get_context_for_result(
+            result=result,
+            context_lines=context,
+            repo_root=repo_root,
+            fs=self._fs,
+        )
+
+        if context_data is None:
+            return None
+
+        return context_data.to_dict()

--- a/tests/unit/core/presentation/__init__.py
+++ b/tests/unit/core/presentation/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for presentation layer."""

--- a/tests/unit/core/presentation/test_context_utils.py
+++ b/tests/unit/core/presentation/test_context_utils.py
@@ -1,0 +1,401 @@
+"""Tests for context_utils module.
+
+Tests the shared utility functions for extracting context lines around search results.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ember.core.presentation.context_utils import (
+    ContextData,
+    ContextLine,
+    get_context_for_result,
+)
+from ember.domain.entities import SearchExplanation
+
+
+@dataclass
+class MockChunk:
+    """Mock Chunk for testing."""
+
+    id: str = "test-chunk-id"
+    project_id: str = "test-project"
+    path: Path = field(default_factory=lambda: Path("src/example.py"))
+    lang: str = "py"
+    symbol: str | None = "test_function"
+    start_line: int = 10
+    end_line: int = 15
+    content: str = "def test_function():\n    pass\n    return True"
+    content_hash: str = "abc123"
+    file_hash: str = "def456"
+    tree_sha: str = "sha123"
+    rev: str = "worktree"
+
+
+@dataclass
+class MockSearchResult:
+    """Mock SearchResult for testing."""
+
+    chunk: MockChunk = field(default_factory=MockChunk)
+    score: float = 0.95
+    rank: int = 1
+    preview: str = "def test_function():"
+    explanation: SearchExplanation = field(
+        default_factory=lambda: SearchExplanation(fused_score=0.0)
+    )
+
+
+class MockFileSystem:
+    """Mock FileSystem for testing."""
+
+    def __init__(self, file_contents: dict[Path, list[str]] | None = None):
+        """Initialize with optional file contents mapping.
+
+        Args:
+            file_contents: Dict mapping paths to list of lines.
+        """
+        self._files = file_contents or {}
+
+    def read_text_lines(self, path: Path) -> list[str] | None:
+        """Return mocked file lines or None."""
+        return self._files.get(path)
+
+
+class TestContextDataDataclass:
+    """Tests for ContextData dataclass."""
+
+    def test_context_data_creation(self):
+        """ContextData can be created with all fields."""
+        before = [ContextLine(line=1, content="line1")]
+        chunk = [ContextLine(line=2, content="line2")]
+        after = [ContextLine(line=3, content="line3")]
+
+        data = ContextData(
+            before=before,
+            chunk=chunk,
+            after=after,
+            start_line=1,
+            end_line=3,
+        )
+
+        assert data.before == before
+        assert data.chunk == chunk
+        assert data.after == after
+        assert data.start_line == 1
+        assert data.end_line == 3
+
+    def test_context_data_to_dict(self):
+        """ContextData can be converted to dictionary."""
+        before = [ContextLine(line=1, content="line1")]
+        chunk = [ContextLine(line=2, content="line2")]
+        after = [ContextLine(line=3, content="line3")]
+
+        data = ContextData(
+            before=before,
+            chunk=chunk,
+            after=after,
+            start_line=1,
+            end_line=3,
+        )
+
+        result = data.to_dict()
+
+        assert result == {
+            "before": [{"line": 1, "content": "line1"}],
+            "chunk": [{"line": 2, "content": "line2"}],
+            "after": [{"line": 3, "content": "line3"}],
+            "start_line": 1,
+            "end_line": 3,
+        }
+
+
+class TestContextLineDataclass:
+    """Tests for ContextLine dataclass."""
+
+    def test_context_line_creation(self):
+        """ContextLine can be created with line number and content."""
+        line = ContextLine(line=5, content="hello world")
+
+        assert line.line == 5
+        assert line.content == "hello world"
+
+    def test_context_line_to_dict(self):
+        """ContextLine can be converted to dictionary."""
+        line = ContextLine(line=5, content="hello world")
+
+        result = line.to_dict()
+
+        assert result == {"line": 5, "content": "hello world"}
+
+
+class TestGetContextForResult:
+    """Tests for get_context_for_result function."""
+
+    def test_returns_context_with_before_and_after_lines(self):
+        """Returns ContextData with proper before/chunk/after partitioning."""
+        file_contents = {
+            Path("/repo/test.py"): ["line1", "line2", "line3", "line4", "line5"]
+        }
+        mock_fs = MockFileSystem(file_contents)
+
+        chunk = MockChunk(path=Path("test.py"), start_line=3, end_line=3)
+        result = MockSearchResult(chunk=chunk)
+
+        context = get_context_for_result(
+            result=result,
+            context_lines=1,
+            repo_root=Path("/repo"),
+            fs=mock_fs,
+        )
+
+        assert context is not None
+        assert len(context.before) == 1
+        assert context.before[0].line == 2
+        assert context.before[0].content == "line2"
+        assert len(context.chunk) == 1
+        assert context.chunk[0].line == 3
+        assert context.chunk[0].content == "line3"
+        assert len(context.after) == 1
+        assert context.after[0].line == 4
+        assert context.after[0].content == "line4"
+
+    def test_handles_multi_line_chunk(self):
+        """Handles chunks spanning multiple lines."""
+        file_contents = {
+            Path("/repo/test.py"): [
+                "line1",
+                "line2",
+                "line3",
+                "line4",
+                "line5",
+                "line6",
+            ]
+        }
+        mock_fs = MockFileSystem(file_contents)
+
+        chunk = MockChunk(path=Path("test.py"), start_line=3, end_line=4)
+        result = MockSearchResult(chunk=chunk)
+
+        context = get_context_for_result(
+            result=result,
+            context_lines=1,
+            repo_root=Path("/repo"),
+            fs=mock_fs,
+        )
+
+        assert context is not None
+        assert len(context.before) == 1
+        assert context.before[0].line == 2
+        assert len(context.chunk) == 2
+        assert context.chunk[0].line == 3
+        assert context.chunk[1].line == 4
+        assert len(context.after) == 1
+        assert context.after[0].line == 5
+
+    def test_handles_file_start_boundary(self):
+        """Handles context request at the start of file."""
+        file_contents = {Path("/repo/test.py"): ["line1", "line2", "line3"]}
+        mock_fs = MockFileSystem(file_contents)
+
+        chunk = MockChunk(path=Path("test.py"), start_line=1, end_line=1)
+        result = MockSearchResult(chunk=chunk)
+
+        context = get_context_for_result(
+            result=result,
+            context_lines=2,
+            repo_root=Path("/repo"),
+            fs=mock_fs,
+        )
+
+        assert context is not None
+        assert len(context.before) == 0
+        assert context.start_line == 1
+        assert len(context.chunk) == 1
+        assert len(context.after) == 2
+
+    def test_handles_file_end_boundary(self):
+        """Handles context request at the end of file."""
+        file_contents = {Path("/repo/test.py"): ["line1", "line2", "line3"]}
+        mock_fs = MockFileSystem(file_contents)
+
+        chunk = MockChunk(path=Path("test.py"), start_line=3, end_line=3)
+        result = MockSearchResult(chunk=chunk)
+
+        context = get_context_for_result(
+            result=result,
+            context_lines=2,
+            repo_root=Path("/repo"),
+            fs=mock_fs,
+        )
+
+        assert context is not None
+        assert len(context.before) == 2
+        assert len(context.chunk) == 1
+        assert len(context.after) == 0
+        assert context.end_line == 3
+
+    def test_returns_none_for_missing_file(self):
+        """Returns None when file doesn't exist."""
+        mock_fs = MockFileSystem()  # Empty - no files
+
+        chunk = MockChunk(path=Path("nonexistent.py"), start_line=1, end_line=1)
+        result = MockSearchResult(chunk=chunk)
+
+        context = get_context_for_result(
+            result=result,
+            context_lines=1,
+            repo_root=Path("/repo"),
+            fs=mock_fs,
+        )
+
+        assert context is None
+
+    def test_returns_correct_start_and_end_lines(self):
+        """Returns correct context start and end line numbers."""
+        file_contents = {
+            Path("/repo/test.py"): [f"line{i}" for i in range(1, 21)]
+        }
+        mock_fs = MockFileSystem(file_contents)
+
+        chunk = MockChunk(path=Path("test.py"), start_line=10, end_line=12)
+        result = MockSearchResult(chunk=chunk)
+
+        context = get_context_for_result(
+            result=result,
+            context_lines=3,
+            repo_root=Path("/repo"),
+            fs=mock_fs,
+        )
+
+        assert context is not None
+        assert context.start_line == 7  # 10 - 3
+        assert context.end_line == 15  # 12 + 3
+
+    def test_zero_context_lines(self):
+        """With zero context lines, only returns chunk lines."""
+        file_contents = {
+            Path("/repo/test.py"): ["line1", "line2", "line3", "line4", "line5"]
+        }
+        mock_fs = MockFileSystem(file_contents)
+
+        chunk = MockChunk(path=Path("test.py"), start_line=2, end_line=4)
+        result = MockSearchResult(chunk=chunk)
+
+        context = get_context_for_result(
+            result=result,
+            context_lines=0,
+            repo_root=Path("/repo"),
+            fs=mock_fs,
+        )
+
+        assert context is not None
+        assert len(context.before) == 0
+        assert len(context.chunk) == 3
+        assert len(context.after) == 0
+        assert context.start_line == 2
+        assert context.end_line == 4
+
+    def test_large_context_clamped_to_file_bounds(self):
+        """Large context request is clamped to file boundaries."""
+        file_contents = {Path("/repo/test.py"): ["line1", "line2", "line3"]}
+        mock_fs = MockFileSystem(file_contents)
+
+        chunk = MockChunk(path=Path("test.py"), start_line=2, end_line=2)
+        result = MockSearchResult(chunk=chunk)
+
+        context = get_context_for_result(
+            result=result,
+            context_lines=100,
+            repo_root=Path("/repo"),
+            fs=mock_fs,
+        )
+
+        assert context is not None
+        assert context.start_line == 1
+        assert context.end_line == 3
+        assert len(context.before) == 1
+        assert len(context.chunk) == 1
+        assert len(context.after) == 1
+
+    def test_uses_custom_file_reader(self):
+        """Can use custom file reader function instead of filesystem."""
+        custom_lines = ["custom1", "custom2", "custom3"]
+
+        def custom_reader(path: Path) -> list[str]:
+            return custom_lines
+
+        chunk = MockChunk(path=Path("test.py"), start_line=2, end_line=2)
+        result = MockSearchResult(chunk=chunk)
+
+        context = get_context_for_result(
+            result=result,
+            context_lines=1,
+            repo_root=Path("/repo"),
+            file_reader=custom_reader,
+        )
+
+        assert context is not None
+        assert context.chunk[0].content == "custom2"
+
+    def test_custom_file_reader_returning_none(self):
+        """Returns None when custom file reader returns None."""
+
+        def failing_reader(path: Path) -> list[str] | None:
+            return None
+
+        chunk = MockChunk(path=Path("test.py"), start_line=2, end_line=2)
+        result = MockSearchResult(chunk=chunk)
+
+        context = get_context_for_result(
+            result=result,
+            context_lines=1,
+            repo_root=Path("/repo"),
+            file_reader=failing_reader,
+        )
+
+        assert context is None
+
+    def test_fs_parameter_is_used_when_file_reader_not_provided(self):
+        """Uses fs.read_text_lines when file_reader is not provided."""
+        file_contents = {Path("/repo/test.py"): ["fs_line1", "fs_line2", "fs_line3"]}
+        mock_fs = MockFileSystem(file_contents)
+
+        chunk = MockChunk(path=Path("test.py"), start_line=2, end_line=2)
+        result = MockSearchResult(chunk=chunk)
+
+        context = get_context_for_result(
+            result=result,
+            context_lines=1,
+            repo_root=Path("/repo"),
+            fs=mock_fs,
+        )
+
+        assert context is not None
+        assert context.chunk[0].content == "fs_line2"
+
+
+class TestContextDataIntegration:
+    """Integration tests for ContextData usage patterns."""
+
+    def test_context_data_works_with_json_serialization(self):
+        """ContextData.to_dict() output is JSON serializable."""
+        import json
+
+        data = ContextData(
+            before=[ContextLine(line=1, content="before")],
+            chunk=[ContextLine(line=2, content="chunk")],
+            after=[ContextLine(line=3, content="after")],
+            start_line=1,
+            end_line=3,
+        )
+
+        # Should not raise
+        json_str = json.dumps(data.to_dict())
+        parsed = json.loads(json_str)
+
+        assert parsed["before"][0]["content"] == "before"
+        assert parsed["chunk"][0]["content"] == "chunk"
+        assert parsed["after"][0]["content"] == "after"


### PR DESCRIPTION
## Summary
- Created `context_utils.py` with `ContextData`, `ContextLine`, and `get_context_for_result()` to eliminate duplicate implementations
- Updated `JsonResultFormatter` and `ResultPresenter` to use the shared utility
- Added 16 unit tests for the new context extraction utility
- Exported new utilities from presentation package `__init__.py`

Fixes #394

## Test Plan
- [x] All 1431 tests pass
- [x] Linter passes (`uv run ruff check .`)
- [x] Existing output format preserved (no behavioral changes)
- [x] New tests cover all edge cases (file boundaries, multi-line chunks, missing files, etc.)