### PR TITLE
feat: improve progress bar consistency and quiet mode support (#417)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Progress bar improvements and message consistency** (#417)
+  - Model download during `init` now shows a Rich progress spinner instead of plain text messages
+  - Interactive sync message (`Syncing index...`) now respects `--quiet` mode flag
+  - Added `quiet` parameter to `ensure_synced()` function for consistent quiet mode support
+  - Progress output is suppressed in quiet mode while errors are still shown
+
 - **Standardized user-facing terminology for sync completion messages** (#420)
   - Manual sync now shows "Synced X files" instead of "Indexed X files" to match `ember sync` command name
   - Status command now shows "Index is up to date" instead of "Index is current" for consistency with auto-sync messages

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -315,6 +315,7 @@ def _setup_search_command(
         SearchCommandDependencies with all initialized components
     """
     db_path = ember_dir / "index.db"
+    quiet = ctx.obj.get("quiet", False)
 
     config = _load_config(ember_dir)
 
@@ -329,6 +330,7 @@ def _setup_search_command(
             show_progress=show_progress,
             interactive_mode=interactive_mode,
             verbose=ctx.obj.get("verbose", False),
+            quiet=quiet,
         )
 
     embedder = _create_embedder(config, show_progress=show_progress)
@@ -481,14 +483,19 @@ def _show_sync_error_message(error: Exception, error_type: SyncErrorType) -> Non
         click.echo(f"Warning: Could not check index staleness: {error}", err=True)
 
 
-def _show_interactive_sync_message(interactive_mode: bool, show_progress: bool) -> None:
+def _show_interactive_sync_message(
+    interactive_mode: bool,
+    show_progress: bool,
+    quiet: bool = False,
+) -> None:
     """Show 'Syncing...' message for interactive mode without progress bar.
 
     Args:
         interactive_mode: Whether command is in interactive mode.
         show_progress: Whether progress bar is being shown.
+        quiet: If True, suppress the message entirely.
     """
-    if interactive_mode and not show_progress:
+    if interactive_mode and not show_progress and not quiet:
         click.echo("Syncing index...", err=True)
 
 
@@ -499,6 +506,7 @@ def ensure_synced(
     show_progress: bool = True,
     interactive_mode: bool = False,
     verbose: bool = False,
+    quiet: bool = False,
 ) -> SyncResult:
     """Ensure the index is synced before running a command.
 
@@ -513,6 +521,7 @@ def ensure_synced(
         interactive_mode: If True, show brief status message even without progress bar.
             Use this for TUI commands where progress bar would corrupt display.
         verbose: If True, show warnings on errors.
+        quiet: If True, suppress all status messages (errors still shown via verbose).
 
     Returns:
         SyncResult with information about whether sync was performed.
@@ -527,16 +536,19 @@ def ensure_synced(
 
         # In JSON output mode (completely silent):
         result = ensure_synced(repo_root, db_path, config, show_progress=False)
+
+        # In quiet mode (suppress all status messages):
+        result = ensure_synced(repo_root, db_path, config, quiet=True)
     """
     try:
         is_stale = _check_index_staleness(repo_root, db_path)
         if not is_stale:
             return SyncResult(synced=False, files_indexed=0)
 
-        _show_interactive_sync_message(interactive_mode, show_progress)
+        _show_interactive_sync_message(interactive_mode, show_progress, quiet)
         success, files_indexed = _execute_sync(repo_root, db_path, config, show_progress)
 
-        if show_progress:
+        if show_progress and not quiet:
             _show_sync_completion_message(success, files_indexed)
 
         return SyncResult(synced=True, files_indexed=files_indexed)
@@ -743,22 +755,34 @@ def _ensure_model_downloaded(model_name: str, quiet: bool) -> bool:
     Returns:
         True if model was downloaded or already cached, False on error.
     """
+    from rich.progress import Progress, SpinnerColumn, TextColumn
+
     from ember.adapters.local_models import create_embedder, is_model_cached
 
     if is_model_cached(model_name):
         return True
 
-    if not quiet:
-        click.echo(f"Downloading embedding model: {model_name}")
-        click.echo("  (this may take a minute on first run)")
-
     try:
         # Create embedder and call ensure_loaded() to trigger download
         embedder = create_embedder(model_name)
-        embedder.ensure_loaded()
 
-        if not quiet:
-            click.echo("  ✓ Model downloaded successfully")
+        if quiet:
+            # In quiet mode, just download without progress
+            embedder.ensure_loaded()
+        else:
+            # Show Rich progress spinner during download
+            with Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                transient=True,
+            ) as progress:
+                progress.add_task(
+                    f"Downloading model: {model_name} (this may take a minute)...",
+                    total=None,
+                )
+                embedder.ensure_loaded()
+            click.echo(f"  Downloaded model: {model_name}")
+
         return True
     except Exception as e:
         # Handle all errors with categorized messages

--- a/tests/unit/entrypoints/test_progress_consistency.py
+++ b/tests/unit/entrypoints/test_progress_consistency.py
@@ -1,0 +1,163 @@
+"""Unit tests for progress bar consistency across commands.
+
+Issue #417: Progress bar inconsistencies across commands
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ember.entrypoints.cli import (
+    _ensure_model_downloaded,
+    _show_interactive_sync_message,
+    _show_sync_completion_message,
+)
+
+
+class TestModelDownloadProgress:
+    """Tests for model download progress bar."""
+
+    def test_returns_true_immediately_when_cached(self) -> None:
+        """Should return True immediately when model is already cached."""
+        with patch(
+            "ember.adapters.local_models.is_model_cached", return_value=True
+        ) as mock_cached:
+            result = _ensure_model_downloaded("jina-code-v2", quiet=False)
+
+            assert result is True
+            mock_cached.assert_called_once_with("jina-code-v2")
+
+    def test_downloads_model_when_not_cached(self) -> None:
+        """Should download model and return True when not cached."""
+        mock_embedder = MagicMock()
+        with (
+            patch("ember.adapters.local_models.is_model_cached", return_value=False),
+            patch(
+                "ember.adapters.local_models.create_embedder",
+                return_value=mock_embedder,
+            ),
+        ):
+            result = _ensure_model_downloaded("jina-code-v2", quiet=False)
+
+            assert result is True
+            mock_embedder.ensure_loaded.assert_called_once()
+
+    def test_downloads_in_quiet_mode(self) -> None:
+        """Should download model without progress bar in quiet mode."""
+        mock_embedder = MagicMock()
+        with (
+            patch("ember.adapters.local_models.is_model_cached", return_value=False),
+            patch(
+                "ember.adapters.local_models.create_embedder",
+                return_value=mock_embedder,
+            ),
+        ):
+            result = _ensure_model_downloaded("jina-code-v2", quiet=True)
+
+            assert result is True
+            mock_embedder.ensure_loaded.assert_called_once()
+
+    def test_quiet_mode_suppresses_output(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Should suppress progress output in quiet mode on success."""
+        mock_embedder = MagicMock()
+        with (
+            patch("ember.adapters.local_models.is_model_cached", return_value=False),
+            patch(
+                "ember.adapters.local_models.create_embedder",
+                return_value=mock_embedder,
+            ),
+        ):
+            _ensure_model_downloaded("jina-code-v2", quiet=True)
+
+            captured = capsys.readouterr()
+            # Quiet mode should not show "Downloading" messages
+            assert "Downloading" not in captured.out
+            assert "Downloaded" not in captured.out
+
+
+class TestInteractiveSyncMessage:
+    """Tests for interactive sync message respecting quiet mode."""
+
+    def test_shows_message_in_interactive_mode_without_progress(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Should show sync message in interactive mode without progress bar."""
+        _show_interactive_sync_message(
+            interactive_mode=True,
+            show_progress=False,
+            quiet=False,
+        )
+
+        captured = capsys.readouterr()
+        assert "Syncing" in captured.err
+
+    def test_no_message_when_progress_bar_shown(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Should not show message when progress bar is already being shown."""
+        _show_interactive_sync_message(
+            interactive_mode=True,
+            show_progress=True,
+            quiet=False,
+        )
+
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_respects_quiet_mode(self, capsys: pytest.CaptureFixture) -> None:
+        """Should respect quiet mode and not show message."""
+        _show_interactive_sync_message(
+            interactive_mode=True,
+            show_progress=False,
+            quiet=True,
+        )
+
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_no_message_in_non_interactive_mode(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Should not show message in non-interactive mode."""
+        _show_interactive_sync_message(
+            interactive_mode=False,
+            show_progress=False,
+            quiet=False,
+        )
+
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+
+class TestSyncCompletionMessage:
+    """Tests for sync completion message destination."""
+
+    def test_completion_message_goes_to_stderr(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Sync completion messages should go to stderr (status output)."""
+        _show_sync_completion_message(success=True, files_indexed=5)
+
+        captured = capsys.readouterr()
+        assert "Synced 5 file(s)" in captured.err
+        assert captured.out == ""
+
+    def test_up_to_date_message_goes_to_stderr(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Index up to date message should go to stderr."""
+        _show_sync_completion_message(success=True, files_indexed=0)
+
+        captured = capsys.readouterr()
+        assert "up to date" in captured.err
+        assert captured.out == ""
+
+    def test_no_message_on_failure(self, capsys: pytest.CaptureFixture) -> None:
+        """Should not show completion message on failure."""
+        _show_sync_completion_message(success=False, files_indexed=5)
+
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert captured.out == ""


### PR DESCRIPTION
## Summary

Resolves #417 - DX: Progress bar inconsistencies across commands

- Add Rich progress spinner for model download during `ember init` (replaces plain text messages)
- Interactive sync message (`Syncing index...`) now respects `--quiet` mode flag
- Add `quiet` parameter to `ensure_synced()` function for consistent quiet mode support
- Progress output is suppressed in quiet mode while errors are still shown

## Changes

1. **Model download progress bar** - `_ensure_model_downloaded()` now uses a Rich spinner instead of `click.echo()` messages
2. **Quiet mode in interactive sync** - `_show_interactive_sync_message()` now takes a `quiet` parameter and respects it
3. **`ensure_synced()` quiet parameter** - Added `quiet` parameter that's propagated to message functions
4. **Tests** - Added `tests/unit/entrypoints/test_progress_consistency.py` with 11 tests covering progress bar and message behavior

## Test plan
- [x] All tests pass (1504 passed)
- [x] Linter passes
- [x] New tests for progress consistency added