### PR TITLE
refactor: consolidate Embedder Protocol to single definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Consolidated Embedder Protocol to single canonical definition** (#440)
+  - Removed duplicate `Embedder` Protocol classes from `adapters/factory.py` and `adapters/local_models/registry.py`
+  - Both files now import `Embedder` from `ember/ports/embedders.py`
+  - Added `ensure_loaded()` method to the canonical Protocol (was missing, causing `hasattr` guards)
+  - Cleaned up `hasattr` workaround in `index_usecase.py` since `ensure_loaded` is now part of the Protocol
+
 ### Removed
 - **Removed stub commands and empty directories** (#419)
   - Removed `export`, `import`, and `audit` CLI commands that only printed "not yet implemented"

--- a/ember/adapters/factory.py
+++ b/ember/adapters/factory.py
@@ -12,28 +12,14 @@ The factories use lazy imports to avoid loading heavy dependencies
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING
+
+from ember.ports.embedders import Embedder
 
 if TYPE_CHECKING:
     from ember.core.indexing.index_usecase import IndexingUseCase
     from ember.core.retrieval.search_usecase import SearchUseCase
     from ember.domain.config import EmberConfig
-
-
-class Embedder(Protocol):
-    """Protocol for embedder implementations."""
-
-    @property
-    def name(self) -> str: ...
-
-    @property
-    def dim(self) -> int: ...
-
-    def fingerprint(self) -> str: ...
-
-    def embed_texts(self, texts: list[str]) -> list[list[float]]: ...
-
-    def ensure_loaded(self) -> None: ...
 
 
 class EmbedderFactory:

--- a/ember/adapters/local_models/registry.py
+++ b/ember/adapters/local_models/registry.py
@@ -7,32 +7,14 @@ Provides a factory function to create the appropriate embedder based on config.
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+
+from ember.ports.embedders import Embedder
 
 # Import try_to_load_from_cache at module level for easier mocking in tests
 try:
     from huggingface_hub import try_to_load_from_cache
 except ImportError:
     try_to_load_from_cache = None  # type: ignore[assignment,misc]
-
-if TYPE_CHECKING:
-    pass
-
-
-class Embedder(Protocol):
-    """Embedder protocol for type checking."""
-
-    @property
-    def name(self) -> str: ...
-
-    @property
-    def dim(self) -> int: ...
-
-    def fingerprint(self) -> str: ...
-
-    def embed_texts(self, texts: list[str]) -> list[list[float]]: ...
-
-    def ensure_loaded(self) -> None: ...
 
 
 @dataclass(frozen=True)

--- a/ember/core/indexing/index_usecase.py
+++ b/ember/core/indexing/index_usecase.py
@@ -153,13 +153,12 @@ class IndexingUseCase:
 
     def _ensure_model_loaded(self, progress: ProgressCallback | None) -> None:
         """Eagerly load embedding model before indexing to prevent misleading progress."""
-        if hasattr(self.embedder, "ensure_loaded"):
-            logger.debug("Loading embedding model")
-            if progress:
-                progress.on_start(1, "Loading embedding model")
-            self.embedder.ensure_loaded()  # type: ignore[attr-defined]
-            if progress:
-                progress.on_complete()
+        logger.debug("Loading embedding model")
+        if progress:
+            progress.on_start(1, "Loading embedding model")
+        self.embedder.ensure_loaded()
+        if progress:
+            progress.on_complete()
 
     def _index_files_with_progress(
         self,

--- a/ember/ports/embedders.py
+++ b/ember/ports/embedders.py
@@ -44,3 +44,12 @@ class Embedder(Protocol):
             RuntimeError: If model fails to load or embed.
         """
         ...
+
+    def ensure_loaded(self) -> None:
+        """Eagerly load the model into memory.
+
+        Calling this before embed_texts ensures the model is ready,
+        avoiding lazy-loading delays during batch processing.
+        Implementations should be idempotent.
+        """
+        ...


### PR DESCRIPTION
## Summary
- Removed duplicate `Embedder` Protocol definitions from `ember/adapters/factory.py` and `ember/adapters/local_models/registry.py`
- Both files now import `Embedder` from the canonical location: `ember/ports/embedders.py`
- Added `ensure_loaded()` method to the canonical Protocol (was missing, causing `hasattr` workarounds)
- Cleaned up `hasattr`/`type: ignore` workaround in `ember/core/indexing/index_usecase.py`

Fixes #440

## Test plan
- [x] All 1504 tests pass (`uv run pytest`)
- [x] Linter passes (`uv run ruff check .`)
- [x] No circular import issues (factory.py and registry.py import directly from ports)
- [x] CHANGELOG.md updated