### PR TITLE
fix: handle corrupted vector BLOBs with clear errors (#443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Corrupted vector BLOBs now produce clear errors instead of crashing** (#443)
+  - Added `CorruptedVectorError` with chunk ID context, expected vs actual byte sizes, and remediation hint
+  - Dimension validation before `struct.unpack()` catches size mismatches early
+  - `VectorRepository.get()` gracefully returns `None` and logs a warning for corrupted vectors
+  - `SqliteVecAdapter._sync_vectors()` skips corrupted vectors and continues syncing valid ones
+  - All error messages suggest `ember sync --force` to rebuild the index
+
 ### Changed
 - **Reduced cyclomatic complexity of `format_time_ago`** (#441)
   - Replaced 13-branch if/elif chain with a data-driven lookup table

--- a/ember/adapters/sqlite/vector_repository.py
+++ b/ember/adapters/sqlite/vector_repository.py
@@ -1,9 +1,43 @@
 """SQLite adapter implementing VectorRepository protocol for embedding storage."""
 
+import logging
 import struct
 from pathlib import Path
 
 from ember.adapters.sqlite.base_repository import SQLiteBaseRepository
+
+logger = logging.getLogger(__name__)
+
+
+class CorruptedVectorError(Exception):
+    """Raised when a vector BLOB cannot be decoded due to corruption.
+
+    This typically happens from interrupted writes, database corruption,
+    or dimension mismatch after an embedding model change without reindexing.
+
+    Attributes:
+        chunk_id: The chunk identifier associated with the corrupted vector.
+        expected_bytes: The number of bytes expected for the given dimension.
+        actual_bytes: The actual number of bytes in the BLOB.
+    """
+
+    def __init__(
+        self,
+        chunk_id: str | None,
+        expected_bytes: int,
+        actual_bytes: int,
+    ) -> None:
+        self.chunk_id = chunk_id
+        self.expected_bytes = expected_bytes
+        self.actual_bytes = actual_bytes
+        chunk_desc = chunk_id if chunk_id else "unknown chunk"
+        super().__init__(
+            f"Corrupted vector BLOB for chunk '{chunk_desc}': "
+            f"expected {expected_bytes} bytes (dim={expected_bytes // 4}) "
+            f"but got {actual_bytes} bytes. "
+            f"This may indicate database corruption or a model change. "
+            f"Run 'ember sync --force' to rebuild the index."
+        )
 
 
 class SQLiteVectorRepository(SQLiteBaseRepository):
@@ -39,18 +73,43 @@ class SQLiteVectorRepository(SQLiteBaseRepository):
         # Pack as array of float32 (4 bytes each)
         return struct.pack(f"{len(vector)}f", *vector)
 
-    def _decode_vector(self, blob: bytes, dim: int) -> list[float]:
+    def _decode_vector(
+        self, blob: bytes, dim: int, chunk_id: str | None = None
+    ) -> list[float]:
         """Decode a vector from binary BLOB.
+
+        Validates BLOB size before decoding and provides informative error
+        messages including chunk context when available.
 
         Args:
             blob: Binary BLOB data.
             dim: Expected vector dimension.
+            chunk_id: Optional chunk identifier for error context.
 
         Returns:
             List of floats.
+
+        Raises:
+            CorruptedVectorError: If BLOB size doesn't match expected dimension.
         """
-        # Unpack array of float32
-        return list(struct.unpack(f"{dim}f", blob))
+        expected_bytes = dim * 4  # float32 = 4 bytes
+        actual_bytes = len(blob)
+
+        if actual_bytes != expected_bytes:
+            raise CorruptedVectorError(
+                chunk_id=chunk_id,
+                expected_bytes=expected_bytes,
+                actual_bytes=actual_bytes,
+            )
+
+        try:
+            return list(struct.unpack(f"{dim}f", blob))
+        except struct.error as e:
+            raise CorruptedVectorError(
+                chunk_id=chunk_id,
+                expected_bytes=expected_bytes,
+                actual_bytes=actual_bytes,
+            ) from e
 
     def _get_db_chunk_id(self, chunk_id: str) -> int | None:
         """Get the DB's internal integer id for a chunk.
@@ -132,11 +191,14 @@ class SQLiteVectorRepository(SQLiteBaseRepository):
     def get(self, chunk_id: str) -> list[float] | None:
         """Retrieve an embedding vector for a chunk.
 
+        Uses graceful degradation: if the stored vector BLOB is corrupted,
+        returns None and logs a warning instead of raising an exception.
+
         Args:
             chunk_id: The chunk identifier.
 
         Returns:
-            The embedding vector if found, None otherwise.
+            The embedding vector if found and valid, None otherwise.
         """
         # Get the DB's internal chunk id
         db_chunk_id = self._get_db_chunk_id(chunk_id)
@@ -162,7 +224,18 @@ class SQLiteVectorRepository(SQLiteBaseRepository):
         blob = row[0]
         dim = row[1]
 
-        return self._decode_vector(blob, dim)
+        try:
+            return self._decode_vector(blob, dim, chunk_id=chunk_id)
+        except CorruptedVectorError:
+            logger.warning(
+                "Skipping corrupted vector for chunk '%s': "
+                "expected %d bytes but got %d bytes. "
+                "Run 'ember sync --force' to rebuild the index.",
+                chunk_id,
+                dim * 4,
+                len(blob),
+            )
+            return None
 
     def delete(self, chunk_id: str) -> None:
         """Delete an embedding vector.

--- a/ember/adapters/vss/sqlite_vec_adapter.py
+++ b/ember/adapters/vss/sqlite_vec_adapter.py
@@ -9,6 +9,7 @@ sqlite-vec provides much better performance than brute-force methods,
 especially for larger datasets.
 """
 
+import logging
 import re
 import sqlite3
 import struct
@@ -17,6 +18,8 @@ from pathlib import Path
 import sqlite_vec
 
 from ember.adapters.sqlite.base_repository import SQLiteBaseRepository
+
+logger = logging.getLogger(__name__)
 
 
 def _clamp_similarity(similarity: float) -> float:
@@ -191,8 +194,33 @@ class SqliteVecAdapter(SQLiteBaseRepository):
             start_line = row[5]
             end_line = row[6]
 
-            # Decode vector from BLOB (stored as float32)
-            vector = list(struct.unpack(f"{dim}f", embedding_blob))
+            # Validate BLOB size before decoding (dim floats * 4 bytes each)
+            expected_bytes = dim * 4
+            actual_bytes = len(embedding_blob)
+            if actual_bytes != expected_bytes:
+                logger.warning(
+                    "Skipping corrupted vector for chunk_db_id=%d (path=%s): "
+                    "expected %d bytes (dim=%d) but got %d bytes. "
+                    "Run 'ember sync --force' to rebuild the index.",
+                    chunk_db_id,
+                    path,
+                    expected_bytes,
+                    dim,
+                    actual_bytes,
+                )
+                continue
+
+            try:
+                vector = list(struct.unpack(f"{dim}f", embedding_blob))
+            except struct.error:
+                logger.warning(
+                    "Skipping corrupted vector for chunk_db_id=%d (path=%s): "
+                    "failed to decode BLOB. "
+                    "Run 'ember sync --force' to rebuild the index.",
+                    chunk_db_id,
+                    path,
+                )
+                continue
 
             vectors_to_add.append((vector, project_id, path, start_line, end_line, chunk_db_id))
 

--- a/tests/unit/adapters/test_vector_blob_corruption.py
+++ b/tests/unit/adapters/test_vector_blob_corruption.py
@@ -1,0 +1,340 @@
+"""Tests for corrupted vector BLOB handling (issue #443).
+
+Tests that corrupted BLOBs in SQLite produce clear error messages with context
+rather than generic struct.error exceptions, and that graceful degradation
+works correctly in the sqlite-vec sync path.
+"""
+
+import logging
+import struct
+from pathlib import Path
+
+import pytest
+
+from ember.adapters.sqlite.chunk_repository import SQLiteChunkRepository
+from ember.adapters.sqlite.schema import init_database
+from ember.adapters.sqlite.vector_repository import (
+    CorruptedVectorError,
+    SQLiteVectorRepository,
+)
+from ember.domain.entities import Chunk
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def db_with_chunk(tmp_path: Path) -> tuple[Path, str]:
+    """Create a database with a single chunk, returning (db_path, chunk_id)."""
+    db_path = tmp_path / "test.db"
+    init_database(db_path)
+
+    chunk_repo = SQLiteChunkRepository(db_path)
+    content = "def hello(): pass"
+    chunk = Chunk(
+        id=Chunk.compute_id("test_proj", Path("test.py"), 1, 10),
+        project_id="test_proj",
+        path=Path("test.py"),
+        start_line=1,
+        end_line=10,
+        content=content,
+        content_hash=Chunk.compute_content_hash(content),
+        file_hash=Chunk.compute_content_hash("file_content"),
+        lang="py",
+        symbol=None,
+        tree_sha="a" * 40,
+        rev="worktree",
+    )
+    chunk_repo.add(chunk)
+    return db_path, chunk.id
+
+
+# =============================================================================
+# SQLiteVectorRepository._decode_vector tests
+# =============================================================================
+
+
+class TestDecodeVectorCorruption:
+    """Tests for _decode_vector handling of corrupted BLOBs."""
+
+    def test_decode_vector_with_truncated_blob(self, db_with_chunk: tuple[Path, str]) -> None:
+        """Truncated BLOB (too few bytes) raises CorruptedVectorError."""
+        db_path, _ = db_with_chunk
+        repo = SQLiteVectorRepository(db_path)
+
+        # 3-dimensional vector needs 12 bytes, provide only 8
+        truncated_blob = b"\x00" * 8
+        with pytest.raises(CorruptedVectorError) as exc_info:
+            repo._decode_vector(truncated_blob, dim=3)
+
+        error = exc_info.value
+        assert "expected 12 bytes" in str(error).lower()
+        assert "got 8 bytes" in str(error).lower()
+
+    def test_decode_vector_with_oversized_blob(self, db_with_chunk: tuple[Path, str]) -> None:
+        """Oversized BLOB (too many bytes) raises CorruptedVectorError."""
+        db_path, _ = db_with_chunk
+        repo = SQLiteVectorRepository(db_path)
+
+        # 3-dimensional vector needs 12 bytes, provide 16
+        oversized_blob = b"\x00" * 16
+        with pytest.raises(CorruptedVectorError) as exc_info:
+            repo._decode_vector(oversized_blob, dim=3)
+
+        error = exc_info.value
+        assert "expected 12 bytes" in str(error).lower()
+        assert "got 16 bytes" in str(error).lower()
+
+    def test_decode_vector_with_empty_blob(self, db_with_chunk: tuple[Path, str]) -> None:
+        """Empty BLOB raises CorruptedVectorError."""
+        db_path, _ = db_with_chunk
+        repo = SQLiteVectorRepository(db_path)
+
+        with pytest.raises(CorruptedVectorError) as exc_info:
+            repo._decode_vector(b"", dim=3)
+
+        assert "expected 12 bytes" in str(exc_info.value).lower()
+        assert "got 0 bytes" in str(exc_info.value).lower()
+
+    def test_decode_vector_with_chunk_id_context(self, db_with_chunk: tuple[Path, str]) -> None:
+        """CorruptedVectorError includes chunk_id when provided."""
+        db_path, _ = db_with_chunk
+        repo = SQLiteVectorRepository(db_path)
+
+        truncated_blob = b"\x00" * 4
+        with pytest.raises(CorruptedVectorError) as exc_info:
+            repo._decode_vector(truncated_blob, dim=3, chunk_id="abc123")
+
+        assert "abc123" in str(exc_info.value)
+
+    def test_decode_vector_with_correct_blob_succeeds(
+        self, db_with_chunk: tuple[Path, str]
+    ) -> None:
+        """Correctly sized BLOB decodes successfully (regression check)."""
+        db_path, _ = db_with_chunk
+        repo = SQLiteVectorRepository(db_path)
+
+        vector = [1.0, 2.0, 3.0]
+        blob = struct.pack("3f", *vector)
+        result = repo._decode_vector(blob, dim=3)
+
+        assert len(result) == 3
+        assert result[0] == pytest.approx(1.0)
+        assert result[1] == pytest.approx(2.0)
+        assert result[2] == pytest.approx(3.0)
+
+    def test_decode_vector_error_suggests_sync_force(
+        self, db_with_chunk: tuple[Path, str]
+    ) -> None:
+        """Error message suggests 'ember sync --force' as remediation."""
+        db_path, _ = db_with_chunk
+        repo = SQLiteVectorRepository(db_path)
+
+        truncated_blob = b"\x00" * 4
+        with pytest.raises(CorruptedVectorError) as exc_info:
+            repo._decode_vector(truncated_blob, dim=3)
+
+        assert "ember sync --force" in str(exc_info.value)
+
+
+class TestCorruptedVectorErrorAttributes:
+    """Tests for CorruptedVectorError exception attributes."""
+
+    def test_error_has_chunk_id(self) -> None:
+        """CorruptedVectorError stores chunk_id attribute."""
+        error = CorruptedVectorError(
+            chunk_id="abc123",
+            expected_bytes=12,
+            actual_bytes=8,
+        )
+        assert error.chunk_id == "abc123"
+
+    def test_error_has_expected_bytes(self) -> None:
+        """CorruptedVectorError stores expected_bytes attribute."""
+        error = CorruptedVectorError(
+            chunk_id="abc123",
+            expected_bytes=12,
+            actual_bytes=8,
+        )
+        assert error.expected_bytes == 12
+
+    def test_error_has_actual_bytes(self) -> None:
+        """CorruptedVectorError stores actual_bytes attribute."""
+        error = CorruptedVectorError(
+            chunk_id="abc123",
+            expected_bytes=12,
+            actual_bytes=8,
+        )
+        assert error.actual_bytes == 8
+
+    def test_error_without_chunk_id(self) -> None:
+        """CorruptedVectorError works without chunk_id."""
+        error = CorruptedVectorError(
+            chunk_id=None,
+            expected_bytes=12,
+            actual_bytes=8,
+        )
+        assert error.chunk_id is None
+        assert "unknown" in str(error).lower() or "12" in str(error)
+
+
+# =============================================================================
+# SQLiteVectorRepository.get() with corrupted data tests
+# =============================================================================
+
+
+class TestGetWithCorruptedData:
+    """Tests for SQLiteVectorRepository.get() when database has corrupted vectors."""
+
+    def test_get_with_corrupted_blob_returns_none_and_logs(
+        self, db_with_chunk: tuple[Path, str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """get() returns None and logs warning for corrupted BLOB (graceful degradation)."""
+        db_path, chunk_id = db_with_chunk
+        repo = SQLiteVectorRepository(db_path)
+
+        # First store a valid vector
+        valid_embedding = [1.0, 2.0, 3.0]
+        repo.add(chunk_id, valid_embedding, "test-model")
+
+        # Now corrupt the BLOB in the database directly
+        conn = repo._get_connection()
+        cursor = conn.cursor()
+        # Get the internal DB id
+        cursor.execute("SELECT id FROM chunks WHERE chunk_id = ?", (chunk_id,))
+        db_id = cursor.fetchone()[0]
+        # Write a truncated BLOB (should be 12 bytes for 3 dims, write only 4)
+        cursor.execute(
+            "UPDATE vectors SET embedding = ? WHERE chunk_id = ?",
+            (b"\x00" * 4, db_id),
+        )
+        conn.commit()
+
+        # get() should return None and log a warning
+        with caplog.at_level(logging.WARNING):
+            result = repo.get(chunk_id)
+
+        assert result is None
+        assert any("corrupted" in record.message.lower() for record in caplog.records)
+        assert any("ember sync --force" in record.message for record in caplog.records)
+
+
+# =============================================================================
+# SqliteVecAdapter._sync_vectors with corrupted data tests
+# =============================================================================
+
+
+class TestSyncVectorsCorruptedBlobs:
+    """Tests for SqliteVecAdapter._sync_vectors handling corrupted BLOBs."""
+
+    def test_sync_skips_corrupted_vectors_and_logs_warning(
+        self, db_with_chunk: tuple[Path, str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """_sync_vectors skips corrupted vectors instead of crashing."""
+        from ember.adapters.vss.sqlite_vec_adapter import SqliteVecAdapter
+
+        db_path, chunk_id = db_with_chunk
+        vector_repo = SQLiteVectorRepository(db_path)
+
+        # Store a valid vector first
+        valid_embedding = [0.1] * 3
+        vector_repo.add(chunk_id, valid_embedding, "test-model")
+
+        # Corrupt the BLOB in the vectors table
+        conn = vector_repo._get_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT id FROM chunks WHERE chunk_id = ?", (chunk_id,))
+        db_id = cursor.fetchone()[0]
+        cursor.execute(
+            "UPDATE vectors SET embedding = ? WHERE chunk_id = ?",
+            (b"\x00" * 4, db_id),  # Wrong size for dim=3
+        )
+        conn.commit()
+        vector_repo.close()
+
+        # SqliteVecAdapter should skip corrupted vectors and log warning
+        with caplog.at_level(logging.WARNING):
+            adapter = SqliteVecAdapter(db_path, vector_dim=3)
+
+        # Should not crash - adapter should be created successfully
+        assert adapter is not None
+
+        # Should have logged a warning about the corrupted vector
+        assert any("corrupted" in record.message.lower() for record in caplog.records)
+
+        adapter.close()
+
+    def test_sync_processes_valid_vectors_alongside_corrupted(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Valid vectors are synced even when some are corrupted."""
+        from ember.adapters.vss.sqlite_vec_adapter import SqliteVecAdapter
+
+        db_path = tmp_path / "test.db"
+        init_database(db_path)
+        chunk_repo = SQLiteChunkRepository(db_path)
+        vector_repo = SQLiteVectorRepository(db_path)
+
+        # Create two chunks
+        content1 = "def foo(): pass"
+        chunk1 = Chunk(
+            id=Chunk.compute_id("proj", Path("a.py"), 1, 5),
+            project_id="proj",
+            path=Path("a.py"),
+            start_line=1,
+            end_line=5,
+            content=content1,
+            content_hash=Chunk.compute_content_hash(content1),
+            file_hash=Chunk.compute_content_hash("file_a"),
+            lang="py",
+            symbol=None,
+            tree_sha="a" * 40,
+            rev="worktree",
+        )
+        content2 = "def bar(): pass"
+        chunk2 = Chunk(
+            id=Chunk.compute_id("proj", Path("b.py"), 1, 5),
+            project_id="proj",
+            path=Path("b.py"),
+            start_line=1,
+            end_line=5,
+            content=content2,
+            content_hash=Chunk.compute_content_hash(content2),
+            file_hash=Chunk.compute_content_hash("file_b"),
+            lang="py",
+            symbol=None,
+            tree_sha="b" * 40,
+            rev="worktree",
+        )
+        chunk_repo.add(chunk1)
+        chunk_repo.add(chunk2)
+
+        # Store valid vectors for both
+        embedding = [0.1] * 3
+        vector_repo.add(chunk1.id, embedding, "test-model")
+        vector_repo.add(chunk2.id, embedding, "test-model")
+
+        # Corrupt only the first vector
+        conn = vector_repo._get_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT id FROM chunks WHERE chunk_id = ?", (chunk1.id,))
+        db_id1 = cursor.fetchone()[0]
+        cursor.execute(
+            "UPDATE vectors SET embedding = ? WHERE chunk_id = ?",
+            (b"\x00" * 4, db_id1),  # Corrupted
+        )
+        conn.commit()
+        vector_repo.close()
+
+        # Sync should process the valid vector and skip the corrupted one
+        with caplog.at_level(logging.WARNING):
+            adapter = SqliteVecAdapter(db_path, vector_dim=3)
+
+        # The valid vector should have been synced
+        query_vector = [0.1] * 3
+        results = adapter.query(query_vector, topk=10)
+        # Should have at least the valid vector
+        assert len(results) >= 1
+
+        adapter.close()


### PR DESCRIPTION
## Summary
- Adds `CorruptedVectorError` exception with chunk ID context, expected vs actual byte sizes, and `ember sync --force` remediation hint
- Validates BLOB size (`len(blob) == dim * 4`) before calling `struct.unpack()` to catch dimension mismatches early
- `SQLiteVectorRepository.get()` uses graceful degradation: returns `None` and logs a warning for corrupted vectors instead of crashing
- `SqliteVecAdapter._sync_vectors()` skips corrupted vectors with a warning and continues syncing valid ones

Closes #443

## Test plan
- [x] 13 new tests in `test_vector_blob_corruption.py` covering all corruption scenarios
- [x] Truncated, oversized, and empty BLOBs raise `CorruptedVectorError` with informative messages
- [x] Error includes chunk ID context and `ember sync --force` suggestion
- [x] `get()` returns `None` and logs warning for corrupted data
- [x] `_sync_vectors()` skips corrupted vectors while processing valid ones
- [x] Full test suite passes (1517 passed)
- [x] Linter passes (`ruff check .`)