### PR TITLE
fix: resolve daemon startup timeout race condition (#398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Daemon startup timeout no longer has race condition** (#398)
+  - Fixed race between stderr reading and process termination during startup failure
+  - stderr is now fully read before sending termination signals (SIGTERM/SIGKILL)
+  - Zombie processes are now properly reaped via `process.wait()`
+  - Startup failure error messages now include any captured stderr output
+  - No more socket errors from reading closed pipes during daemon startup failures
+
 - **`is_model_cached()` no longer loads the entire model to check cache** (#395)
   - Previously, the fallback path loaded the full model (~1.6GB for Jina) just to verify caching
   - Now uses direct HuggingFace cache directory inspection as fallback instead

--- a/ember/adapters/daemon/lifecycle.py
+++ b/ember/adapters/daemon/lifecycle.py
@@ -314,16 +314,89 @@ class DaemonLifecycle:
             self._cleanup_failed_startup()
             stderr_output = self._read_stderr_output(process)
 
+            # Close stderr after reading (#398)
+            if process.stderr:
+                with contextlib.suppress(OSError):
+                    process.stderr.close()
+
             error_msg = f"Daemon failed to start (exit code: {exit_code})"
             if stderr_output:
                 error_msg += f"\nStderr: {stderr_output}"
             error_msg += f"\nCheck daemon logs at: {self.log_file}"
             raise RuntimeError(error_msg)
 
+    def _read_and_close_stderr(self, process: subprocess.Popen) -> str:
+        """Read remaining stderr output and close the pipe.
+
+        This must be called before sending signals to avoid race conditions
+        where stderr is read while process is being terminated (#398).
+
+        Args:
+            process: The spawned process
+
+        Returns:
+            Decoded stderr output, or empty string if unavailable
+        """
+        if not process.stderr:
+            return ""
+
+        stderr_output = ""
+        try:
+            stderr_bytes = process.stderr.read()
+            if stderr_bytes:
+                stderr_output = stderr_bytes.decode("utf-8", errors="replace").strip()
+                if stderr_output:
+                    logger.debug(f"Stderr before timeout: {stderr_output}")
+        except OSError:
+            # Pipe may already be closed or broken
+            logger.debug("Failed to read stderr from process")
+
+        # Close stderr before sending signals
+        with contextlib.suppress(OSError):
+            process.stderr.close()
+
+        return stderr_output
+
+    def _terminate_unresponsive_process(self, process: subprocess.Popen) -> None:
+        """Terminate an unresponsive process with SIGTERM, falling back to SIGKILL.
+
+        Args:
+            process: The spawned process to terminate
+        """
+        try:
+            os.kill(process.pid, signal.SIGTERM)
+            # Give process brief time to exit gracefully
+            for _ in range(DaemonTimeouts.STARTUP_FAILURE_LOOP_COUNT):
+                time.sleep(DaemonTimeouts.STARTUP_FAILURE_LOOP_WAIT)
+                if not self.is_process_alive(process.pid):
+                    break
+            else:
+                # Force kill if still alive
+                os.kill(process.pid, signal.SIGKILL)
+        except OSError:
+            pass  # Process already dead
+
+    def _wait_for_process_exit(self, process: subprocess.Popen) -> None:
+        """Wait for process to exit and reap zombie.
+
+        Args:
+            process: The spawned process to wait for
+        """
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            logger.debug(f"Process {process.pid} did not exit within wait timeout")
+
     def _handle_startup_timeout(
         self, process: subprocess.Popen, timeout_used: float | None = None
     ) -> None:
         """Handle the case where daemon didn't become ready in time.
+
+        This method properly coordinates stderr reading with process lifecycle
+        to avoid race conditions (#398):
+        1. Read any remaining stderr before terminating
+        2. Close stderr before sending signals
+        3. Wait for process termination to reap zombie
 
         Args:
             process: The spawned process
@@ -336,6 +409,10 @@ class DaemonLifecycle:
         if timeout_used is None:
             timeout_used = DaemonTimeouts.READY_WAIT_DEFAULT
 
+        # Read and close stderr before any termination attempts (#398)
+        # This prevents race conditions between stderr reading and process death
+        stderr_output = self._read_and_close_stderr(process)
+
         if self.is_process_alive(process.pid):
             # Process is alive but not responding - terminate it to avoid orphan
             # This prevents the race condition where:
@@ -346,18 +423,11 @@ class DaemonLifecycle:
                 f"Daemon process {process.pid} not responding after "
                 f"{timeout_used}s, terminating..."
             )
-            try:
-                os.kill(process.pid, signal.SIGTERM)
-                # Give process brief time to exit gracefully
-                for _ in range(DaemonTimeouts.STARTUP_FAILURE_LOOP_COUNT):
-                    time.sleep(DaemonTimeouts.STARTUP_FAILURE_LOOP_WAIT)
-                    if not self.is_process_alive(process.pid):
-                        break
-                else:
-                    # Force kill if still alive
-                    os.kill(process.pid, signal.SIGKILL)
-            except OSError:
-                pass  # Process already dead
+
+            self._terminate_unresponsive_process(process)
+
+            # Reap zombie process (#398)
+            self._wait_for_process_exit(process)
 
             self._cleanup_failed_startup()
             raise RuntimeError(
@@ -367,11 +437,17 @@ class DaemonLifecycle:
                 f"Check daemon logs at: {self.log_file}"
             )
         else:
+            # Reap zombie process (#398)
+            self._wait_for_process_exit(process)
+
             self._cleanup_failed_startup()
-            raise RuntimeError(
-                f"Daemon process {process.pid} exited unexpectedly during startup. "
-                f"Check daemon logs at: {self.log_file}"
+            error_msg = (
+                f"Daemon process {process.pid} exited unexpectedly during startup."
             )
+            if stderr_output:
+                error_msg += f"\nStderr: {stderr_output}"
+            error_msg += f"\nCheck daemon logs at: {self.log_file}"
+            raise RuntimeError(error_msg)
 
     def start(self, foreground: bool = False) -> bool:
         """Start the daemon.
@@ -416,18 +492,19 @@ class DaemonLifecycle:
             process = self._spawn_background_process(cmd)
             self._write_pid_file(process)
 
-            try:
-                self._check_instant_failure(process)
-            finally:
-                if process.stderr:
-                    process.stderr.close()
+            # Check for instant failure - reads stderr if process died immediately
+            self._check_instant_failure(process)
 
             # Determine timeout based on whether model is cached
             startup_timeout = self._get_startup_timeout()
 
             if self._wait_for_daemon_ready(startup_timeout):
+                # Success - close stderr since daemon is ready
+                if process.stderr:
+                    process.stderr.close()
                 return True
 
+            # Timeout - _handle_startup_timeout will read/close stderr (#398)
             self._handle_startup_timeout(process, startup_timeout)
 
         except RuntimeError:

--- a/tests/unit/adapters/test_daemon_lifecycle.py
+++ b/tests/unit/adapters/test_daemon_lifecycle.py
@@ -383,3 +383,248 @@ class TestDynamicStartupTimeout:
 
                 # Should NOT call _get_startup_timeout when explicit timeout given
                 mock_get_timeout.assert_not_called()
+
+
+class TestHandleStartupTimeoutRaceCondition:
+    """Tests for _handle_startup_timeout race condition fix (#398).
+
+    The fix addresses:
+    - stderr may be closed while process is still writing
+    - Process may be killed while read operations are pending
+    - Zombie processes may not be reaped properly
+    """
+
+    @pytest.fixture
+    def lifecycle(self, tmp_path: Path) -> DaemonLifecycle:
+        """Create a DaemonLifecycle instance for testing."""
+        return DaemonLifecycle(
+            socket_path=tmp_path / "test.sock",
+            pid_file=tmp_path / "test.pid",
+            log_file=tmp_path / "test.log",
+        )
+
+    def test_handle_startup_timeout_reads_stderr_before_termination(
+        self, lifecycle: DaemonLifecycle
+    ) -> None:
+        """Test _handle_startup_timeout reads stderr before killing process."""
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_process.stderr = MagicMock()
+        mock_process.stderr.read.return_value = b"some error output"
+        mock_process.poll.return_value = None  # Process still running
+
+        with (
+            patch.object(lifecycle, "is_process_alive") as mock_alive,
+            patch.object(lifecycle, "_cleanup_failed_startup"),
+            patch("os.kill"),
+            patch("time.sleep"),
+            patch.object(mock_process, "wait"),
+        ):
+            # Process alive initially, then dies after SIGTERM
+            mock_alive.side_effect = [True, False]
+
+            with pytest.raises(RuntimeError):
+                lifecycle._handle_startup_timeout(mock_process, 30.0)
+
+            # Verify stderr was read before termination
+            mock_process.stderr.read.assert_called_once()
+
+    def test_handle_startup_timeout_closes_stderr_before_signals(
+        self, lifecycle: DaemonLifecycle
+    ) -> None:
+        """Test _handle_startup_timeout closes stderr before sending signals."""
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_process.stderr = MagicMock()
+        mock_process.stderr.read.return_value = b""
+        mock_process.poll.return_value = None
+
+        call_order = []
+
+        def track_close():
+            call_order.append("stderr_close")
+
+        def track_kill(pid, sig):
+            call_order.append(f"kill_{sig.name}")
+
+        mock_process.stderr.close = track_close
+
+        with (
+            patch.object(lifecycle, "is_process_alive") as mock_alive,
+            patch.object(lifecycle, "_cleanup_failed_startup"),
+            patch("os.kill", side_effect=track_kill),
+            patch("time.sleep"),
+            patch.object(mock_process, "wait"),
+        ):
+            mock_alive.side_effect = [True, False]
+
+            with pytest.raises(RuntimeError):
+                lifecycle._handle_startup_timeout(mock_process, 30.0)
+
+            # Verify stderr close happens before SIGTERM
+            assert "stderr_close" in call_order
+            assert "kill_SIGTERM" in call_order
+            assert call_order.index("stderr_close") < call_order.index("kill_SIGTERM")
+
+    def test_handle_startup_timeout_waits_for_process_termination(
+        self, lifecycle: DaemonLifecycle
+    ) -> None:
+        """Test _handle_startup_timeout calls process.wait() to reap zombie."""
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_process.stderr = MagicMock()
+        mock_process.stderr.read.return_value = b""
+        mock_process.poll.return_value = None
+
+        with (
+            patch.object(lifecycle, "is_process_alive") as mock_alive,
+            patch.object(lifecycle, "_cleanup_failed_startup"),
+            patch("os.kill"),
+            patch("time.sleep"),
+        ):
+            mock_alive.side_effect = [True, False]
+
+            with pytest.raises(RuntimeError):
+                lifecycle._handle_startup_timeout(mock_process, 30.0)
+
+            # Verify process.wait() is called to reap zombie
+            mock_process.wait.assert_called_once_with(timeout=5)
+
+    def test_handle_startup_timeout_handles_wait_timeout(
+        self, lifecycle: DaemonLifecycle
+    ) -> None:
+        """Test _handle_startup_timeout handles TimeoutExpired from process.wait()."""
+        import subprocess
+
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_process.stderr = MagicMock()
+        mock_process.stderr.read.return_value = b""
+        mock_process.poll.return_value = None
+        mock_process.wait.side_effect = subprocess.TimeoutExpired(
+            cmd=["test"], timeout=5
+        )
+
+        with (
+            patch.object(lifecycle, "is_process_alive") as mock_alive,
+            patch.object(lifecycle, "_cleanup_failed_startup"),
+            patch("os.kill"),
+            patch("time.sleep"),
+        ):
+            mock_alive.side_effect = [True, False]
+
+            # Should not raise due to TimeoutExpired from wait()
+            with pytest.raises(RuntimeError) as exc_info:
+                lifecycle._handle_startup_timeout(mock_process, 30.0)
+
+            # Should still raise the expected RuntimeError about timeout
+            assert "not responding to health checks" in str(exc_info.value)
+
+    def test_handle_startup_timeout_handles_none_stderr(
+        self, lifecycle: DaemonLifecycle
+    ) -> None:
+        """Test _handle_startup_timeout handles process with no stderr pipe."""
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_process.stderr = None  # No stderr pipe
+        mock_process.poll.return_value = None
+
+        with (
+            patch.object(lifecycle, "is_process_alive") as mock_alive,
+            patch.object(lifecycle, "_cleanup_failed_startup"),
+            patch("os.kill"),
+            patch("time.sleep"),
+            patch.object(mock_process, "wait"),
+        ):
+            mock_alive.side_effect = [True, False]
+
+            with pytest.raises(RuntimeError):
+                lifecycle._handle_startup_timeout(mock_process, 30.0)
+
+            # Should complete without error
+
+    def test_handle_startup_timeout_handles_stderr_read_error(
+        self, lifecycle: DaemonLifecycle
+    ) -> None:
+        """Test _handle_startup_timeout handles OSError when reading stderr."""
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_process.stderr = MagicMock()
+        mock_process.stderr.read.side_effect = OSError("Pipe closed")
+        mock_process.poll.return_value = None
+
+        with (
+            patch.object(lifecycle, "is_process_alive") as mock_alive,
+            patch.object(lifecycle, "_cleanup_failed_startup"),
+            patch("os.kill"),
+            patch("time.sleep"),
+            patch.object(mock_process, "wait"),
+        ):
+            mock_alive.side_effect = [True, False]
+
+            # Should not propagate OSError from stderr read
+            with pytest.raises(RuntimeError) as exc_info:
+                lifecycle._handle_startup_timeout(mock_process, 30.0)
+
+            assert "not responding to health checks" in str(exc_info.value)
+
+    def test_handle_startup_timeout_includes_stderr_in_dead_process_message(
+        self, lifecycle: DaemonLifecycle
+    ) -> None:
+        """Test error message includes stderr when process died during startup."""
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_process.stderr = MagicMock()
+        mock_process.stderr.read.return_value = b"ImportError: No module named foo"
+        mock_process.poll.return_value = None
+
+        with (
+            patch.object(lifecycle, "is_process_alive") as mock_alive,
+            patch.object(lifecycle, "_cleanup_failed_startup"),
+            patch("os.kill"),
+            patch("time.sleep"),
+            patch.object(mock_process, "wait"),
+        ):
+            # Process is already dead
+            mock_alive.return_value = False
+
+            with pytest.raises(RuntimeError) as exc_info:
+                lifecycle._handle_startup_timeout(mock_process, 30.0)
+
+            # Should include stderr output in the error message
+            assert "exited unexpectedly" in str(exc_info.value)
+            assert "ImportError" in str(exc_info.value)
+
+    def test_handle_startup_timeout_sigkill_fallback_when_sigterm_fails(
+        self, lifecycle: DaemonLifecycle
+    ) -> None:
+        """Test _handle_startup_timeout falls back to SIGKILL when SIGTERM fails."""
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_process.stderr = MagicMock()
+        mock_process.stderr.read.return_value = b""
+        mock_process.poll.side_effect = [None, None]  # Still running after SIGTERM
+
+        kill_calls = []
+
+        def track_kill(pid, sig):
+            kill_calls.append(sig)
+
+        with (
+            patch.object(lifecycle, "is_process_alive") as mock_alive,
+            patch.object(lifecycle, "_cleanup_failed_startup"),
+            patch("os.kill", side_effect=track_kill),
+            patch("time.sleep"),
+            patch.object(mock_process, "wait"),
+        ):
+            # First call: check if process is alive (True)
+            # Next 10 calls: loop checking if process died after SIGTERM (all True)
+            # This triggers the else clause which sends SIGKILL
+            mock_alive.return_value = True
+
+            with pytest.raises(RuntimeError):
+                lifecycle._handle_startup_timeout(mock_process, 30.0)
+
+            # Verify both SIGTERM and SIGKILL were sent
+            assert signal.SIGTERM in kill_calls
+            assert signal.SIGKILL in kill_calls


### PR DESCRIPTION
## Summary
- Fixes race condition in `_handle_startup_timeout` where stderr could be read while the process was being terminated
- stderr is now fully read and closed before sending SIGTERM/SIGKILL signals
- Zombie processes are properly reaped via `process.wait()`
- Error messages for failed startups now include captured stderr output

Closes #398

## Changes
- Added `_read_and_close_stderr()` helper to safely read and close stderr
- Added `_terminate_unresponsive_process()` helper for SIGTERM/SIGKILL logic
- Added `_wait_for_process_exit()` helper to reap zombie processes
- Updated `_check_instant_failure()` to close stderr after reading on failure
- Updated `start()` to not prematurely close stderr before timeout handling
- Updated CHANGELOG.md

## Test plan
- [x] 8 new unit tests for the race condition fix
- [x] All 31 daemon lifecycle tests pass
- [x] Full test suite passes (1441 tests)
- [x] Linter passes