### PR TITLE
fix: surface tree-sitter parse failures to users (#438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Tree-sitter parse failures are now surfaced to users instead of being silently swallowed** (#438)
+  - `TreeSitterChunker` now raises `ParseError` on parse failure instead of returning an empty list
+  - `ChunkFileUseCase` catches `ParseError`, records a `ParseWarning`, and falls back to line-based chunking
+  - Sync output shows count of files that failed to parse (e.g., "3 file(s) failed to parse")
+  - `--verbose` flag lists specific files and reasons for parse failures
+  - Files that parse successfully are completely unaffected
+  - Files with no definitions (only statements) still fall back normally without a warning
+
 - **SimpleVectorSearch no longer loads all vectors into memory on every query** (#435)
   - Replaced `fetchall()` with streaming `fetchmany()` batches and a bounded min-heap
   - Memory usage is now O(topk + batch_size) regardless of corpus size

--- a/ember/adapters/parsers/tree_sitter_chunker.py
+++ b/ember/adapters/parsers/tree_sitter_chunker.py
@@ -10,7 +10,7 @@ from tree_sitter import QueryCursor
 
 from ember.adapters.parsers.definition_matcher import DefinitionMatcher
 from ember.adapters.parsers.language_registry import LanguageRegistry
-from ember.ports.chunkers import ChunkData
+from ember.ports.chunkers import ChunkData, ParseError
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,11 @@ class TreeSitterChunker:
 
         Returns:
             List of ChunkData for extracted functions/classes.
-            Empty list if language not supported or parsing fails.
+            Empty list if language not supported or no definitions found.
+
+        Raises:
+            ParseError: If tree-sitter fails to parse the file or execute the query.
+                The caller should catch this and fall back to line-based chunking.
         """
         # Get language configuration
         config = self._registry.get_by_identifier(lang)
@@ -54,26 +58,30 @@ class TreeSitterChunker:
         query = self._registry.get_query(config.name)
 
         if not parser or not query:
-            logger.warning(f"Failed to initialize parser for {config.name} (file: {path})")
-            return []
+            raise ParseError(
+                f"Failed to initialize parser for {config.name} (file: {path})"
+            )
 
         # Parse the content
         try:
             tree = parser.parse(bytes(content, "utf-8"))
         except UnicodeEncodeError as e:
-            logger.warning(f"Failed to encode {path} as UTF-8: {e}")
-            return []
+            raise ParseError(
+                f"Failed to encode {path} as UTF-8: {e}"
+            ) from e
         except Exception as e:
-            logger.warning(f"Failed to parse {path} as {config.name}: {e}")
-            return []
+            raise ParseError(
+                f"Failed to parse {path} as {config.name}: {e}"
+            ) from e
 
         # Execute query to find definitions (query is pre-compiled and cached)
         try:
             cursor = QueryCursor(query)
             captures = cursor.captures(tree.root_node)
         except Exception as e:
-            logger.warning(f"Query execution failed for {path} ({config.name}): {e}")
-            return []
+            raise ParseError(
+                f"Query execution failed for {path} ({config.name}): {e}"
+            ) from e
 
         # Match names to definitions using DefinitionMatcher
         definitions = DefinitionMatcher.match(captures)

--- a/ember/core/chunking/chunk_usecase.py
+++ b/ember/core/chunking/chunk_usecase.py
@@ -4,11 +4,11 @@ This module provides the business logic for chunking files using tree-sitter
 when available, falling back to line-based chunking for unsupported languages.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from ember.core.use_case_errors import format_error_message, log_use_case_error
-from ember.ports.chunkers import ChunkData, Chunker
+from ember.ports.chunkers import ChunkData, Chunker, ParseError, ParseWarning
 
 
 @dataclass
@@ -35,22 +35,29 @@ class ChunkFileResponse:
         strategy: Strategy used ("tree-sitter" or "line-based").
         success: Whether chunking succeeded.
         error: Error message if chunking failed.
+        parse_warnings: List of parse warnings (e.g., tree-sitter fallback).
     """
 
     chunks: list[ChunkData]
     strategy: str
     success: bool = True
     error: str | None = None
+    parse_warnings: list[ParseWarning] = field(default_factory=list)
 
     @classmethod
     def create_success(
-        cls, *, chunks: list[ChunkData], strategy: str
+        cls,
+        *,
+        chunks: list[ChunkData],
+        strategy: str,
+        parse_warnings: list[ParseWarning] | None = None,
     ) -> "ChunkFileResponse":
         """Create a success response with chunks.
 
         Args:
             chunks: List of extracted chunks.
             strategy: Strategy used ("tree-sitter", "line-based", or "none").
+            parse_warnings: Optional list of parse warnings.
 
         Returns:
             ChunkFileResponse with success=True and chunks.
@@ -60,6 +67,7 @@ class ChunkFileResponse:
             strategy=strategy,
             success=True,
             error=None,
+            parse_warnings=parse_warnings or [],
         )
 
     @classmethod
@@ -107,6 +115,7 @@ class ChunkFileUseCase:
 
         Error handling contract:
             - KeyboardInterrupt/SystemExit are re-raised (user wants to exit)
+            - ParseError from tree-sitter triggers fallback with a warning
             - All other exceptions are caught and converted to error responses
             - See ember.core.use_case_errors for the error handling pattern
 
@@ -121,21 +130,34 @@ class ChunkFileUseCase:
             if not request.content.strip():
                 return ChunkFileResponse.create_success(chunks=[], strategy="none")
 
+            parse_warnings: list[ParseWarning] = []
+
             # Try tree-sitter first for supported languages
             if request.lang in self.tree_sitter.supported_languages:
-                chunks = self.tree_sitter.chunk_file(
-                    content=request.content,
-                    path=request.path,
-                    lang=request.lang,
-                )
-
-                # If tree-sitter succeeded and returned chunks, use them
-                if chunks:
-                    return ChunkFileResponse.create_success(
-                        chunks=chunks, strategy="tree-sitter"
+                try:
+                    chunks = self.tree_sitter.chunk_file(
+                        content=request.content,
+                        path=request.path,
+                        lang=request.lang,
                     )
 
-                # Tree-sitter failed or returned no chunks, fall back to line-based
+                    # If tree-sitter succeeded and returned chunks, use them
+                    if chunks:
+                        return ChunkFileResponse.create_success(
+                            chunks=chunks, strategy="tree-sitter"
+                        )
+
+                    # Tree-sitter returned no chunks (no definitions found),
+                    # fall back to line-based without a warning
+                except ParseError as e:
+                    # Tree-sitter failed to parse - record warning and fall back
+                    parse_warnings.append(
+                        ParseWarning(
+                            path=request.path,
+                            language=request.lang,
+                            reason=str(e),
+                        )
+                    )
 
             # Fall back to line-based chunking
             chunks = self.line_chunker.chunk_file(
@@ -144,7 +166,11 @@ class ChunkFileUseCase:
                 lang=request.lang,
             )
 
-            return ChunkFileResponse.create_success(chunks=chunks, strategy="line-based")
+            return ChunkFileResponse.create_success(
+                chunks=chunks,
+                strategy="line-based",
+                parse_warnings=parse_warnings,
+            )
 
         except (KeyboardInterrupt, SystemExit):
             raise

--- a/ember/core/indexing/index_usecase.py
+++ b/ember/core/indexing/index_usecase.py
@@ -28,7 +28,7 @@ from ember.core.use_case_errors import (
     log_use_case_error,
 )
 from ember.domain.entities import Chunk
-from ember.ports.chunkers import ChunkData
+from ember.ports.chunkers import ChunkData, ParseWarning
 from ember.ports.embedders import Embedder
 from ember.ports.fs import FileSystem
 from ember.ports.progress import ProgressCallback
@@ -168,13 +168,14 @@ class IndexingUseCase:
         sync_mode: str,
         sync_type: str,
         progress: ProgressCallback | None,
-    ) -> dict[str, int]:
+    ) -> dict:
         """Index all files with progress reporting. Returns counts dict."""
         files_indexed = 0
         chunks_created = 0
         chunks_updated = 0
         vectors_stored = 0
         files_failed = 0
+        all_parse_warnings: list[ParseWarning] = []
 
         # Report progress start
         if progress and files_to_index:
@@ -198,6 +199,7 @@ class IndexingUseCase:
             chunks_updated += result["chunks_updated"]
             vectors_stored += result["vectors_stored"]
             files_failed += result["failed"]
+            all_parse_warnings.extend(result.get("parse_warnings", []))
 
         # Report completion
         if progress and files_to_index:
@@ -209,6 +211,7 @@ class IndexingUseCase:
             "chunks_updated": chunks_updated,
             "vectors_stored": vectors_stored,
             "files_failed": files_failed,
+            "parse_warnings": all_parse_warnings,
         }
 
     def _update_metadata(self, tree_sha: str, sync_mode: str) -> None:
@@ -230,6 +233,7 @@ class IndexingUseCase:
         tree_sha: str,
         is_incremental: bool,
         files_failed: int = 0,
+        parse_warnings: list[ParseWarning] | None = None,
     ) -> IndexResponse:
         """Create a success response with indexing statistics.
 
@@ -242,6 +246,7 @@ class IndexingUseCase:
             tree_sha: Git tree SHA that was indexed.
             is_incremental: Whether this was an incremental sync.
             files_failed: Number of files that failed to chunk.
+            parse_warnings: Optional list of parse warnings from tree-sitter failures.
 
         Returns:
             IndexResponse with success=True and all statistics.
@@ -253,6 +258,8 @@ class IndexingUseCase:
         )
         if files_failed > 0:
             log_msg += f", {files_failed} failed"
+        if parse_warnings:
+            log_msg += f", {len(parse_warnings)} parse warning(s)"
         logger.info(log_msg)
 
         return IndexResponse.create_success(
@@ -264,6 +271,7 @@ class IndexingUseCase:
             tree_sha=tree_sha,
             is_incremental=is_incremental,
             files_failed=files_failed,
+            parse_warnings=parse_warnings,
         )
 
     def execute(
@@ -384,7 +392,7 @@ class IndexingUseCase:
         repo_root: Path,
         tree_sha: str,
         sync_mode: str,
-    ) -> dict[str, int]:
+    ) -> dict:
         """Index a single file.
 
         This method orchestrates the file indexing pipeline:
@@ -400,7 +408,8 @@ class IndexingUseCase:
             sync_mode: Sync mode (for rev field).
 
         Returns:
-            Dict with counts: chunks_created, chunks_updated, vectors_stored, failed.
+            Dict with counts: chunks_created, chunks_updated, vectors_stored, failed,
+            and parse_warnings list.
             On failure, failed=1 and other counts are 0.
         """
         # Step 1: Preprocess file (I/O, hashing, decoding, language detection)
