### PR TITLE
feat: align SearchUseCase with standard use case API pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **SearchUseCase now follows standard use case API pattern** (#422)
+  - Added `execute(SearchRequest) -> SearchResponse` method with error handling
+  - Created `SearchRequest` and `SearchResponse` DTOs matching other use cases
+  - Proper try-catch pattern with KeyboardInterrupt/SystemExit re-raise
+  - Old `search(Query)` method retained for backward compatibility
+  - Errors now return `SearchResponse.create_error()` instead of propagating exceptions
+
+- **ChunkFileUseCase now has proper error handling** (#422)
+  - Added try-catch pattern matching other use cases
+  - Chunker exceptions now return `ChunkFileResponse.create_error()` instead of crashing
+  - KeyboardInterrupt/SystemExit are properly re-raised
+
 ### Fixed
 - **Daemon startup timeout no longer has race condition** (#398)
   - Fixed race between stderr reading and process termination during startup failure

--- a/ember/core/chunking/chunk_usecase.py
+++ b/ember/core/chunking/chunk_usecase.py
@@ -7,6 +7,7 @@ when available, falling back to line-based chunking for unsupported languages.
 from dataclasses import dataclass
 from pathlib import Path
 
+from ember.core.use_case_errors import format_error_message, log_use_case_error
 from ember.ports.chunkers import ChunkData, Chunker
 
 
@@ -104,37 +105,49 @@ class ChunkFileUseCase:
     def execute(self, request: ChunkFileRequest) -> ChunkFileResponse:
         """Execute chunking on a file with automatic fallback.
 
+        Error handling contract:
+            - KeyboardInterrupt/SystemExit are re-raised (user wants to exit)
+            - All other exceptions are caught and converted to error responses
+            - See ember.core.use_case_errors for the error handling pattern
+
         Args:
             request: Chunking request with file content and metadata.
 
         Returns:
             Response with chunks and strategy used.
         """
-        # Validate input
-        if not request.content.strip():
-            return ChunkFileResponse.create_success(chunks=[], strategy="none")
+        try:
+            # Validate input
+            if not request.content.strip():
+                return ChunkFileResponse.create_success(chunks=[], strategy="none")
 
-        # Try tree-sitter first for supported languages
-        if request.lang in self.tree_sitter.supported_languages:
-            chunks = self.tree_sitter.chunk_file(
+            # Try tree-sitter first for supported languages
+            if request.lang in self.tree_sitter.supported_languages:
+                chunks = self.tree_sitter.chunk_file(
+                    content=request.content,
+                    path=request.path,
+                    lang=request.lang,
+                )
+
+                # If tree-sitter succeeded and returned chunks, use them
+                if chunks:
+                    return ChunkFileResponse.create_success(
+                        chunks=chunks, strategy="tree-sitter"
+                    )
+
+                # Tree-sitter failed or returned no chunks, fall back to line-based
+
+            # Fall back to line-based chunking
+            chunks = self.line_chunker.chunk_file(
                 content=request.content,
                 path=request.path,
                 lang=request.lang,
             )
 
-            # If tree-sitter succeeded and returned chunks, use them
-            if chunks:
-                return ChunkFileResponse.create_success(
-                    chunks=chunks, strategy="tree-sitter"
-                )
+            return ChunkFileResponse.create_success(chunks=chunks, strategy="line-based")
 
-            # Tree-sitter failed or returned no chunks, fall back to line-based
-
-        # Fall back to line-based chunking
-        chunks = self.line_chunker.chunk_file(
-            content=request.content,
-            path=request.path,
-            lang=request.lang,
-        )
-
-        return ChunkFileResponse.create_success(chunks=chunks, strategy="line-based")
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as e:
+            log_use_case_error(e, "chunking")
+            return ChunkFileResponse.create_error(format_error_message(e, "chunking"))

--- a/ember/core/retrieval/search_usecase.py
+++ b/ember/core/retrieval/search_usecase.py
@@ -7,6 +7,7 @@ with Reciprocal Rank Fusion for optimal retrieval quality.
 import logging
 from dataclasses import dataclass
 
+from ember.core.use_case_errors import format_error_message, log_use_case_error
 from ember.domain.entities import (
     Chunk,
     Query,
@@ -54,6 +55,85 @@ class _RetrievalResult:
     missing_count: int
 
 
+@dataclass
+class SearchRequest:
+    """Request to search the code index.
+
+    Follows the standard use case Request DTO pattern with simple types.
+
+    Attributes:
+        query_text: The search query string.
+        topk: Maximum number of results to return. Default 20.
+        path_filter: Optional glob pattern to filter by file path (e.g., "*.py").
+        lang_filter: Optional language filter (e.g., "python").
+    """
+
+    query_text: str
+    topk: int = 20
+    path_filter: str | None = None
+    lang_filter: str | None = None
+
+
+@dataclass
+class SearchResponse:
+    """Response from search operation.
+
+    Follows the standard use case Response DTO pattern with success/error fields.
+
+    Attributes:
+        result_set: The SearchResultSet containing results (None on error).
+        success: Whether the search succeeded.
+        error: Error message if search failed.
+    """
+
+    result_set: SearchResultSet | None = None
+    success: bool = True
+    error: str | None = None
+
+    @property
+    def results(self) -> list[SearchResult]:
+        """Get the list of search results.
+
+        Returns:
+            List of SearchResult objects, or empty list if no results or error.
+        """
+        if self.result_set is None:
+            return []
+        return self.result_set.results
+
+    @classmethod
+    def create_success(cls, *, result_set: SearchResultSet) -> "SearchResponse":
+        """Create a success response with results.
+
+        Args:
+            result_set: The SearchResultSet containing results.
+
+        Returns:
+            SearchResponse with success=True.
+        """
+        return cls(
+            result_set=result_set,
+            success=True,
+            error=None,
+        )
+
+    @classmethod
+    def create_error(cls, message: str) -> "SearchResponse":
+        """Create an error response.
+
+        Args:
+            message: Error message describing what went wrong.
+
+        Returns:
+            SearchResponse with success=False.
+        """
+        return cls(
+            result_set=None,
+            success=False,
+            error=message,
+        )
+
+
 class SearchUseCase:
     """Orchestrates hybrid search combining BM25 and vector retrieval.
 
@@ -93,6 +173,47 @@ class SearchUseCase:
         self.rrf_k = rrf_k
         self.retrieval_pool_multiplier = retrieval_pool_multiplier
         self.min_retrieval_pool = min_retrieval_pool
+
+    def execute(self, request: SearchRequest) -> SearchResponse:
+        """Execute hybrid search and return ranked results.
+
+        Follows the standard use case API pattern with Request/Response DTOs
+        and proper error handling.
+
+        Error handling contract:
+            - KeyboardInterrupt/SystemExit are re-raised (user wants to exit)
+            - All other exceptions are caught and converted to error responses
+            - See ember.core.use_case_errors for the error handling pattern
+
+        Args:
+            request: SearchRequest with query parameters.
+
+        Returns:
+            SearchResponse with results or error information.
+        """
+        # Validate query text
+        query_text = request.query_text.strip()
+        if not query_text:
+            return SearchResponse.create_error("Query text cannot be empty")
+
+        try:
+            # Convert request to domain Query entity
+            query = Query.from_strings(
+                text=query_text,
+                topk=request.topk,
+                path_filter=request.path_filter,
+                lang_filter=request.lang_filter,
+            )
+
+            # Delegate to internal search implementation
+            result_set = self.search(query)
+            return SearchResponse.create_success(result_set=result_set)
+
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as e:
+            log_use_case_error(e, "search")
+            return SearchResponse.create_error(format_error_message(e, "search"))
 
     def search(self, query: Query) -> SearchResultSet:
         """Execute hybrid search and return ranked results.

--- a/tests/unit/core/test_search_usecase_api.py
+++ b/tests/unit/core/test_search_usecase_api.py
@@ -1,0 +1,299 @@
+"""Unit tests for SearchUseCase API pattern compliance.
+
+Tests for the new SearchRequest/SearchResponse DTOs and execute() method
+that align SearchUseCase with the standard use case API pattern.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ember.core.retrieval.search_usecase import (
+    SearchRequest,
+    SearchResponse,
+    SearchUseCase,
+)
+from ember.domain.entities import SearchResult, SearchResultSet
+
+
+class TestSearchRequest:
+    """Tests for SearchRequest dataclass."""
+
+    def test_create_with_required_fields(self):
+        """Test creating SearchRequest with only required fields."""
+        request = SearchRequest(query_text="test query")
+
+        assert request.query_text == "test query"
+        assert request.topk == 20  # default
+        assert request.path_filter is None
+        assert request.lang_filter is None
+
+    def test_create_with_all_fields(self):
+        """Test creating SearchRequest with all fields."""
+        request = SearchRequest(
+            query_text="test query",
+            topk=10,
+            path_filter="*.py",
+            lang_filter="python",
+        )
+
+        assert request.query_text == "test query"
+        assert request.topk == 10
+        assert request.path_filter == "*.py"
+        assert request.lang_filter == "python"
+
+    def test_empty_query_text_is_allowed_in_dto(self):
+        """Test that empty query is allowed in DTO (validation is in use case)."""
+        # The DTO should allow empty strings - validation happens in execute()
+        request = SearchRequest(query_text="")
+        assert request.query_text == ""
+
+
+class TestSearchResponse:
+    """Tests for SearchResponse dataclass."""
+
+    def test_create_success_with_results(self):
+        """Test creating a success response with results."""
+        mock_results = [MagicMock(spec=SearchResult)]
+        mock_result_set = MagicMock(spec=SearchResultSet)
+        mock_result_set.results = mock_results
+        mock_result_set.requested_count = 10
+        mock_result_set.missing_chunks = 0
+        mock_result_set.warning = None
+
+        response = SearchResponse.create_success(result_set=mock_result_set)
+
+        assert response.success is True
+        assert response.error is None
+        assert response.result_set is mock_result_set
+        assert response.results == mock_results
+
+    def test_create_success_with_empty_results(self):
+        """Test creating a success response with empty results."""
+        mock_result_set = MagicMock(spec=SearchResultSet)
+        mock_result_set.results = []
+        mock_result_set.requested_count = 10
+        mock_result_set.missing_chunks = 0
+        mock_result_set.warning = None
+
+        response = SearchResponse.create_success(result_set=mock_result_set)
+
+        assert response.success is True
+        assert response.error is None
+        assert response.results == []
+
+    def test_create_error(self):
+        """Test creating an error response."""
+        response = SearchResponse.create_error("Embedder failed")
+
+        assert response.success is False
+        assert response.error == "Embedder failed"
+        assert response.result_set is None
+        assert response.results == []
+
+    def test_results_property_empty_when_no_result_set(self):
+        """Test that results property returns empty list when result_set is None."""
+        response = SearchResponse.create_error("Some error")
+
+        assert response.results == []
+
+
+class TestSearchUseCaseExecute:
+    """Tests for SearchUseCase.execute() method."""
+
+    @pytest.fixture
+    def mock_dependencies(self):
+        """Create mock dependencies for SearchUseCase."""
+        text_search = MagicMock()
+        vector_search = MagicMock()
+        chunk_repo = MagicMock()
+        embedder = MagicMock()
+
+        # Configure embedder to return a dummy embedding
+        embedder.embed_texts.return_value = [[0.1, 0.2, 0.3]]
+
+        # Configure searches to return empty results
+        text_search.query.return_value = []
+        vector_search.query.return_value = []
+
+        return {
+            "text_search": text_search,
+            "vector_search": vector_search,
+            "chunk_repo": chunk_repo,
+            "embedder": embedder,
+        }
+
+    def test_execute_returns_success_response(self, mock_dependencies):
+        """Test that execute() returns a SearchResponse on success."""
+        use_case = SearchUseCase(**mock_dependencies)
+        request = SearchRequest(query_text="test query", topk=5)
+
+        response = use_case.execute(request)
+
+        assert response.success is True
+        assert response.error is None
+        assert response.result_set is not None
+        assert isinstance(response.result_set, SearchResultSet)
+
+    def test_execute_with_path_filter(self, mock_dependencies):
+        """Test that execute() respects path_filter parameter."""
+        use_case = SearchUseCase(**mock_dependencies)
+        request = SearchRequest(
+            query_text="test query",
+            topk=5,
+            path_filter="*.py",
+        )
+
+        use_case.execute(request)
+
+        # Verify path filter was passed to search
+        mock_dependencies["text_search"].query.assert_called_once()
+        call_kwargs = mock_dependencies["text_search"].query.call_args.kwargs
+        assert call_kwargs.get("path_filter") == "*.py"
+
+    def test_execute_with_lang_filter(self, mock_dependencies):
+        """Test that execute() respects lang_filter parameter."""
+        use_case = SearchUseCase(**mock_dependencies)
+        request = SearchRequest(
+            query_text="test query",
+            topk=5,
+            lang_filter="py",  # Use short form recognized by language filter
+        )
+
+        response = use_case.execute(request)
+
+        assert response.success is True
+        # Lang filter is applied after retrieval, so we can't directly verify
+        # it was passed to mocks, but we can verify successful execution
+
+    def test_execute_catches_embedder_exception(self, mock_dependencies):
+        """Test that execute() catches embedder exceptions."""
+        mock_dependencies["embedder"].embed_texts.side_effect = RuntimeError(
+            "Model failed to load"
+        )
+        use_case = SearchUseCase(**mock_dependencies)
+        request = SearchRequest(query_text="test query")
+
+        response = use_case.execute(request)
+
+        assert response.success is False
+        assert "error" in response.error.lower() or "Model failed" in response.error
+
+    def test_execute_catches_text_search_exception(self, mock_dependencies):
+        """Test that execute() catches text search exceptions."""
+        mock_dependencies["text_search"].query.side_effect = OSError(
+            "Database locked"
+        )
+        use_case = SearchUseCase(**mock_dependencies)
+        request = SearchRequest(query_text="test query")
+
+        response = use_case.execute(request)
+
+        assert response.success is False
+        assert response.error is not None
+
+    def test_execute_catches_vector_search_exception(self, mock_dependencies):
+        """Test that execute() catches vector search exceptions."""
+        mock_dependencies["vector_search"].query.side_effect = ValueError(
+            "Invalid dimensions"
+        )
+        use_case = SearchUseCase(**mock_dependencies)
+        request = SearchRequest(query_text="test query")
+
+        response = use_case.execute(request)
+
+        assert response.success is False
+        assert response.error is not None
+
+    def test_execute_reraises_keyboard_interrupt(self, mock_dependencies):
+        """Test that execute() re-raises KeyboardInterrupt."""
+        mock_dependencies["embedder"].embed_texts.side_effect = KeyboardInterrupt()
+        use_case = SearchUseCase(**mock_dependencies)
+        request = SearchRequest(query_text="test query")
+
+        with pytest.raises(KeyboardInterrupt):
+            use_case.execute(request)
+
+    def test_execute_reraises_system_exit(self, mock_dependencies):
+        """Test that execute() re-raises SystemExit."""
+        mock_dependencies["embedder"].embed_texts.side_effect = SystemExit()
+        use_case = SearchUseCase(**mock_dependencies)
+        request = SearchRequest(query_text="test query")
+
+        with pytest.raises(SystemExit):
+            use_case.execute(request)
+
+    def test_execute_returns_error_for_empty_query(self, mock_dependencies):
+        """Test that execute() returns error for empty query text."""
+        use_case = SearchUseCase(**mock_dependencies)
+        request = SearchRequest(query_text="")
+
+        response = use_case.execute(request)
+
+        assert response.success is False
+        assert "empty" in response.error.lower() or "query" in response.error.lower()
+
+    def test_execute_returns_error_for_whitespace_query(self, mock_dependencies):
+        """Test that execute() returns error for whitespace-only query."""
+        use_case = SearchUseCase(**mock_dependencies)
+        request = SearchRequest(query_text="   ")
+
+        response = use_case.execute(request)
+
+        assert response.success is False
+
+
+class TestSearchUseCaseBackwardCompatibility:
+    """Tests to ensure backward compatibility with old search() method."""
+
+    @pytest.fixture
+    def mock_dependencies(self):
+        """Create mock dependencies for SearchUseCase."""
+        text_search = MagicMock()
+        vector_search = MagicMock()
+        chunk_repo = MagicMock()
+        embedder = MagicMock()
+
+        # Configure embedder to return a dummy embedding
+        embedder.embed_texts.return_value = [[0.1, 0.2, 0.3]]
+
+        # Configure searches to return empty results
+        text_search.query.return_value = []
+        vector_search.query.return_value = []
+
+        return {
+            "text_search": text_search,
+            "vector_search": vector_search,
+            "chunk_repo": chunk_repo,
+            "embedder": embedder,
+        }
+
+    def test_search_method_still_works(self, mock_dependencies):
+        """Test that the old search() method still works for backward compatibility."""
+        from ember.domain.entities import Query
+
+        use_case = SearchUseCase(**mock_dependencies)
+        query = Query(text="test query", topk=5)
+
+        # Old API should still work
+        result = use_case.search(query)
+
+        assert isinstance(result, SearchResultSet)
+
+    def test_execute_and_search_produce_consistent_results(self, mock_dependencies):
+        """Test that execute() and search() produce equivalent results."""
+        from ember.domain.entities import Query
+
+        use_case = SearchUseCase(**mock_dependencies)
+
+        # Using execute()
+        request = SearchRequest(query_text="test query", topk=5)
+        response = use_case.execute(request)
+
+        # Using search()
+        query = Query(text="test query", topk=5)
+        result_set = use_case.search(query)
+
+        # Both should produce same results (empty in this case with mocks)
+        assert response.result_set.results == result_set.results
+        assert response.result_set.requested_count == result_set.requested_count

--- a/tests/unit/test_chunk_usecase.py
+++ b/tests/unit/test_chunk_usecase.py
@@ -1,6 +1,9 @@
 """Tests for chunking use case."""
 
 from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
 
 from ember.adapters.parsers.line_chunker import LineChunker
 from ember.adapters.parsers.tree_sitter_chunker import TreeSitterChunker
@@ -266,3 +269,83 @@ def test_chunk_usecase_preserves_metadata():
     # Check metadata is preserved
     for chunk in response.chunks:
         assert chunk.lang == "rs"
+
+
+class TestChunkFileUseCaseErrorHandling:
+    """Tests for ChunkFileUseCase error handling."""
+
+    def test_execute_catches_tree_sitter_exception(self):
+        """Test that execute() catches tree-sitter exceptions."""
+        mock_tree_sitter = MagicMock()
+        mock_tree_sitter.supported_languages = {"py"}
+        mock_tree_sitter.chunk_file.side_effect = RuntimeError("Parse error")
+
+        mock_line_chunker = MagicMock()
+
+        use_case = ChunkFileUseCase(mock_tree_sitter, mock_line_chunker)
+        request = ChunkFileRequest(
+            content="def foo(): pass",
+            path=Path("test.py"),
+            lang="py",
+        )
+
+        response = use_case.execute(request)
+
+        assert response.success is False
+        assert response.error is not None
+
+    def test_execute_catches_line_chunker_exception(self):
+        """Test that execute() catches line chunker exceptions."""
+        mock_tree_sitter = MagicMock()
+        mock_tree_sitter.supported_languages = set()  # No supported languages
+
+        mock_line_chunker = MagicMock()
+        mock_line_chunker.chunk_file.side_effect = OSError("File error")
+
+        use_case = ChunkFileUseCase(mock_tree_sitter, mock_line_chunker)
+        request = ChunkFileRequest(
+            content="some content",
+            path=Path("test.txt"),
+            lang="txt",
+        )
+
+        response = use_case.execute(request)
+
+        assert response.success is False
+        assert response.error is not None
+
+    def test_execute_reraises_keyboard_interrupt(self):
+        """Test that execute() re-raises KeyboardInterrupt."""
+        mock_tree_sitter = MagicMock()
+        mock_tree_sitter.supported_languages = {"py"}
+        mock_tree_sitter.chunk_file.side_effect = KeyboardInterrupt()
+
+        mock_line_chunker = MagicMock()
+
+        use_case = ChunkFileUseCase(mock_tree_sitter, mock_line_chunker)
+        request = ChunkFileRequest(
+            content="def foo(): pass",
+            path=Path("test.py"),
+            lang="py",
+        )
+
+        with pytest.raises(KeyboardInterrupt):
+            use_case.execute(request)
+
+    def test_execute_reraises_system_exit(self):
+        """Test that execute() re-raises SystemExit."""
+        mock_tree_sitter = MagicMock()
+        mock_tree_sitter.supported_languages = {"py"}
+        mock_tree_sitter.chunk_file.side_effect = SystemExit()
+
+        mock_line_chunker = MagicMock()
+
+        use_case = ChunkFileUseCase(mock_tree_sitter, mock_line_chunker)
+        request = ChunkFileRequest(
+            content="def foo(): pass",
+            path=Path("test.py"),
+            lang="py",
+        )
+
+        with pytest.raises(SystemExit):
+            use_case.execute(request)


### PR DESCRIPTION
## Summary
- Add `execute(SearchRequest) -> SearchResponse` method to SearchUseCase with proper error handling
- Create `SearchRequest` and `SearchResponse` DTOs matching the pattern used by IndexingUseCase, StatusUseCase, etc.
- Add error handling to ChunkFileUseCase with the same try-catch pattern
- Retain old `search(Query)` method for backward compatibility

Implements #422

## Changes
- **ember/core/retrieval/search_usecase.py**: Added SearchRequest, SearchResponse DTOs and execute() method
- **ember/core/chunking/chunk_usecase.py**: Added try-catch error handling pattern
- **tests/unit/core/test_search_usecase_api.py**: New tests for API pattern compliance
- **tests/unit/test_chunk_usecase.py**: Added error handling tests
- **CHANGELOG.md**: Documented changes

## Test Plan
- [x] All 1464 tests pass
- [x] Linter passes (ruff check)
- [x] New API tests verify SearchRequest/SearchResponse DTOs work correctly
- [x] Error handling tests verify exceptions are caught and converted to error responses
- [x] Backward compatibility tests verify old search(Query) method still works
- [x] KeyboardInterrupt/SystemExit are properly re-raised