### PR TITLE
fix: improve error handling with targeted hints for database and network errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Improved error handling with targeted hints for database and network errors** (#421)
+  - `handle_cli_errors` decorator now catches `sqlite3.Error` with hint: "Run 'ember sync --reindex' to rebuild."
+  - Network errors (`requests.exceptions.ConnectionError`, `URLError`) now provide: "Check your internet connection and retry."
+  - Timeout errors (`requests.exceptions.Timeout`, `TimeoutError`) now provide: "The operation timed out. Try again or check system resources."
+  - `classify_sync_error()` now classifies `TimeoutError` and `ConnectionError` as `GIT_ERROR`
+  - `_load_and_display_config()` now returns a boolean indicating success/failure
+  - Search result cache warnings are now always shown (not just in verbose mode)
+
 ### Added
 - **Use cases now support context manager protocol for deterministic resource cleanup** (#416)
   - `SearchUseCase` and `IndexingUseCase` now implement `__enter__`/`__exit__`

--- a/ember/core/sync/sync_service.py
+++ b/ember/core/sync/sync_service.py
@@ -32,6 +32,12 @@ def classify_sync_error(exception: Exception) -> SyncErrorType:
     if isinstance(exception, PermissionError):
         return SyncErrorType.PERMISSION_ERROR
 
+    # Check for timeout and connection errors BEFORE generic OSError
+    # (TimeoutError and ConnectionError are subclasses of OSError in Python 3)
+    # These typically occur from network operations during sync
+    if isinstance(exception, (TimeoutError, ConnectionError)):
+        return SyncErrorType.GIT_ERROR
+
     # Check for OSError with permission-related errno
     if isinstance(exception, OSError):
         if exception.errno in (errno.EACCES, errno.EPERM):

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -110,6 +110,10 @@ def handle_cli_errors(command_name: str):
     Returns:
         Decorated function with error handling.
     """
+    import sqlite3
+    from urllib.error import URLError
+
+    import requests.exceptions
 
     def decorator(func):
         @functools.wraps(func)
@@ -133,6 +137,30 @@ def handle_cli_errors(command_name: str):
                 raise EmberCliError(
                     str(e),
                     hint="The embedding model in your config differs from the one used to build the index.",
+                ) from e
+            except sqlite3.Error as e:
+                # Database error - suggest reindex to rebuild
+                raise EmberCliError(
+                    f"Database error: {e}",
+                    hint="Run 'ember sync --reindex' to rebuild the index.",
+                ) from e
+            except requests.exceptions.Timeout as e:
+                # Network timeout - suggest retry
+                raise EmberCliError(
+                    f"Network timeout: {e}",
+                    hint="Request timed out. Check your network connection and retry.",
+                ) from e
+            except (requests.exceptions.ConnectionError, URLError) as e:
+                # Network connection error - suggest checking connection
+                raise EmberCliError(
+                    f"Network error: {e}",
+                    hint="Check your internet connection and retry.",
+                ) from e
+            except TimeoutError as e:
+                # Built-in timeout (e.g., from subprocess or socket operations)
+                raise EmberCliError(
+                    f"Operation timed out: {e}",
+                    hint="The operation timed out. Try again or check system resources.",
                 ) from e
             except PermissionError as e:
                 # Permission denied - provide targeted hint with filename if available
@@ -1173,9 +1201,8 @@ def find(
         cache_data = ResultPresenter.serialize_for_cache(query, result_set.results)
         cache_path.write_text(json.dumps(cache_data, indent=2))
     except Exception as e:
-        # Log cache errors but don't fail the command
-        if ctx.obj.get("verbose", False):
-            click.echo(f"Warning: Could not cache results: {e}", err=True)
+        # Always show cache errors to stderr (Issue #421 - don't silently swallow)
+        click.echo(f"Warning: Could not cache results: {e}", err=True)
 
     # Display results
     presenter = ResultPresenter(LocalFileSystem())
@@ -1568,14 +1595,20 @@ def _display_path_status(path: Path, label: str) -> None:
 
 def _load_and_display_config(
     title: str, loader: Callable[[], EmberConfig]  # noqa: F821
-) -> None:
-    """Load config using the provided loader and display it with a title."""
+) -> bool:
+    """Load config using the provided loader and display it with a title.
+
+    Returns:
+        True if config was loaded and displayed successfully, False on error.
+    """
     click.echo(f"\n{title}:")
     try:
         config = loader()
         _display_config_summary(config)
+        return True
     except Exception as e:
-        click.echo(f"  Error loading config: {e}")
+        click.echo(f"  Error loading config: {e}", err=True)
+        return False
 
 
 def _get_local_config_path() -> Path | None:

--- a/tests/unit/core/sync/test_sync_service.py
+++ b/tests/unit/core/sync/test_sync_service.py
@@ -117,6 +117,18 @@ class TestClassifySyncError:
         result = classify_sync_error(error)
         assert result == SyncErrorType.GIT_ERROR
 
+    def test_classifies_timeout_error_as_git_error(self) -> None:
+        """TimeoutError is classified as GIT_ERROR (operations that timeout are typically git-related)."""
+        error = TimeoutError("Operation timed out")
+        result = classify_sync_error(error)
+        assert result == SyncErrorType.GIT_ERROR
+
+    def test_classifies_connection_error_as_git_error(self) -> None:
+        """ConnectionError during sync is classified as GIT_ERROR."""
+        error = ConnectionError("Network unreachable")
+        result = classify_sync_error(error)
+        assert result == SyncErrorType.GIT_ERROR
+
 
 class TestSyncService:
     """Tests for the SyncService class."""

--- a/tests/unit/entrypoints/test_sync_error_hints.py
+++ b/tests/unit/entrypoints/test_sync_error_hints.py
@@ -392,3 +392,212 @@ class TestSyncCommandErrorIntegration:
         # Should fail with reindex hint for database corruption
         assert result.exit_code != 0
         assert "reindex" in result.output.lower()
+
+
+class TestSqlite3ErrorHandling:
+    """Tests for sqlite3.Error handling in handle_cli_errors decorator."""
+
+    @pytest.fixture
+    def mock_click_context(self):
+        """Create a mock click context for tests."""
+        mock_ctx = MagicMock()
+        mock_ctx.obj = {"verbose": False}
+        return mock_ctx
+
+    def test_sqlite_operational_error_provides_database_hint(
+        self, mock_click_context
+    ) -> None:
+        """sqlite3.OperationalError should provide database-specific hint."""
+        import sqlite3
+
+        @handle_cli_errors("test")
+        def cmd():
+            raise sqlite3.OperationalError("database is locked")
+
+        with (
+            patch("click.get_current_context", return_value=mock_click_context),
+            pytest.raises(EmberCliError) as exc_info,
+        ):
+            cmd()
+
+        error = exc_info.value
+        assert "database" in error.message.lower()
+        assert error.hint is not None
+        # Should suggest reindex as the recovery action
+        assert "reindex" in error.hint.lower() or "sync" in error.hint.lower()
+
+    def test_sqlite_integrity_error_provides_database_hint(
+        self, mock_click_context
+    ) -> None:
+        """sqlite3.IntegrityError should provide database-specific hint."""
+        import sqlite3
+
+        @handle_cli_errors("test")
+        def cmd():
+            raise sqlite3.IntegrityError("constraint failed")
+
+        with (
+            patch("click.get_current_context", return_value=mock_click_context),
+            pytest.raises(EmberCliError) as exc_info,
+        ):
+            cmd()
+
+        error = exc_info.value
+        assert "database" in error.message.lower()
+        assert error.hint is not None
+        assert "reindex" in error.hint.lower() or "sync" in error.hint.lower()
+
+    def test_sqlite_database_error_provides_database_hint(
+        self, mock_click_context
+    ) -> None:
+        """sqlite3.DatabaseError should provide database-specific hint."""
+        import sqlite3
+
+        @handle_cli_errors("test")
+        def cmd():
+            raise sqlite3.DatabaseError("database disk image is malformed")
+
+        with (
+            patch("click.get_current_context", return_value=mock_click_context),
+            pytest.raises(EmberCliError) as exc_info,
+        ):
+            cmd()
+
+        error = exc_info.value
+        assert "database" in error.message.lower()
+        assert error.hint is not None
+        assert "reindex" in error.hint.lower() or "sync" in error.hint.lower()
+
+
+class TestNetworkErrorHandling:
+    """Tests for network/timeout errors in handle_cli_errors decorator."""
+
+    @pytest.fixture
+    def mock_click_context(self):
+        """Create a mock click context for tests."""
+        mock_ctx = MagicMock()
+        mock_ctx.obj = {"verbose": False}
+        return mock_ctx
+
+    def test_connection_error_provides_network_hint(
+        self, mock_click_context
+    ) -> None:
+        """requests.exceptions.ConnectionError should provide network hint."""
+        import requests.exceptions
+
+        @handle_cli_errors("test")
+        def cmd():
+            raise requests.exceptions.ConnectionError("Failed to connect")
+
+        with (
+            patch("click.get_current_context", return_value=mock_click_context),
+            pytest.raises(EmberCliError) as exc_info,
+        ):
+            cmd()
+
+        error = exc_info.value
+        assert error.hint is not None
+        # Should suggest checking network connection
+        assert "network" in error.hint.lower() or "connection" in error.hint.lower() or "internet" in error.hint.lower()
+
+    def test_timeout_error_provides_network_hint(
+        self, mock_click_context
+    ) -> None:
+        """requests.exceptions.Timeout should provide timeout hint."""
+        import requests.exceptions
+
+        @handle_cli_errors("test")
+        def cmd():
+            raise requests.exceptions.Timeout("Connection timed out")
+
+        with (
+            patch("click.get_current_context", return_value=mock_click_context),
+            pytest.raises(EmberCliError) as exc_info,
+        ):
+            cmd()
+
+        error = exc_info.value
+        assert error.hint is not None
+        # Should suggest retry or check connection
+        assert "timeout" in error.hint.lower() or "retry" in error.hint.lower() or "network" in error.hint.lower()
+
+    def test_urlerror_provides_network_hint(
+        self, mock_click_context
+    ) -> None:
+        """urllib.error.URLError should provide network hint."""
+        from urllib.error import URLError
+
+        @handle_cli_errors("test")
+        def cmd():
+            raise URLError("Name or service not known")
+
+        with (
+            patch("click.get_current_context", return_value=mock_click_context),
+            pytest.raises(EmberCliError) as exc_info,
+        ):
+            cmd()
+
+        error = exc_info.value
+        assert error.hint is not None
+        # Should suggest checking network connection
+        assert "network" in error.hint.lower() or "connection" in error.hint.lower() or "internet" in error.hint.lower()
+
+    def test_builtin_timeout_error_provides_timeout_hint(
+        self, mock_click_context
+    ) -> None:
+        """Built-in TimeoutError should provide timeout hint."""
+
+        @handle_cli_errors("test")
+        def cmd():
+            raise TimeoutError("Operation timed out")
+
+        with (
+            patch("click.get_current_context", return_value=mock_click_context),
+            pytest.raises(EmberCliError) as exc_info,
+        ):
+            cmd()
+
+        error = exc_info.value
+        assert error.hint is not None
+        # Should suggest retry or check system resources
+        assert "timed out" in error.hint.lower() or "try again" in error.hint.lower()
+
+
+class TestLoadAndDisplayConfigErrorHandling:
+    """Tests for _load_and_display_config error handling improvements."""
+
+    def test_load_and_display_config_returns_true_on_success(self) -> None:
+        """_load_and_display_config returns True when config loads successfully."""
+        from ember.entrypoints.cli import _load_and_display_config
+
+        mock_config = MagicMock()
+        result = _load_and_display_config("Test Config", lambda: mock_config)
+        assert result is True
+
+    def test_load_and_display_config_returns_false_on_failure(self) -> None:
+        """_load_and_display_config returns False when config loading fails."""
+        from ember.entrypoints.cli import _load_and_display_config
+
+        def failing_loader():
+            raise ValueError("Config parse error")
+
+        result = _load_and_display_config("Test Config", failing_loader)
+        assert result is False
+
+
+class TestQuickCheckUnchangedErrorHandling:
+    """Tests for _quick_check_unchanged error handling."""
+
+    def test_quick_check_returns_false_on_exception(self, tmp_path) -> None:
+        """_quick_check_unchanged returns False (triggering full sync) on any error."""
+        from ember.entrypoints.cli import _quick_check_unchanged
+
+        # Non-existent paths will cause errors
+        result = _quick_check_unchanged(
+            repo_root=tmp_path / "nonexistent",
+            db_path=tmp_path / "nonexistent.db",
+            sync_mode="worktree",
+            reindex=False,
+        )
+        # Should return False (indicating need for full sync), not raise
+        assert result is False


### PR DESCRIPTION
## Summary

Implements #421 - Addresses error handling gaps identified in the DX audit:

- **sqlite3.Error handling**: Added to `handle_cli_errors` decorator with hint: "Run 'ember sync --reindex' to rebuild the index."
- **Network error handling**: Added for `requests.exceptions.ConnectionError`, `URLError` with hint: "Check your internet connection and retry."
- **Timeout error handling**: Added for `requests.exceptions.Timeout` and built-in `TimeoutError` with appropriate hints
- **classify_sync_error()**: Now properly classifies `TimeoutError` and `ConnectionError` as `GIT_ERROR`
- **Silent error swallowing fixes**:
  - `_load_and_display_config()` now returns a boolean indicating success/failure
  - Search result cache warnings are now always shown (not just in verbose mode)

## Changes

### Error Handling in `handle_cli_errors` decorator
- Added `sqlite3.Error` -> Database error with reindex hint
- Added `requests.exceptions.Timeout` -> Network timeout with retry hint  
- Added `requests.exceptions.ConnectionError`, `URLError` -> Network error with connection hint
- Added built-in `TimeoutError` -> Operation timeout with system resources hint

### Error Classification in `classify_sync_error()`
- Added `TimeoutError` and `ConnectionError` classification as `GIT_ERROR`
- Fixed ordering: timeout/connection errors are now checked BEFORE generic OSError (since they're subclasses of OSError in Python 3)

### Silent Error Swallowing Fixes
- `_load_and_display_config()` now returns `True` on success, `False` on failure
- Search result cache warnings are now always shown to stderr

## Test Plan

- [x] Added 3 tests for sqlite3.Error handling
- [x] Added 4 tests for network/timeout error handling
- [x] Added 2 tests for classify_sync_error TimeoutError/ConnectionError
- [x] Added 2 tests for _load_and_display_config return values
- [x] Added 1 test for _quick_check_unchanged error handling
- [x] All tests pass (1493 passed, 2 skipped)
- [x] Linter passes (`ruff check .`)

Fixes #421