@@ -419,11 +428,19 @@ class IndexingUseCase:
                 f"Failed to chunk {preprocessed.rel_path}: {chunk_response.error}. "
                 f"Preserving existing chunks to avoid data loss."
             )
-            return {"chunks_created": 0, "chunks_updated": 0, "vectors_stored": 0, "failed": 1}
+            return {
+                "chunks_created": 0, "chunks_updated": 0,
+                "vectors_stored": 0, "failed": 1,
+                "parse_warnings": [],
+            }
 
         # Step 3: Delete old chunks (done AFTER chunking succeeds to prevent data loss)
         if not self.chunk_storage.delete_old_chunks(preprocessed.rel_path):
-            return {"chunks_created": 0, "chunks_updated": 0, "vectors_stored": 0, "failed": 1}
+            return {
+                "chunks_created": 0, "chunks_updated": 0,
+                "vectors_stored": 0, "failed": 1,
+                "parse_warnings": chunk_response.parse_warnings,
+            }
 
         # Step 4: Create Chunk entities from ChunkData
         chunks = self._create_chunks(
@@ -440,7 +457,11 @@ class IndexingUseCase:
         )
 
         if result.failed:
-            return {"chunks_created": 0, "chunks_updated": 0, "vectors_stored": 0, "failed": 1}
+            return {
+                "chunks_created": 0, "chunks_updated": 0,
+                "vectors_stored": 0, "failed": 1,
+                "parse_warnings": chunk_response.parse_warnings,
+            }
 
         # Step 6: Track file metadata (non-critical, failures logged but don't fail indexing)
         self._track_file_metadata(file_path, preprocessed)
