### PR TITLE
feat: add context manager support to use cases (#416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Use cases now support context manager protocol for deterministic resource cleanup** (#416)
+  - `SearchUseCase` and `IndexingUseCase` now implement `__enter__`/`__exit__`
+  - Both use cases have a `close()` method to explicitly close repository connections
+  - Allows using use cases as context managers: `with search_usecase: ...`
+  - Connections are now closed deterministically rather than relying on garbage collection
+  - `SimpleVectorSearch` now inherits from `SQLiteBaseRepository` for consistent connection management
+
 ### Fixed
 - **Architecture violation: core/editor.py no longer imports from adapters** (#415)
   - Moved CLI-specific editor facade from `core/editor.py` to `app/editor.py`

--- a/ember/adapters/vss/simple_vector_search.py
+++ b/ember/adapters/vss/simple_vector_search.py
@@ -4,12 +4,13 @@ This is an MVP implementation that loads all vectors and computes similarity in 
 For production, consider migrating to FAISS or sqlite-vss for better performance.
 """
 
-import sqlite3
 import struct
 from pathlib import Path
 
+from ember.adapters.sqlite.base_repository import SQLiteBaseRepository
 
-class SimpleVectorSearch:
+
+class SimpleVectorSearch(SQLiteBaseRepository):
     """Simple brute-force vector search using cosine similarity.
 
     This adapter loads all vectors from the database and computes cosine
@@ -19,6 +20,11 @@ class SimpleVectorSearch:
     - FAISS (Facebook AI Similarity Search)
     - sqlite-vss (SQLite vector search extension)
     - Approximate Nearest Neighbor (ANN) indexes
+
+    Inherits from SQLiteBaseRepository to get:
+    - Thread-safe connection initialization
+    - Context manager protocol (__enter__/__exit__)
+    - Connection reuse across queries
     """
 
     def __init__(self, db_path: Path) -> None:
@@ -27,15 +33,7 @@ class SimpleVectorSearch:
         Args:
             db_path: Path to SQLite database file.
         """
-        self.db_path = db_path
-
-    def _get_connection(self) -> sqlite3.Connection:
-        """Get a database connection.
-
-        Returns:
-            SQLite connection object.
-        """
-        return sqlite3.connect(self.db_path)
+        super().__init__(db_path)
 
     def _decode_vector(self, blob: bytes, dim: int) -> list[float]:
         """Decode a vector from binary BLOB.
@@ -95,41 +93,37 @@ class SimpleVectorSearch:
             Similarity is cosine similarity in range [-1, 1].
         """
         conn = self._get_connection()
-        try:
-            cursor = conn.cursor()
+        cursor = conn.cursor()
 
-            # Load all vectors with their stored chunk_id
-            cursor.execute(
-                """
-                SELECT
-                    c.chunk_id,
-                    v.embedding,
-                    v.dim
-                FROM vectors v
-                JOIN chunks c ON v.chunk_id = c.id
-                """
-            )
+        # Load all vectors with their stored chunk_id
+        cursor.execute(
+            """
+            SELECT
+                c.chunk_id,
+                v.embedding,
+                v.dim
+            FROM vectors v
+            JOIN chunks c ON v.chunk_id = c.id
+            """
+        )
 
-            rows = cursor.fetchall()
-            results = []
+        rows = cursor.fetchall()
+        results = []
 
-            for row in rows:
-                # Use the stored chunk_id from database instead of computing it
-                chunk_id = row[0]
-                embedding_blob = row[1]
-                dim = row[2]
+        for row in rows:
+            # Use the stored chunk_id from database instead of computing it
+            chunk_id = row[0]
+            embedding_blob = row[1]
+            dim = row[2]
 
-                # Decode vector
-                chunk_vector = self._decode_vector(embedding_blob, dim)
+            # Decode vector
+            chunk_vector = self._decode_vector(embedding_blob, dim)
 
-                # Compute cosine similarity
-                similarity = self._cosine_similarity(vector, chunk_vector)
+            # Compute cosine similarity
+            similarity = self._cosine_similarity(vector, chunk_vector)
 
-                results.append((chunk_id, similarity))
+            results.append((chunk_id, similarity))
 
-            # Sort by similarity (descending) and return top-k
-            results.sort(key=lambda x: x[1], reverse=True)
-            return results[:topk]
-
-        finally:
-            conn.close()
+        # Sort by similarity (descending) and return top-k
+        results.sort(key=lambda x: x[1], reverse=True)
+        return results[:topk]

--- a/ember/core/indexing/index_usecase.py
+++ b/ember/core/indexing/index_usecase.py
@@ -10,6 +10,7 @@ This use case orchestrates the complete indexing pipeline:
 import logging
 import time
 from pathlib import Path
+from typing import Self
 
 from ember.core.chunking.chunk_usecase import ChunkFileRequest, ChunkFileUseCase
 from ember.core.indexing.chunk_storage import ChunkStorageService
@@ -100,6 +101,34 @@ class IndexingUseCase:
         )
         self.file_detection = file_detection or FileDetectionService(vcs, meta_repo)
         self.file_filter = file_filter or FileFilterService()
+
+    def close(self) -> None:
+        """Close all repository connections.
+
+        This method ensures deterministic cleanup of database connections.
+        It's safe to call multiple times - each call will attempt to close
+        the underlying connections.
+
+        Dependencies without a close() method are silently skipped.
+        """
+        for dep_name in ("chunk_repo", "vector_repo", "file_repo", "meta_repo"):
+            dep = getattr(self, dep_name, None)
+            if dep is not None and hasattr(dep, "close"):
+                dep.close()
+
+    def __enter__(self) -> Self:
+        """Enter context manager."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> bool:
+        """Exit context manager, closing all repository connections."""
+        self.close()
+        return False
 
     def _create_error_response(self, error: str) -> IndexResponse:
         """Create a standardized error response with zero counts."""

--- a/ember/core/retrieval/search_usecase.py
+++ b/ember/core/retrieval/search_usecase.py
@@ -6,6 +6,7 @@ with Reciprocal Rank Fusion for optimal retrieval quality.
 
 import logging
 from dataclasses import dataclass
+from typing import Self
 
 from ember.core.use_case_errors import format_error_message, log_use_case_error
 from ember.domain.entities import (
@@ -173,6 +174,34 @@ class SearchUseCase:
         self.rrf_k = rrf_k
         self.retrieval_pool_multiplier = retrieval_pool_multiplier
         self.min_retrieval_pool = min_retrieval_pool
+
+    def close(self) -> None:
+        """Close all repository connections.
+
+        This method ensures deterministic cleanup of database connections.
+        It's safe to call multiple times - each call will attempt to close
+        the underlying connections.
+
+        Dependencies without a close() method are silently skipped.
+        """
+        for dep_name in ("text_search", "vector_search", "chunk_repo"):
+            dep = getattr(self, dep_name, None)
+            if dep is not None and hasattr(dep, "close"):
+                dep.close()
+
+    def __enter__(self) -> Self:
+        """Enter context manager."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> bool:
+        """Exit context manager, closing all repository connections."""
+        self.close()
+        return False
 
     def execute(self, request: SearchRequest) -> SearchResponse:
         """Execute hybrid search and return ranked results.

--- a/tests/unit/core/test_usecase_context_managers.py
+++ b/tests/unit/core/test_usecase_context_managers.py
@@ -1,0 +1,292 @@
+"""Unit tests for use case context manager protocol.
+
+Tests that SearchUseCase and IndexingUseCase properly implement the context
+manager protocol for deterministic resource cleanup (closes repository
+connections on exit).
+
+This addresses issue #416: DX: Repository connections not explicitly closed
+in CLI layer.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class TestSearchUseCaseContextManager:
+    """Tests for SearchUseCase context manager protocol."""
+
+    @pytest.fixture
+    def mock_closeable_dependencies(self):
+        """Create mock dependencies with close() methods."""
+        text_search = MagicMock()
+        vector_search = MagicMock()
+        chunk_repo = MagicMock()
+        embedder = MagicMock()
+
+        # Configure embedder
+        embedder.embed_texts.return_value = [[0.1, 0.2, 0.3]]
+
+        # Configure searches to return empty results
+        text_search.query.return_value = []
+        vector_search.query.return_value = []
+
+        return {
+            "text_search": text_search,
+            "vector_search": vector_search,
+            "chunk_repo": chunk_repo,
+            "embedder": embedder,
+        }
+
+    def test_context_manager_returns_self(self, mock_closeable_dependencies):
+        """Test that __enter__ returns the use case instance."""
+        from ember.core.retrieval.search_usecase import SearchUseCase
+
+        use_case = SearchUseCase(**mock_closeable_dependencies)
+        with use_case as ctx:
+            assert ctx is use_case
+
+    def test_context_manager_closes_all_repositories(self, mock_closeable_dependencies):
+        """Test that __exit__ closes all repository connections."""
+        from ember.core.retrieval.search_usecase import SearchUseCase
+
+        use_case = SearchUseCase(**mock_closeable_dependencies)
+
+        with use_case:
+            pass
+
+        # Verify close was called on all closeable dependencies
+        mock_closeable_dependencies["text_search"].close.assert_called_once()
+        mock_closeable_dependencies["vector_search"].close.assert_called_once()
+        mock_closeable_dependencies["chunk_repo"].close.assert_called_once()
+
+    def test_context_manager_closes_on_exception(self, mock_closeable_dependencies):
+        """Test that connections are closed even when exception occurs."""
+        from ember.core.retrieval.search_usecase import SearchUseCase
+
+        use_case = SearchUseCase(**mock_closeable_dependencies)
+
+        try:
+            with use_case:
+                raise ValueError("Test exception")
+        except ValueError:
+            pass
+
+        # Connections should still be closed
+        mock_closeable_dependencies["text_search"].close.assert_called_once()
+        mock_closeable_dependencies["vector_search"].close.assert_called_once()
+        mock_closeable_dependencies["chunk_repo"].close.assert_called_once()
+
+    def test_close_method_available(self, mock_closeable_dependencies):
+        """Test that close() method is available on use case."""
+        from ember.core.retrieval.search_usecase import SearchUseCase
+
+        use_case = SearchUseCase(**mock_closeable_dependencies)
+        use_case.close()
+
+        mock_closeable_dependencies["text_search"].close.assert_called_once()
+        mock_closeable_dependencies["vector_search"].close.assert_called_once()
+        mock_closeable_dependencies["chunk_repo"].close.assert_called_once()
+
+    def test_close_handles_missing_close_method(self, mock_closeable_dependencies):
+        """Test close() handles dependencies without close() method gracefully."""
+        from ember.core.retrieval.search_usecase import SearchUseCase
+
+        # Remove close method from text_search
+        del mock_closeable_dependencies["text_search"].close
+
+        use_case = SearchUseCase(**mock_closeable_dependencies)
+
+        # Should not raise
+        use_case.close()
+
+        # Other close methods should still be called
+        mock_closeable_dependencies["vector_search"].close.assert_called_once()
+        mock_closeable_dependencies["chunk_repo"].close.assert_called_once()
+
+    def test_close_is_idempotent(self, mock_closeable_dependencies):
+        """Test that close() can be called multiple times safely."""
+        from ember.core.retrieval.search_usecase import SearchUseCase
+
+        use_case = SearchUseCase(**mock_closeable_dependencies)
+        use_case.close()
+        use_case.close()  # Should not raise
+
+        # close should be called twice (once per close() call)
+        assert mock_closeable_dependencies["text_search"].close.call_count == 2
+
+
+class TestIndexingUseCaseContextManager:
+    """Tests for IndexingUseCase context manager protocol."""
+
+    @pytest.fixture
+    def mock_indexing_dependencies(self):
+        """Create mock dependencies for IndexingUseCase with close() methods."""
+        vcs = MagicMock()
+        fs = MagicMock()
+        chunk_usecase = MagicMock()
+        embedder = MagicMock()
+        chunk_repo = MagicMock()
+        vector_repo = MagicMock()
+        file_repo = MagicMock()
+        meta_repo = MagicMock()
+
+        # Configure embedder
+        embedder.dim = 384
+        embedder.fingerprint.return_value = "mock:384"
+
+        return {
+            "vcs": vcs,
+            "fs": fs,
+            "chunk_usecase": chunk_usecase,
+            "embedder": embedder,
+            "chunk_repo": chunk_repo,
+            "vector_repo": vector_repo,
+            "file_repo": file_repo,
+            "meta_repo": meta_repo,
+            "project_id": "test_project",
+        }
+
+    def test_context_manager_returns_self(self, mock_indexing_dependencies):
+        """Test that __enter__ returns the use case instance."""
+        from ember.core.indexing.index_usecase import IndexingUseCase
+
+        use_case = IndexingUseCase(**mock_indexing_dependencies)
+        with use_case as ctx:
+            assert ctx is use_case
+
+    def test_context_manager_closes_all_repositories(self, mock_indexing_dependencies):
+        """Test that __exit__ closes all repository connections."""
+        from ember.core.indexing.index_usecase import IndexingUseCase
+
+        use_case = IndexingUseCase(**mock_indexing_dependencies)
+
+        with use_case:
+            pass
+
+        # Verify close was called on all repository dependencies
+        mock_indexing_dependencies["chunk_repo"].close.assert_called_once()
+        mock_indexing_dependencies["vector_repo"].close.assert_called_once()
+        mock_indexing_dependencies["file_repo"].close.assert_called_once()
+        mock_indexing_dependencies["meta_repo"].close.assert_called_once()
+
+    def test_context_manager_closes_on_exception(self, mock_indexing_dependencies):
+        """Test that connections are closed even when exception occurs."""
+        from ember.core.indexing.index_usecase import IndexingUseCase
+
+        use_case = IndexingUseCase(**mock_indexing_dependencies)
+
+        try:
+            with use_case:
+                raise ValueError("Test exception")
+        except ValueError:
+            pass
+
+        # Connections should still be closed
+        mock_indexing_dependencies["chunk_repo"].close.assert_called_once()
+        mock_indexing_dependencies["vector_repo"].close.assert_called_once()
+        mock_indexing_dependencies["file_repo"].close.assert_called_once()
+        mock_indexing_dependencies["meta_repo"].close.assert_called_once()
+
+    def test_close_method_available(self, mock_indexing_dependencies):
+        """Test that close() method is available on use case."""
+        from ember.core.indexing.index_usecase import IndexingUseCase
+
+        use_case = IndexingUseCase(**mock_indexing_dependencies)
+        use_case.close()
+
+        mock_indexing_dependencies["chunk_repo"].close.assert_called_once()
+        mock_indexing_dependencies["vector_repo"].close.assert_called_once()
+        mock_indexing_dependencies["file_repo"].close.assert_called_once()
+        mock_indexing_dependencies["meta_repo"].close.assert_called_once()
+
+    def test_close_handles_missing_close_method(self, mock_indexing_dependencies):
+        """Test close() handles dependencies without close() method gracefully."""
+        from ember.core.indexing.index_usecase import IndexingUseCase
+
+        # Remove close method from file_repo
+        del mock_indexing_dependencies["file_repo"].close
+
+        use_case = IndexingUseCase(**mock_indexing_dependencies)
+
+        # Should not raise
+        use_case.close()
+
+        # Other close methods should still be called
+        mock_indexing_dependencies["chunk_repo"].close.assert_called_once()
+        mock_indexing_dependencies["vector_repo"].close.assert_called_once()
+        mock_indexing_dependencies["meta_repo"].close.assert_called_once()
+
+    def test_close_is_idempotent(self, mock_indexing_dependencies):
+        """Test that close() can be called multiple times safely."""
+        from ember.core.indexing.index_usecase import IndexingUseCase
+
+        use_case = IndexingUseCase(**mock_indexing_dependencies)
+        use_case.close()
+        use_case.close()  # Should not raise
+
+        # close should be called twice (once per close() call)
+        assert mock_indexing_dependencies["chunk_repo"].close.call_count == 2
+
+
+class TestSimpleVectorSearchContextManager:
+    """Tests for SimpleVectorSearch context manager protocol."""
+
+    def test_context_manager_returns_self(self, db_path: Path):
+        """Test that __enter__ returns the instance."""
+        from ember.adapters.vss.simple_vector_search import SimpleVectorSearch
+
+        adapter = SimpleVectorSearch(db_path)
+        with adapter as ctx:
+            assert ctx is adapter
+
+    def test_context_manager_closes_connection(self, db_path: Path):
+        """Test that __exit__ closes the database connection."""
+        from ember.adapters.vss.simple_vector_search import SimpleVectorSearch
+
+        adapter = SimpleVectorSearch(db_path)
+        with adapter:
+            # Access connection to ensure it's created
+            _ = adapter._get_connection()
+            assert adapter._conn is not None
+
+        # After exiting context, connection should be closed
+        assert adapter._conn is None
+
+    def test_context_manager_closes_on_exception(self, db_path: Path):
+        """Test that connection is closed even when exception occurs."""
+        from ember.adapters.vss.simple_vector_search import SimpleVectorSearch
+
+        adapter = SimpleVectorSearch(db_path)
+        try:
+            with adapter:
+                _ = adapter._get_connection()
+                raise ValueError("Test exception")
+        except ValueError:
+            pass
+
+        # Connection should still be closed
+        assert adapter._conn is None
+
+    def test_close_method_idempotent(self, db_path: Path):
+        """Test that close() can be called multiple times safely."""
+        from ember.adapters.vss.simple_vector_search import SimpleVectorSearch
+
+        adapter = SimpleVectorSearch(db_path)
+        adapter._get_connection()
+        adapter.close()
+        adapter.close()  # Should not raise
+        assert adapter._conn is None
+
+    def test_connection_reuse(self, db_path: Path):
+        """Test that connections are reused across multiple operations."""
+        from ember.adapters.vss.simple_vector_search import SimpleVectorSearch
+
+        adapter = SimpleVectorSearch(db_path)
+        conn1 = adapter._get_connection()
+        conn2 = adapter._get_connection()
+
+        # Should be the same connection object
+        assert conn1 is conn2
+        adapter.close()


### PR DESCRIPTION
## Summary
- Add context manager protocol (`__enter__`/`__exit__`) to `SearchUseCase` and `IndexingUseCase`
- Add explicit `close()` methods to both use cases for deterministic resource cleanup
- Refactor `SimpleVectorSearch` to inherit from `SQLiteBaseRepository` instead of creating new connections per query
- Add comprehensive tests for context manager behavior

Implements #416

## Changes
- **SearchUseCase**: Now supports context manager protocol, closes `text_search`, `vector_search`, and `chunk_repo` connections
- **IndexingUseCase**: Now supports context manager protocol, closes `chunk_repo`, `vector_repo`, `file_repo`, and `meta_repo` connections
- **SimpleVectorSearch**: Now inherits from `SQLiteBaseRepository` for consistent connection management and reuse
- **Tests**: 17 new tests covering context manager protocol for both use cases and SimpleVectorSearch

## Test Plan
- [x] All 17 new context manager tests pass
- [x] All 1481 existing tests pass
- [x] Ruff linter passes
- [x] SimpleVectorSearch tests pass (20 tests)