### PR TITLE
fix: standardize terminology - sync vs index, completion messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Standardized user-facing terminology for sync completion messages** (#420)
+  - Manual sync now shows "Synced X files" instead of "Indexed X files" to match `ember sync` command name
+  - Status command now shows "Index is up to date" instead of "Index is current" for consistency with auto-sync messages
+
 ### Fixed
 - **Improved error handling with targeted hints for database and network errors** (#421)
   - `handle_cli_errors` decorator now catches `sqlite3.Error` with hint: "Run 'ember sync --reindex' to rebuild."

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -993,7 +993,7 @@ def _format_sync_results(response) -> None:
     if response.files_indexed == 0 and response.chunks_deleted == 0:
         click.echo(f"✓ No changes detected ({sync_type} scan completed)")
     else:
-        click.echo(f"✓ Indexed {response.files_indexed} files ({sync_type} sync)")
+        click.echo(f"✓ Synced {response.files_indexed} files ({sync_type} sync)")
 
     if response.chunks_created > 0:
         click.echo(f"  • {response.chunks_created} chunks created")
@@ -1545,7 +1545,7 @@ def status(ctx: click.Context, detailed: bool) -> None:
             click.echo(click.style("Run 'ember sync' to update", fg="yellow"))
         else:
             click.echo(
-                click.style("Index is current", fg="green") + sync_time_display
+                click.style("Index is up to date", fg="green") + sync_time_display
             )
             click.echo(f"  {response.indexed_files} files indexed ({response.total_chunks:,} chunks)")
             if response.model_name:

--- a/tests/helpers/cli_assertions.py
+++ b/tests/helpers/cli_assertions.py
@@ -94,8 +94,8 @@ def assert_output_matches(
         The regex Match object for further inspection if needed.
 
     Example:
-        # Matches "Indexed 5 files" or "Indexed 10 files"
-        assert_output_matches(result, r"Indexed \\d+ files?")
+        # Matches "Synced 5 files" or "Synced 10 files"
+        assert_output_matches(result, r"Synced \\d+ files?")
 
         # Case-insensitive matching
         assert_output_matches(result, r"error", flags=re.IGNORECASE)

--- a/tests/unit/test_sync_feedback.py
+++ b/tests/unit/test_sync_feedback.py
@@ -78,8 +78,8 @@ class TestFormatSyncResults:
         with patch("click.echo") as mock_echo:
             _format_sync_results(response)
             calls = [call.args[0] for call in mock_echo.call_args_list]
-            # Flexible pattern: indexed N files with full sync type
-            assert any(re.search(r"[Ii]ndexed 5 files.*full sync", call) for call in calls)
+            # Flexible pattern: synced N files with full sync type
+            assert any(re.search(r"[Ss]ynced 5 files.*full sync", call) for call in calls)
 
     def test_changes_detected_incremental_sync(self) -> None:
         """Incremental sync with changes shows correct sync type."""
@@ -96,8 +96,8 @@ class TestFormatSyncResults:
         with patch("click.echo") as mock_echo:
             _format_sync_results(response)
             calls = [call.args[0] for call in mock_echo.call_args_list]
-            # Flexible pattern: indexed N files with incremental sync type
-            assert any(re.search(r"[Ii]ndexed 3 files.*incremental sync", call) for call in calls)
+            # Flexible pattern: synced N files with incremental sync type
+            assert any(re.search(r"[Ss]ynced 3 files.*incremental sync", call) for call in calls)
 
     def test_chunks_deleted_shows_details(self) -> None:
         """Deleted chunks are shown in output."""


### PR DESCRIPTION
## Summary
- Change "Indexed X files" to "Synced X files" in manual sync output to match the `ember sync` command name
- Change "Index is current" to "Index is up to date" in status command for consistency with auto-sync messages
- Update test assertions and comments to reflect new terminology

Closes #420

## Test Plan
- [x] All 1493 tests pass
- [x] Linter passes (ruff check .)
- [x] Updated test assertions for the new message format