@@ -450,6 +471,7 @@ class IndexingUseCase:
             "chunks_updated": result.chunks_updated,
             "vectors_stored": result.vectors_stored,
             "failed": 0,
+            "parse_warnings": chunk_response.parse_warnings,
         }
 
     def _track_file_metadata(

--- a/ember/core/indexing/orchestrator.py
+++ b/ember/core/indexing/orchestrator.py
@@ -94,6 +94,7 @@ class IndexingOrchestrator:
             tree_sha=ctx.tree_sha,
             is_incremental=ctx.is_incremental,
             files_failed=ctx.stats["files_failed"],
+            parse_warnings=ctx.stats.get("parse_warnings", []),
         )
 
     def _handle_deletions_if_incremental(self, ctx: IndexingContext) -> int:

--- a/ember/core/indexing/types.py
+++ b/ember/core/indexing/types.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from ember.core.use_case_errors import EmberError
+from ember.ports.chunkers import ParseWarning
 
 
 class ModelMismatchError(EmberError):
@@ -58,6 +59,7 @@ class IndexResponse:
         is_incremental: Whether this was an incremental sync (vs full reindex).
         success: Whether indexing succeeded.
         error: Error message if indexing failed.
+        parse_warnings: List of parse warnings from tree-sitter failures.
     """
 
     files_indexed: int
@@ -70,6 +72,7 @@ class IndexResponse:
     is_incremental: bool = False
     success: bool = True
     error: str | None = None
+    parse_warnings: list[ParseWarning] = field(default_factory=list)
 
     @classmethod
     def create_success(
@@ -83,6 +86,7 @@ class IndexResponse:
         tree_sha: str,
         is_incremental: bool = False,
         files_failed: int = 0,
+        parse_warnings: list[ParseWarning] | None = None,
     ) -> "IndexResponse":
         """Create a success response with indexing statistics.
 
