### PR TITLE
refactor: clean up deprecated check_and_auto_sync and standardize sync flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **Removed deprecated `check_and_auto_sync()` function** (#418)
+  - Function was defined but never called anywhere in the codebase
+  - Use `ensure_synced()` instead, which provides the same functionality with a cleaner API
+
 ### Changed
+- **Standardized sync flag naming to use `show_progress` (positive form)** (#418)
+  - `progress_context()` parameter renamed from `quiet_mode` to `show_progress`
+  - Internal CLI code now uses `show_progress` consistently instead of inverting `quiet_mode`
+  - No user-facing changes - this is an internal API cleanup
+
 - **Progress bar improvements and message consistency** (#417)
   - Model download during `init` now shows a Rich progress spinner instead of plain text messages
   - Interactive sync message (`Syncing index...`) now respects `--quiet` mode flag

--- a/ember/core/progress.py
+++ b/ember/core/progress.py
@@ -62,24 +62,24 @@ class RichProgressCallback:
 
 @contextmanager
 def progress_context(
-    quiet_mode: bool = False,
+    show_progress: bool = True,
 ) -> Generator[RichProgressCallback | None, None, None]:
     """Context manager for creating progress bars.
 
     Args:
-        quiet_mode: If True, returns None (no progress reporting).
+        show_progress: If True, shows progress bar. If False, returns None.
 
     Yields:
-        RichProgressCallback if not quiet, None otherwise.
+        RichProgressCallback if show_progress is True, None otherwise.
 
     Example:
-        with progress_context(quiet=False) as progress:
+        with progress_context(show_progress=True) as progress:
             if progress:
                 usecase.execute(request, progress=progress)
             else:
                 usecase.execute(request)
     """
-    if quiet_mode:
+    if not show_progress:
         yield None
     else:
         with Progress(

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -444,8 +444,7 @@ def _execute_sync(
         force_reindex=False,
     )
 
-    quiet_mode = not show_progress
-    with progress_context(quiet_mode=quiet_mode) as progress:
+    with progress_context(show_progress=show_progress) as progress:
         if progress:
             response = indexing_usecase.execute(request, progress=progress)
         else:
@@ -558,39 +557,6 @@ def ensure_synced(
         if verbose:
             _show_sync_error_message(e, error_type)
         return SyncResult(synced=False, files_indexed=0, error=str(e), error_type=error_type)
-
-
-def check_and_auto_sync(
-    repo_root: Path,
-    db_path: Path,
-    config,
-    quiet_mode: bool = False,
-    verbose: bool = False,
-) -> None:
-    """Check if index is stale and auto-sync if needed.
-
-    .. deprecated::
-        Use :func:`ensure_synced` instead. This function is kept for backward
-        compatibility and will be removed in a future version.
-
-    Args:
-        repo_root: Repository root path.
-        db_path: Path to SQLite database.
-        config: Configuration object.
-        quiet_mode: If True, suppress progress and messages.
-        verbose: If True, show warnings on errors.
-
-    Note:
-        If staleness check fails, continues silently to allow search to proceed.
-    """
-    # Delegate to ensure_synced with appropriate parameters
-    ensure_synced(
-        repo_root=repo_root,
-        db_path=db_path,
-        config=config,
-        show_progress=not quiet_mode,
-        verbose=verbose,
-    )
 
 
 @click.group()
@@ -1089,7 +1055,7 @@ def sync(
         force_reindex=reindex,
     )
 
-    with progress_context(quiet_mode=ctx.obj.get("quiet", False)) as progress:
+    with progress_context(show_progress=not ctx.obj.get("quiet", False)) as progress:
         if progress:
             response = indexing_usecase.execute(request, progress=progress)
         else:

--- a/tests/unit/test_ensure_synced.py
+++ b/tests/unit/test_ensure_synced.py
@@ -64,8 +64,8 @@ class TestEnsureSynced:
                 show_progress=True,
             )
 
-            # Should use progress context with quiet_mode=False
-            mock_progress_ctx.assert_called_once_with(quiet_mode=False)
+            # Should use progress context with show_progress=True
+            mock_progress_ctx.assert_called_once_with(show_progress=True)
 
     def test_no_progress_when_syncing_and_show_progress_false(self) -> None:
         """Progress bar is NOT shown when show_progress=False."""
@@ -98,8 +98,8 @@ class TestEnsureSynced:
                 show_progress=False,
             )
 
-            # Should use progress context with quiet_mode=True
-            mock_progress_ctx.assert_called_once_with(quiet_mode=True)
+            # Should use progress context with show_progress=False
+            mock_progress_ctx.assert_called_once_with(show_progress=False)
 
     def test_shows_syncing_message_when_interactive_mode(self) -> None:
         """A brief 'Syncing...' message is shown in interactive_mode even without progress bar."""


### PR DESCRIPTION
## Summary

Implements #418: DX: Clean up deprecated check_and_auto_sync() and standardize sync flags

- Removed the deprecated `check_and_auto_sync()` function that was never called anywhere
- Standardized flag naming to use `show_progress` (positive form) instead of `quiet_mode` (negative form)
- Updated `progress_context()` parameter from `quiet_mode` to `show_progress`
- Updated CLI code to use the new parameter consistently
- Updated tests to reflect the parameter naming change

## Changes

| File | Change |
|------|--------|
| `ember/entrypoints/cli.py` | Removed `check_and_auto_sync()`, updated `progress_context` calls |
| `ember/core/progress.py` | Renamed `quiet_mode` to `show_progress` |
| `tests/unit/test_ensure_synced.py` | Updated test assertions for new parameter name |
| `CHANGELOG.md` | Added entry documenting the changes |

## Test Plan

- [x] All existing tests pass (1506 passed)
- [x] Linter passes (`ruff check .`)
- [x] No user-facing changes - internal API cleanup only

Fixes #418