### PR TITLE
fix: daemon client and server thread safety (#439)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Daemon client and server thread safety improvements** (#439)
+  - Fallback embedder creation is now thread-safe using double-checked locking; only one fallback embedder is created even under concurrent access
+  - Server request stats (`requests_served`, `last_request_time`) are updated atomically via `threading.Lock`
+  - Added `close()` method and context manager support to `DaemonEmbedderClient` for proper fallback embedder cleanup
+
 - **Schema migration is now safe against partial failure** (#436)
   - Database is backed up (via `shutil.copy`) before any migration runs
   - Added `migration_history` table to track which migrations have been applied

--- a/ember/adapters/daemon/client.py
+++ b/ember/adapters/daemon/client.py
@@ -7,6 +7,7 @@ Falls back to direct mode if daemon is unavailable.
 import contextlib
 import logging
 import socket
+import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -113,7 +114,8 @@ class DaemonEmbedderClient:
         self.daemon_timeout = daemon_timeout
         self.model_name = model_name
 
-        # Lazy-loaded fallback embedder
+        # Lazy-loaded fallback embedder (protected by _fallback_lock)
+        self._fallback_lock = threading.Lock()
         self._fallback_embedder: Embedder | None = None
         self._using_fallback = False
         self._daemon_start_attempted = False
@@ -168,23 +170,32 @@ class DaemonEmbedderClient:
         return temp_embedder.fingerprint()
 
     def _get_fallback_embedder(self) -> "Embedder":
-        """Get or create fallback embedder.
+        """Get or create fallback embedder (thread-safe).
+
+        Uses double-checked locking to ensure only one fallback embedder
+        is created even when multiple threads trigger fallback simultaneously.
 
         Returns:
             Embedder instance for direct mode
         """
-        if self._fallback_embedder is None:
-            from ember.adapters.local_models.registry import create_embedder
+        # Fast path: embedder already created (no lock needed)
+        if self._fallback_embedder is not None:
+            return self._fallback_embedder
 
-            logger.info(
-                f"Creating fallback embedder (direct mode): "
-                f"{self.model_name or 'default'}"
-            )
-            self._fallback_embedder = create_embedder(
-                model_name=self.model_name,
-                max_seq_length=self.max_seq_length,
-                batch_size=self.batch_size,
-            )
+        with self._fallback_lock:
+            # Double-check after acquiring lock
+            if self._fallback_embedder is None:
+                from ember.adapters.local_models.registry import create_embedder
+
+                logger.info(
+                    f"Creating fallback embedder (direct mode): "
+                    f"{self.model_name or 'default'}"
+                )
+                self._fallback_embedder = create_embedder(
+                    model_name=self.model_name,
+                    max_seq_length=self.max_seq_length,
+                    batch_size=self.batch_size,
+                )
         return self._fallback_embedder
 
     def _ensure_daemon_running(self) -> bool:
@@ -273,6 +284,9 @@ class DaemonEmbedderClient:
     def embed_texts(self, texts: list[str]) -> list[list[float]]:
         """Embed texts using daemon or fallback.
 
+        Thread-safe: the fallback transition is protected by a lock to ensure
+        only one fallback embedder is created even under concurrent access.
+
         Args:
             texts: List of text strings to embed
 
@@ -298,8 +312,28 @@ class DaemonEmbedderClient:
                 raise RuntimeError(f"Daemon failed and fallback disabled: {e}") from e
 
             logger.warning(f"Daemon failed, falling back to direct mode: {e}")
-            self._using_fallback = True
+            with self._fallback_lock:
+                self._using_fallback = True
             return self._get_fallback_embedder().embed_texts(texts)
+
+    def close(self) -> None:
+        """Release fallback embedder resources.
+
+        Cleans up the lazily-created fallback embedder, freeing GPU memory.
+        Resets fallback state so the client can potentially retry the daemon
+        if reused. Safe to call multiple times (idempotent).
+        """
+        with self._fallback_lock:
+            self._fallback_embedder = None
+            self._using_fallback = False
+
+    def __enter__(self) -> "DaemonEmbedderClient":
+        """Enter context manager."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Exit context manager, releasing fallback resources."""
+        self.close()
 
 
 def is_daemon_running(socket_path: Path | None = None) -> bool:

--- a/ember/adapters/daemon/server.py
+++ b/ember/adapters/daemon/server.py
@@ -11,6 +11,7 @@ import logging
 import signal
 import socket
 import sys
+import threading
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -58,8 +59,11 @@ class DaemonServer:
 
         self.embedder: Embedder | None = None
         self.server_socket: socket.socket | None = None
-        self.last_request_time = time.time()
         self.running = False
+
+        # Request stats (protected by _stats_lock)
+        self._stats_lock = threading.Lock()
+        self.last_request_time = time.time()
         self.requests_served = 0
 
     def setup_signal_handlers(self) -> None:
@@ -112,6 +116,16 @@ class DaemonServer:
         self.server_socket.settimeout(DaemonTimeouts.SERVER_ACCEPT)
 
         logger.info(f"Listening on {self.socket_path}")
+
+    def update_stats(self) -> None:
+        """Update request statistics (thread-safe).
+
+        Atomically updates both last_request_time and requests_served
+        under a single lock acquisition.
+        """
+        with self._stats_lock:
+            self.last_request_time = time.time()
+            self.requests_served += 1
 
     def handle_request(self, request: Request) -> Response:
         """Handle a single request.
@@ -205,9 +219,8 @@ class DaemonServer:
             request = receive_message(client_socket, Request)
             logger.debug(f"Received request: {request.method}")
 
-            # Update activity time
-            self.last_request_time = time.time()
-            self.requests_served += 1
+            # Update activity time (thread-safe)
+            self.update_stats()
 
             # Handle request
             response = self.handle_request(request)

--- a/tests/unit/adapters/test_daemon_thread_safety.py
+++ b/tests/unit/adapters/test_daemon_thread_safety.py
@@ -1,0 +1,351 @@
+"""Tests for daemon client and server thread safety (issue #439).
+
+Tests cover:
+1. Fallback flag race condition - only one fallback embedder created
+2. Request counter atomicity - accurate stats under concurrent access
+3. Fallback embedder cleanup - close() releases resources
+"""
+
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ember.adapters.daemon.client import DaemonEmbedderClient
+from ember.adapters.daemon.server import DaemonServer
+
+# ============================================================================
+# 1. Fallback transition thread safety
+# ============================================================================
+
+
+class TestFallbackThreadSafety:
+    """Test that fallback transition is thread-safe."""
+
+    @pytest.fixture
+    def temp_socket_path(self, tmp_path: Path) -> Path:
+        """Temporary socket path for testing."""
+        return tmp_path / "test.sock"
+
+    def test_concurrent_fallback_creates_single_embedder(
+        self, temp_socket_path: Path
+    ) -> None:
+        """Multiple threads hitting daemon errors should create only one fallback embedder.
+
+        This is the core race condition from issue #439: two threads hitting a daemon
+        error simultaneously could both enter the fallback creation path and create
+        duplicate embedders, wasting GPU memory.
+        """
+        client = DaemonEmbedderClient(
+            socket_path=temp_socket_path,
+            fallback=True,
+            auto_start=False,
+        )
+
+        # Track how many times create_embedder is called
+        create_count = 0
+        create_lock = threading.Lock()
+
+        mock_embedder = MagicMock()
+        mock_embedder.embed_texts.return_value = [[0.1, 0.2, 0.3]]
+        mock_embedder.name = "test-model"
+        mock_embedder.dim = 3
+
+        def counting_create_embedder(**kwargs):
+            nonlocal create_count
+            with create_lock:
+                create_count += 1
+            # Simulate slow model loading to widen the race window
+            time.sleep(0.05)
+            return mock_embedder
+
+        # Barrier to synchronize thread start
+        barrier = threading.Barrier(10)
+        errors: list[Exception] = []
+
+        def thread_func():
+            try:
+                barrier.wait(timeout=5)
+                client.embed_texts(["test"])
+            except Exception as e:
+                errors.append(e)
+
+        with patch(
+            "ember.adapters.local_models.registry.create_embedder",
+            side_effect=counting_create_embedder,
+        ):
+            threads = [threading.Thread(target=thread_func) for _ in range(10)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+
+        assert not errors, f"Threads raised errors: {errors}"
+        # Only one fallback embedder should have been created
+        assert create_count == 1, (
+            f"Expected exactly 1 call to create_embedder, got {create_count}. "
+            f"Race condition: multiple threads created fallback embedders."
+        )
+
+    def test_fallback_transition_sets_flag_atomically(
+        self, temp_socket_path: Path
+    ) -> None:
+        """After fallback transition, all subsequent calls use fallback directly.
+
+        The _using_fallback flag and _fallback_embedder should be set together
+        under lock protection so no thread sees an inconsistent state.
+        """
+        client = DaemonEmbedderClient(
+            socket_path=temp_socket_path,
+            fallback=True,
+            auto_start=False,
+        )
+
+        mock_embedder = MagicMock()
+        mock_embedder.embed_texts.return_value = [[0.1, 0.2, 0.3]]
+        mock_embedder.name = "test-model"
+        mock_embedder.dim = 3
+
+        with patch(
+            "ember.adapters.local_models.registry.create_embedder",
+            return_value=mock_embedder,
+        ):
+            # First call triggers fallback
+            client.embed_texts(["trigger fallback"])
+
+        assert client._using_fallback is True
+        assert client._fallback_embedder is not None
+
+        # Subsequent calls should go straight to fallback (no daemon attempt)
+        mock_embedder.embed_texts.return_value = [[0.4, 0.5, 0.6]]
+        result = client.embed_texts(["already in fallback"])
+        assert result == [[0.4, 0.5, 0.6]]
+
+    def test_embed_texts_without_fallback_raises_on_daemon_failure(
+        self, temp_socket_path: Path
+    ) -> None:
+        """When fallback is disabled, daemon failure should raise RuntimeError."""
+        client = DaemonEmbedderClient(
+            socket_path=temp_socket_path,
+            fallback=False,
+            auto_start=False,
+        )
+
+        with pytest.raises(RuntimeError, match="Daemon failed and fallback disabled"):
+            client.embed_texts(["test"])
+
+
+# ============================================================================
+# 2. Request counter thread safety
+# ============================================================================
+
+
+class TestRequestCounterThreadSafety:
+    """Test that request counters are thread-safe."""
+
+    @pytest.fixture
+    def temp_socket_path(self, tmp_path: Path) -> Path:
+        """Temporary socket path for testing."""
+        return tmp_path / "test.sock"
+
+    @pytest.fixture
+    def server(self, temp_socket_path: Path) -> DaemonServer:
+        """Create a DaemonServer instance for testing."""
+        return DaemonServer(
+            socket_path=temp_socket_path,
+            idle_timeout=0,
+        )
+
+    def test_concurrent_request_counting(self, server: DaemonServer) -> None:
+        """Concurrent handle_client calls should produce accurate request count.
+
+        Without a lock, `self.requests_served += 1` can lose increments under
+        concurrent access because read-modify-write is not atomic at the bytecode level.
+        """
+        # Set up a mock embedder for embed_texts requests
+        mock_embedder = MagicMock()
+        mock_embedder.embed_texts.return_value = [[0.1, 0.2]]
+        server.embedder = mock_embedder
+
+        num_threads = 50
+        barrier = threading.Barrier(num_threads)
+        errors: list[Exception] = []
+
+        def thread_func():
+            try:
+                barrier.wait(timeout=5)
+                # Call update_stats directly to test the counter
+                server.update_stats()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=thread_func) for _ in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"Threads raised errors: {errors}"
+        assert server.requests_served == num_threads, (
+            f"Expected {num_threads} requests_served, got {server.requests_served}. "
+            f"Race condition: lost counter increments."
+        )
+
+    def test_last_request_time_updated_under_lock(
+        self, server: DaemonServer
+    ) -> None:
+        """last_request_time should be updated atomically with requests_served."""
+        initial_time = server.last_request_time
+
+        # Small delay to ensure time difference
+        time.sleep(0.01)
+        server.update_stats()
+
+        assert server.requests_served == 1
+        assert server.last_request_time > initial_time
+
+    def test_stats_endpoint_reads_consistent_values(
+        self, server: DaemonServer
+    ) -> None:
+        """Stats endpoint should read consistent counter values."""
+        from ember.adapters.daemon.protocol import Request
+
+        # Simulate some requests
+        for _ in range(5):
+            server.update_stats()
+
+        request = Request(method="stats", params={})
+        response = server.handle_request(request)
+
+        assert not response.is_error()
+        assert response.result["requests_served"] == 5
+
+
+# ============================================================================
+# 3. Fallback embedder cleanup
+# ============================================================================
+
+
+class TestFallbackEmbedderCleanup:
+    """Test that fallback embedder is properly cleaned up."""
+
+    @pytest.fixture
+    def temp_socket_path(self, tmp_path: Path) -> Path:
+        """Temporary socket path for testing."""
+        return tmp_path / "test.sock"
+
+    def test_close_releases_fallback_embedder(
+        self, temp_socket_path: Path
+    ) -> None:
+        """close() should release the fallback embedder reference."""
+        client = DaemonEmbedderClient(
+            socket_path=temp_socket_path,
+            fallback=True,
+            auto_start=False,
+        )
+
+        # Manually set a fallback embedder
+        mock_embedder = MagicMock()
+        client._fallback_embedder = mock_embedder
+        client._using_fallback = True
+
+        # Close should release it
+        client.close()
+
+        assert client._fallback_embedder is None
+        assert client._using_fallback is False
+
+    def test_close_is_idempotent(self, temp_socket_path: Path) -> None:
+        """Calling close() multiple times should not raise errors."""
+        client = DaemonEmbedderClient(
+            socket_path=temp_socket_path,
+            fallback=True,
+            auto_start=False,
+        )
+
+        # Close with no fallback embedder created
+        client.close()
+        client.close()  # Should not raise
+
+        # Close after setting a fallback embedder
+        client._fallback_embedder = MagicMock()
+        client._using_fallback = True
+        client.close()
+        client.close()  # Should not raise
+
+    def test_close_resets_state_for_potential_reuse(
+        self, temp_socket_path: Path
+    ) -> None:
+        """After close(), client should be in a clean state.
+
+        If the client is reused after close(), it should try the daemon
+        again before falling back.
+        """
+        client = DaemonEmbedderClient(
+            socket_path=temp_socket_path,
+            fallback=True,
+            auto_start=False,
+        )
+
+        client._fallback_embedder = MagicMock()
+        client._using_fallback = True
+
+        client.close()
+
+        assert client._using_fallback is False
+        assert client._fallback_embedder is None
+
+    def test_context_manager_support(self, temp_socket_path: Path) -> None:
+        """Client should support context manager protocol for automatic cleanup."""
+        client = DaemonEmbedderClient(
+            socket_path=temp_socket_path,
+            fallback=True,
+            auto_start=False,
+        )
+
+        mock_embedder = MagicMock()
+        mock_embedder.embed_texts.return_value = [[0.1, 0.2, 0.3]]
+
+        with (
+            patch(
+                "ember.adapters.local_models.registry.create_embedder",
+                return_value=mock_embedder,
+            ),
+            client,
+        ):
+            client.embed_texts(["test"])
+            assert client._using_fallback is True
+            assert client._fallback_embedder is not None
+
+        # After exiting context, fallback should be cleaned up
+        assert client._fallback_embedder is None
+        assert client._using_fallback is False
+
+    def test_context_manager_cleans_up_on_exception(
+        self, temp_socket_path: Path
+    ) -> None:
+        """Context manager should clean up even if an exception occurs."""
+        client = DaemonEmbedderClient(
+            socket_path=temp_socket_path,
+            fallback=True,
+            auto_start=False,
+        )
+
+        mock_embedder = MagicMock()
+        mock_embedder.embed_texts.side_effect = RuntimeError("embedding failed")
+
+        with pytest.raises(RuntimeError, match="embedding failed"), patch(
+            "ember.adapters.local_models.registry.create_embedder",
+            return_value=mock_embedder,
+        ), client:
+            # First call triggers fallback and creates embedder
+            client._fallback_embedder = mock_embedder
+            client._using_fallback = True
+            # This call raises
+            client.embed_texts(["test"])
+
+        # Should still be cleaned up
+        assert client._fallback_embedder is None
+        assert client._using_fallback is False


### PR DESCRIPTION
## Summary
- **Fallback race condition fixed**: Uses `threading.Lock` with double-checked locking in `_get_fallback_embedder()` so only one fallback embedder is ever created, even when multiple threads hit daemon errors simultaneously
- **Request stats now atomic**: Added `update_stats()` method to `DaemonServer` that updates `last_request_time` and `requests_served` under a single lock acquisition
- **Fallback embedder cleanup**: Added `close()` method and context manager (`__enter__`/`__exit__`) to `DaemonEmbedderClient` for proper GPU memory release

Closes #439

## Test plan
- [x] 11 new tests in `tests/unit/adapters/test_daemon_thread_safety.py`
  - [x] Concurrent fallback creates only one embedder (10 threads, barrier-synchronized)
  - [x] Fallback transition sets flag atomically
  - [x] Fallback-disabled raises RuntimeError on daemon failure
  - [x] Concurrent request counting is accurate (50 threads)
  - [x] `last_request_time` updated atomically with `requests_served`
  - [x] Stats endpoint reads consistent values
  - [x] `close()` releases fallback embedder
  - [x] `close()` is idempotent
  - [x] `close()` resets state for reuse
  - [x] Context manager cleans up on normal exit
  - [x] Context manager cleans up on exception
- [x] All 1548 existing tests pass
- [x] Linter passes (`ruff check .`)