@@ -95,6 +99,7 @@ class IndexResponse:
             tree_sha: Git tree SHA that was indexed.
             is_incremental: Whether this was an incremental sync.
             files_failed: Number of files that failed to chunk.
+            parse_warnings: Optional list of parse warnings.
 
         Returns:
             IndexResponse with success=True and all statistics.
@@ -110,6 +115,7 @@ class IndexResponse:
             is_incremental=is_incremental,
             success=True,
             error=None,
+            parse_warnings=parse_warnings or [],
         )
 
     @classmethod

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -972,11 +972,12 @@ def _get_targeted_sync_hint(error_message: str) -> str:
     return "Run 'ember sync --verbose' for more details"
 
 
-def _format_sync_results(response) -> None:
+def _format_sync_results(response, verbose: bool = False) -> None:
     """Print formatted sync results.
 
     Args:
         response: IndexResponse from indexing use case.
+        verbose: If True, show detailed information including individual parse failures.
     """
     sync_type = "incremental" if response.is_incremental else "full"
 
@@ -993,6 +994,22 @@ def _format_sync_results(response) -> None:
         click.echo(f"  • {response.chunks_deleted} chunks deleted")
     if response.vectors_stored > 0:
         click.echo(f"  • {response.vectors_stored} vectors stored")
+
+    # Show parse failure summary
+    parse_warnings = getattr(response, "parse_warnings", [])
+    if parse_warnings:
+        click.echo(
+            f"  • {len(parse_warnings)} file(s) failed to parse "
+            f"(fell back to line-based chunking)"
+        )
+        if verbose:
+            for warning in parse_warnings:
+                click.echo(f"    - {warning.path}: {warning.reason}")
+        else:
+            click.echo("    Run with --verbose to see which files failed")
+    if response.files_failed > 0:
+        click.echo(f"  • {response.files_failed} file(s) failed to index")
+
     if response.files_indexed > 0 or response.chunks_deleted > 0:
         click.echo(f"  • Tree SHA: {response.tree_sha[:12]}...")
 
@@ -1068,7 +1085,7 @@ def sync(
             hint=hint,
         )
 
-    _format_sync_results(response)
+    _format_sync_results(response, verbose=ctx.obj.get("verbose", False))
 
 
 @cli.command()

--- a/ember/ports/chunkers.py
+++ b/ember/ports/chunkers.py
@@ -9,6 +9,38 @@ from pathlib import Path
 from typing import Protocol
 
 
+class ParseError(Exception):
+    """Raised when tree-sitter fails to parse a file.
+
+    This is a non-fatal error: the chunking use case catches it, records
+    a warning, and falls back to line-based chunking. The file is still
+    indexed, but users are informed that semantic parsing failed.
+
+    Distinct from returning an empty list (no definitions found), which
+    is normal behavior for files containing only statements.
+    """
+
+    pass
+
+
+@dataclass(frozen=True)
+class ParseWarning:
+    """Records a parse failure for user-facing reporting.
+
+    Created when tree-sitter fails to parse a file and the chunker
+    falls back to line-based chunking.
+
+    Attributes:
+        path: Relative path to the file that failed to parse.
+        language: Language identifier (py, ts, go, etc.).
+        reason: Human-readable description of the failure.
+    """
+
+    path: Path
+    language: str
+    reason: str
+
+
 @dataclass(frozen=True)
 class ChunkData:
     """Raw chunk data before creating a Chunk entity.

--- a/tests/unit/test_parse_failure_surfacing.py
+++ b/tests/unit/test_parse_failure_surfacing.py
@@ -1,0 +1,478 @@
+"""Tests for surfacing tree-sitter parse failures to users.
+
+Issue #438: Tree-sitter chunker silently returns empty list on parse failure.
+This module tests the end-to-end flow of detecting, propagating, and displaying
+parse failures from tree-sitter through the chunking use case and sync output.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ember.core.chunking.chunk_usecase import ChunkFileRequest, ChunkFileResponse, ChunkFileUseCase
+from ember.ports.chunkers import ChunkData, ParseWarning
+
+
+class TestParseWarningDataclass:
+    """Tests for the ParseWarning dataclass."""
+
+    def test_parse_warning_creation(self) -> None:
+        """ParseWarning stores file path and reason."""
+        warning = ParseWarning(
+            path=Path("src/broken.py"),
+            language="py",
+            reason="Failed to parse as python: syntax error",
+        )
+        assert warning.path == Path("src/broken.py")
+        assert warning.language == "py"
+        assert "syntax error" in warning.reason
+
+    def test_parse_warning_immutable(self) -> None:
+        """ParseWarning is frozen (immutable)."""
+        warning = ParseWarning(
+            path=Path("test.py"),
+            language="py",
+            reason="parse error",
+        )
+        with pytest.raises(AttributeError):
+            warning.path = Path("other.py")  # type: ignore[misc]
+
+
+class TestChunkFileResponseWarnings:
+    """Tests for parse warnings in ChunkFileResponse."""
+
+    def test_response_has_empty_warnings_by_default(self) -> None:
+        """ChunkFileResponse defaults to empty parse_warnings list."""
+        response = ChunkFileResponse.create_success(
+            chunks=[], strategy="none"
+        )
+        assert response.parse_warnings == []
+
+    def test_response_create_success_with_warnings(self) -> None:
+        """ChunkFileResponse can be created with parse warnings."""
+        warning = ParseWarning(
+            path=Path("broken.py"),
+            language="py",
+            reason="parse failed",
+        )
+        response = ChunkFileResponse.create_success(
+            chunks=[], strategy="line-based", parse_warnings=[warning]
+        )
+        assert len(response.parse_warnings) == 1
+        assert response.parse_warnings[0].path == Path("broken.py")
+        assert response.success is True
+
+    def test_error_response_has_empty_warnings(self) -> None:
+        """Error responses have empty parse_warnings."""
+        response = ChunkFileResponse.create_error("something broke")
+        assert response.parse_warnings == []
+
+
+class TestChunkUseCaseParseFailureFallback:
+    """Tests for ChunkFileUseCase recording parse warnings on fallback."""
+
+    def test_tree_sitter_parse_error_records_warning(self) -> None:
+        """When tree-sitter raises ParseError, use case falls back and records warning."""
+        from ember.ports.chunkers import ParseError
+
+        mock_tree_sitter = MagicMock()
+        mock_tree_sitter.supported_languages = {"py"}
+        mock_tree_sitter.chunk_file.side_effect = ParseError(
+            "Failed to parse test.py as python: unexpected token"
+        )
+
+        mock_line_chunker = MagicMock()
+        mock_line_chunker.chunk_file.return_value = [
+            ChunkData(
+                start_line=1, end_line=5, content="line content",
+                symbol=None, lang="py",
+            )
+        ]
+
+        use_case = ChunkFileUseCase(mock_tree_sitter, mock_line_chunker)
+        request = ChunkFileRequest(
+            content="def broken(\n  return 42\n",
+            path=Path("test.py"),
+            lang="py",
+        )
+
+        response = use_case.execute(request)
+
+        assert response.success is True
+        assert response.strategy == "line-based"
+        assert len(response.parse_warnings) == 1
+        assert response.parse_warnings[0].path == Path("test.py")
+        assert response.parse_warnings[0].language == "py"
+        assert "unexpected token" in response.parse_warnings[0].reason
+
+    def test_tree_sitter_success_no_warnings(self) -> None:
+        """Successful tree-sitter parsing produces no warnings."""
+        mock_tree_sitter = MagicMock()
+        mock_tree_sitter.supported_languages = {"py"}
+        mock_tree_sitter.chunk_file.return_value = [
+            ChunkData(
+                start_line=1, end_line=3, content="def add():\n  return 1",
+                symbol="add", lang="py",
+            )
+        ]
+
+        mock_line_chunker = MagicMock()
+
+        use_case = ChunkFileUseCase(mock_tree_sitter, mock_line_chunker)
+        request = ChunkFileRequest(
+            content="def add():\n  return 1\n",
+            path=Path("math.py"),
+            lang="py",
+        )
+
+        response = use_case.execute(request)
+
+        assert response.success is True
+        assert response.strategy == "tree-sitter"
+        assert response.parse_warnings == []
+
+    def test_unsupported_language_no_warnings(self) -> None:
+        """Unsupported languages fall back to line-based without warnings."""
+        mock_tree_sitter = MagicMock()
+        mock_tree_sitter.supported_languages = set()
+
+        mock_line_chunker = MagicMock()
+        mock_line_chunker.chunk_file.return_value = [
+            ChunkData(
+                start_line=1, end_line=3, content="data",
+                symbol=None, lang="sql",
+            )
+        ]
+
+        use_case = ChunkFileUseCase(mock_tree_sitter, mock_line_chunker)
+        request = ChunkFileRequest(
+            content="SELECT * FROM users;",
+            path=Path("query.sql"),
+            lang="sql",
+        )
+
+        response = use_case.execute(request)
+
+        assert response.success is True
+        assert response.strategy == "line-based"
+        assert response.parse_warnings == []
+
+    def test_tree_sitter_no_definitions_no_warning(self) -> None:
+        """When tree-sitter returns empty list (no definitions), no warning is generated.
+
+        This is the normal case for files with only statements (no functions/classes).
+        """
+        mock_tree_sitter = MagicMock()
+        mock_tree_sitter.supported_languages = {"py"}
+        mock_tree_sitter.chunk_file.return_value = []  # No definitions found
+
+        mock_line_chunker = MagicMock()
+        mock_line_chunker.chunk_file.return_value = [
+            ChunkData(
+                start_line=1, end_line=3, content="x = 42",
+                symbol=None, lang="py",
+            )
+        ]
+
+        use_case = ChunkFileUseCase(mock_tree_sitter, mock_line_chunker)
+        request = ChunkFileRequest(
+            content="x = 42\ny = x + 1\n",
+            path=Path("script.py"),
+            lang="py",
+        )
+
+        response = use_case.execute(request)
+
+        assert response.success is True
+        assert response.strategy == "line-based"
+        # No warning: tree-sitter didn't fail, it just found no definitions
+        assert response.parse_warnings == []
+
+
+class TestTreeSitterChunkerParseError:
+    """Tests for TreeSitterChunker raising ParseError on parse failure."""
+
+    def test_parse_failure_raises_parse_error(self) -> None:
+        """Tree-sitter chunker raises ParseError when parsing fails."""
+        from ember.adapters.parsers.tree_sitter_chunker import TreeSitterChunker
+        from ember.ports.chunkers import ParseError
+
+        chunker = TreeSitterChunker()
+
+        # Patch the parser to raise an exception during parse
+        with patch.object(chunker, "_registry") as mock_registry:
+            mock_config = MagicMock()
+            mock_config.name = "python"
+            mock_registry.get_by_identifier.return_value = mock_config
+
+            mock_parser = MagicMock()
+            mock_parser.parse.side_effect = RuntimeError("segfault in tree-sitter")
+            mock_registry.get_parser.return_value = mock_parser
+            mock_registry.get_query.return_value = MagicMock()
+
+            with pytest.raises(ParseError) as exc_info:
+                chunker.chunk_file("broken content", Path("test.py"), "py")
+
+            assert "test.py" in str(exc_info.value)
+            assert "python" in str(exc_info.value)
+
+    def test_unicode_encode_failure_raises_parse_error(self) -> None:
+        """Tree-sitter chunker raises ParseError on UTF-8 encoding failure."""
+        from ember.adapters.parsers.tree_sitter_chunker import TreeSitterChunker
+        from ember.ports.chunkers import ParseError
+
+        chunker = TreeSitterChunker()
+
+        with patch.object(chunker, "_registry") as mock_registry:
+            mock_config = MagicMock()
+            mock_config.name = "python"
+            mock_registry.get_by_identifier.return_value = mock_config
+
+            mock_parser = MagicMock()
+            mock_parser.parse.side_effect = UnicodeEncodeError(
+                "utf-8", "", 0, 1, "invalid"
+            )
+            mock_registry.get_parser.return_value = mock_parser
+            mock_registry.get_query.return_value = MagicMock()
+
+            with pytest.raises(ParseError) as exc_info:
+                chunker.chunk_file("content", Path("test.py"), "py")
+
+            assert "test.py" in str(exc_info.value)
+
+    def test_query_execution_failure_raises_parse_error(self) -> None:
+        """Tree-sitter chunker raises ParseError when query execution fails."""
+        from ember.adapters.parsers.tree_sitter_chunker import TreeSitterChunker
+        from ember.ports.chunkers import ParseError
+
+        chunker = TreeSitterChunker()
+
+        with patch.object(chunker, "_registry") as mock_registry:
+            mock_config = MagicMock()
+            mock_config.name = "python"
+            mock_registry.get_by_identifier.return_value = mock_config
+
+            mock_parser = MagicMock()
+            mock_registry.get_parser.return_value = mock_parser
+            mock_registry.get_query.return_value = MagicMock()
+
+            # Make QueryCursor raise
+            with patch(
+                "ember.adapters.parsers.tree_sitter_chunker.QueryCursor",
+                side_effect=RuntimeError("query failed"),
+            ):
+                with pytest.raises(ParseError) as exc_info:
+                    chunker.chunk_file("def foo(): pass", Path("test.py"), "py")
+
+                assert "test.py" in str(exc_info.value)
+
+    def test_parser_init_failure_raises_parse_error(self) -> None:
+        """Tree-sitter chunker raises ParseError when parser init fails."""
+        from ember.adapters.parsers.tree_sitter_chunker import TreeSitterChunker
+        from ember.ports.chunkers import ParseError
+
+        chunker = TreeSitterChunker()
+
+        with patch.object(chunker, "_registry") as mock_registry:
+            mock_config = MagicMock()
+            mock_config.name = "python"
+            mock_registry.get_by_identifier.return_value = mock_config
+            mock_registry.get_parser.return_value = None  # Parser init failed
+            mock_registry.get_query.return_value = MagicMock()
+
+            with pytest.raises(ParseError) as exc_info:
+                chunker.chunk_file("content", Path("test.py"), "py")
+
+            assert "test.py" in str(exc_info.value)
+
+    def test_unsupported_language_returns_empty_no_error(self) -> None:
+        """Unsupported language still returns empty list (not an error)."""
+        from ember.adapters.parsers.tree_sitter_chunker import TreeSitterChunker
+
+        chunker = TreeSitterChunker()
+        result = chunker.chunk_file("SELECT 1;", Path("q.sql"), "sql")
+        assert result == []
+
+    def test_successful_parse_returns_chunks(self) -> None:
+        """Successful parse returns chunks as before (no behavioral change)."""
+        from ember.adapters.parsers.tree_sitter_chunker import TreeSitterChunker
+
+        chunker = TreeSitterChunker()
+        content = "def add(a, b):\n    return a + b\n"
+        chunks = chunker.chunk_file(content, Path("math.py"), "py")
+        assert len(chunks) == 1
+        assert chunks[0].symbol == "add"
+
+
+class TestIndexResponseParseWarnings:
+    """Tests for parse warnings in IndexResponse."""
+
+    def test_index_response_has_parse_warnings(self) -> None:
+        """IndexResponse includes parse_warnings field."""
+        from ember.core.indexing.types import IndexResponse
+
+        warnings = [
+            ParseWarning(path=Path("a.py"), language="py", reason="parse failed"),
+            ParseWarning(path=Path("b.ts"), language="ts", reason="syntax error"),
+        ]
+        response = IndexResponse.create_success(
+            files_indexed=10,
+            chunks_created=20,
+            chunks_updated=0,
+            chunks_deleted=0,
+            vectors_stored=20,
+            tree_sha="abc123",
+            parse_warnings=warnings,
+        )
+        assert len(response.parse_warnings) == 2
+        assert response.parse_warnings[0].path == Path("a.py")
+
+    def test_index_response_default_empty_warnings(self) -> None:
+        """IndexResponse defaults to empty parse_warnings."""
+        from ember.core.indexing.types import IndexResponse
+
+        response = IndexResponse.create_success(
+            files_indexed=5,
+            chunks_created=10,
+            chunks_updated=0,
+            chunks_deleted=0,
+            vectors_stored=10,
+            tree_sha="abc123",
+        )
+        assert response.parse_warnings == []
+
+    def test_error_response_has_empty_warnings(self) -> None:
+        """Error response has empty parse_warnings."""
+        from ember.core.indexing.types import IndexResponse
+
+        response = IndexResponse.create_error("something broke")
+        assert response.parse_warnings == []
+
+
+class TestSyncOutputParseFailures:
+    """Tests for parse failure display in sync output."""
+
+    def test_format_sync_results_shows_parse_failures(self) -> None:
+        """Sync output shows parse failure count when there are parse warnings."""
+        from ember.entrypoints.cli import _format_sync_results
+
+        warnings = [
+            ParseWarning(path=Path("a.py"), language="py", reason="parse failed"),
+            ParseWarning(path=Path("b.py"), language="py", reason="parse failed"),
+            ParseWarning(path=Path("c.ts"), language="ts", reason="parse failed"),
+        ]
+
+        response = MagicMock()
+        response.files_indexed = 10
+        response.chunks_created = 20
+        response.chunks_updated = 0
+        response.chunks_deleted = 0
+        response.vectors_stored = 20
+        response.files_failed = 0
+        response.is_incremental = False
+        response.tree_sha = "abc123def456"
+        response.parse_warnings = warnings
+
+        with patch("click.echo") as mock_echo:
+            _format_sync_results(response)
+            calls = [call.args[0] for call in mock_echo.call_args_list]
+            # Should show parse failure count
+            assert any("3" in c and "parse" in c.lower() for c in calls)
+
+    def test_format_sync_results_no_failures_no_message(self) -> None:
+        """Sync output does not show parse failure line when count is 0."""
+        from ember.entrypoints.cli import _format_sync_results
+
+        response = MagicMock()
+        response.files_indexed = 5
+        response.chunks_created = 10
+        response.chunks_updated = 0
+        response.chunks_deleted = 0
+        response.vectors_stored = 10
+        response.files_failed = 0
+        response.is_incremental = False
+        response.tree_sha = "abc123def456"
+        response.parse_warnings = []
+
+        with patch("click.echo") as mock_echo:
+            _format_sync_results(response)
+            calls = [call.args[0] for call in mock_echo.call_args_list]
+            # Should NOT show parse failure line
+            assert not any("parse" in c.lower() for c in calls)
+
+    def test_format_sync_results_verbose_lists_files(self) -> None:
+        """With verbose=True, sync output lists specific files that failed to parse."""
+        from ember.entrypoints.cli import _format_sync_results
+
+        warnings = [
+            ParseWarning(path=Path("src/broken.py"), language="py", reason="parse failed"),
+            ParseWarning(path=Path("lib/bad.ts"), language="ts", reason="syntax error"),
+        ]
+
+        response = MagicMock()
+        response.files_indexed = 10
+        response.chunks_created = 20
+        response.chunks_updated = 0
+        response.chunks_deleted = 0
+        response.vectors_stored = 20
+        response.files_failed = 2
+        response.is_incremental = False
+        response.tree_sha = "abc123def456"
+        response.parse_warnings = warnings
+
+        with patch("click.echo") as mock_echo:
+            _format_sync_results(response, verbose=True)
+            calls = [call.args[0] for call in mock_echo.call_args_list]
+            all_output = "\n".join(calls)
+            # Should list the specific files
+            assert "src/broken.py" in all_output
+            assert "lib/bad.ts" in all_output
+
+    def test_format_sync_results_non_verbose_no_file_list(self) -> None:
+        """Without verbose, sync output shows count but not individual files."""
+        from ember.entrypoints.cli import _format_sync_results
+
+        warnings = [
+            ParseWarning(path=Path("src/broken.py"), language="py", reason="parse failed"),
+        ]
+
+        response = MagicMock()
+        response.files_indexed = 10
+        response.chunks_created = 20
+        response.chunks_updated = 0
+        response.chunks_deleted = 0
+        response.vectors_stored = 20
+        response.files_failed = 0
+        response.is_incremental = False
+        response.tree_sha = "abc123def456"
+        response.parse_warnings = warnings
+
+        with patch("click.echo") as mock_echo:
+            _format_sync_results(response, verbose=False)
+            calls = [call.args[0] for call in mock_echo.call_args_list]
+            all_output = "\n".join(calls)
+            # Should NOT list specific files in non-verbose mode
+            # But should mention the count and suggest --verbose
+            assert "src/broken.py" not in all_output
+            assert "--verbose" in all_output
+
+
+class TestParseErrorException:
+    """Tests for the ParseError exception class."""
+
+    def test_parse_error_is_exception(self) -> None:
+        """ParseError is a proper exception."""
+        from ember.ports.chunkers import ParseError
+
+        error = ParseError("test error")
+        assert isinstance(error, Exception)
+        assert str(error) == "test error"
+
+    def test_parse_error_not_caught_by_generic_ember_error(self) -> None:
+        """ParseError is not an EmberError - it's caught specifically by chunk use case."""
+        from ember.core.use_case_errors import EmberError
+        from ember.ports.chunkers import ParseError
+
+        error = ParseError("test")
+        assert not isinstance(error, EmberError)


### PR DESCRIPTION
## Summary
- **TreeSitterChunker** now raises `ParseError` on parse failure instead of silently returning an empty list. This distinguishes actual parse failures from the normal case of "no definitions found."
- **ChunkFileUseCase** catches `ParseError`, records a `ParseWarning`, and falls back to line-based chunking. Files with no definitions (only statements) still fall back normally without a warning.
- **Parse warnings propagate** through `ChunkFileResponse` -> `IndexResponse` -> CLI sync output, so users see "N file(s) failed to parse (fell back to line-based chunking)" after sync.
- **`--verbose` flag** lists specific files and reasons for parse failures.
- Added `ParseError` exception and `ParseWarning` dataclass to `ports/chunkers.py`.
- Added `parse_warnings` field to `ChunkFileResponse`, `IndexResponse`, and the indexing pipeline.
- 24 new tests covering all parse failure paths.

Closes #438

## Test plan
- [x] All 1579 tests pass (`uv run pytest`)
- [x] Linter passes (`uv run ruff check .`)
- [x] 24 new tests for parse failure surfacing
- [x] Existing tree-sitter chunker tests still pass (no behavioral regression for successful parsing)
- [x] Existing sync feedback tests still pass
- [x] Existing chunk use case tests still pass