### PR TITLE
fix: standardize --quiet mode support across all CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Consistent `--quiet` mode support across all CLI commands** (#433)
+  - Added `_echo()` and `_secho()` helpers that check the quiet flag before printing
+  - `sync` now fully suppresses completion messages, quick-check messages, and progress in quiet mode
+  - `status` suppresses all informational output in quiet mode (errors still display)
+  - `find` suppresses cache warnings and degraded-result warnings in quiet mode
+  - Daemon commands (`start`, `stop`, `restart`, `status`) all respect quiet mode
+  - `config edit` suppresses informational messages in quiet mode
+  - Primary output (search results, cat content, JSON output) is never suppressed
+  - Errors always display regardless of quiet mode
+
 - **Tree-sitter parse failures are now surfaced to users instead of being silently swallowed** (#438)
   - `TreeSitterChunker` now raises `ParseError` on parse failure instead of returning an empty list
   - `ChunkFileUseCase` catches `ParseError`, records a `ParseWarning`, and falls back to line-based chunking

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -45,6 +45,39 @@ from ember.domain.exceptions import EmberDomainError
 from ember.version import __version__
 
 
+def _echo(ctx: click.Context, message: str, **kwargs) -> None:
+    """Print a message only if quiet mode is not active.
+
+    Use this for all informational output that should be suppressed with --quiet.
+    Do NOT use this for error messages or primary command output (search results,
+    cat content, etc.) -- those should always be displayed.
+
+    Args:
+        ctx: Click context containing the quiet flag in ctx.obj.
+        message: Message to print.
+        **kwargs: Additional keyword arguments passed to click.echo
+            (e.g., err=True, nl=True).
+    """
+    if not ctx.obj.get("quiet", False):
+        click.echo(message, **kwargs)
+
+
+def _secho(ctx: click.Context, message: str, **kwargs) -> None:
+    """Print a styled message only if quiet mode is not active.
+
+    Use this for styled informational output that should be suppressed with --quiet.
+    Do NOT use this for error messages or primary command output.
+
+    Args:
+        ctx: Click context containing the quiet flag in ctx.obj.
+        message: Message to print.
+        **kwargs: Additional keyword arguments passed to click.secho
+            (e.g., fg="green", err=True).
+    """
+    if not ctx.obj.get("quiet", False):
+        click.secho(message, **kwargs)
+
+
 def _make_path_in_exclusive_callback(command_name: str, in_param_name: str = "path_filter"):
     """Create a callback that validates PATH and --in are mutually exclusive.
 
@@ -896,7 +929,7 @@ def _parse_sync_mode(rev: str | None, staged: bool, worktree: bool) -> str:
 
 
 def _quick_check_unchanged(
-    repo_root: Path, db_path: Path, sync_mode: str, reindex: bool
+    repo_root: Path, db_path: Path, sync_mode: str, reindex: bool, quiet: bool = False
 ) -> bool:
     """Check if index is up-to-date without expensive setup.
 
@@ -908,6 +941,7 @@ def _quick_check_unchanged(
         db_path: Path to SQLite database.
         sync_mode: Sync mode (worktree, staged, or revision).
         reindex: Whether force reindex is requested.
+        quiet: If True, suppress warning messages.
 
     Returns:
         True if index is unchanged and sync can be skipped, False otherwise.
@@ -923,7 +957,8 @@ def _quick_check_unchanged(
         return sync_service.quick_check_unchanged(sync_mode, reindex)
     except Exception as e:
         # If quick check fails, fall through to full sync
-        click.echo(f"Warning: Quick check failed, performing full sync: {e}", err=True)
+        if not quiet:
+            click.echo(f"Warning: Quick check failed, performing full sync: {e}", err=True)
         return False
 
 
@@ -972,13 +1007,17 @@ def _get_targeted_sync_hint(error_message: str) -> str:
     return "Run 'ember sync --verbose' for more details"
 
 
-def _format_sync_results(response, verbose: bool = False) -> None:
+def _format_sync_results(response, verbose: bool = False, quiet: bool = False) -> None:
     """Print formatted sync results.
 
     Args:
         response: IndexResponse from indexing use case.
         verbose: If True, show detailed information including individual parse failures.
+        quiet: If True, suppress all informational output.
     """
+    if quiet:
+        return
+
     sync_type = "incremental" if response.is_incremental else "full"
 
     if response.files_indexed == 0 and response.chunks_deleted == 0:
@@ -1055,9 +1094,11 @@ def sync(
     db_path = ember_dir / "index.db"
     sync_mode = _parse_sync_mode(rev, staged, worktree)
 
+    quiet = ctx.obj.get("quiet", False)
+
     # Quick check optimization
-    if _quick_check_unchanged(repo_root, db_path, sync_mode, reindex):
-        click.echo("✓ No changes detected (quick check)")
+    if _quick_check_unchanged(repo_root, db_path, sync_mode, reindex, quiet=quiet):
+        _echo(ctx, "✓ No changes detected (quick check)")
         return
 
     # Load config and create indexing use case
@@ -1085,7 +1126,7 @@ def sync(
             hint=hint,
         )
 
-    _format_sync_results(response, verbose=ctx.obj.get("verbose", False))
+    _format_sync_results(response, verbose=ctx.obj.get("verbose", False), quiet=quiet)
 
 
 @cli.command()
@@ -1198,7 +1239,7 @@ def find(
 
     # Display warning if results are degraded (missing chunks)
     if result_set.warning:
-        click.secho(result_set.warning, fg="yellow", err=True)
+        _secho(ctx, result_set.warning, fg="yellow", err=True)
 
     # Cache results for cat/open commands
     cache_path = deps.ember_dir / ".last_search.json"
@@ -1208,8 +1249,8 @@ def find(
         cache_data = ResultPresenter.serialize_for_cache(query, result_set.results)
         cache_path.write_text(json.dumps(cache_data, indent=2))
     except Exception as e:
-        # Always show cache errors to stderr (Issue #421 - don't silently swallow)
-        click.echo(f"Warning: Could not cache results: {e}", err=True)
+        # Show cache errors to stderr unless quiet mode (non-critical warning)
+        _echo(ctx, f"Warning: Could not cache results: {e}", err=True)
 
     # Display results
     presenter = ResultPresenter(LocalFileSystem())
@@ -1490,6 +1531,11 @@ def status(ctx: click.Context, detailed: bool) -> None:
             hint="Try 'ember sync' to refresh the index",
         )
 
+    # In quiet mode, suppress all informational status output
+    quiet = ctx.obj.get("quiet", False)
+    if quiet:
+        return
+
     # Build sync time display
     sync_time_display = ""
     if response.last_sync_time_ago:
@@ -1700,7 +1746,7 @@ def config_edit(ctx: click.Context, edit_global: bool) -> None:
 
     # Create config file if it doesn't exist
     if not config_path.exists():
-        click.echo(f"Creating {config_type} config at {config_path}...")
+        _echo(ctx, f"Creating {config_type} config at {config_path}...")
         if edit_global:
             create_global_config_file(config_path)
         else:
@@ -1708,7 +1754,7 @@ def config_edit(ctx: click.Context, edit_global: bool) -> None:
 
     # Open in editor
     editor = get_editor()
-    click.echo(f"Opening {config_path} in {editor}...")
+    _echo(ctx, f"Opening {config_path} in {editor}...")
     try:
         subprocess.run([editor, str(config_path)], check=True)
     except subprocess.CalledProcessError as e:
@@ -1798,10 +1844,10 @@ def start(ctx: click.Context, foreground: bool) -> None:
         )
 
         if lifecycle.is_running():
-            click.echo("✓ Daemon is already running")
+            _echo(ctx, "✓ Daemon is already running")
             return
 
-        click.echo("Starting daemon in foreground...")
+        _echo(ctx, "Starting daemon in foreground...")
         try:
             lifecycle.start(foreground=True)
         except RuntimeError as e:
@@ -1827,8 +1873,9 @@ def start(ctx: click.Context, foreground: bool) -> None:
 
 
 @daemon.command()
+@click.pass_context
 @handle_cli_errors("daemon stop")
-def stop() -> None:
+def stop(ctx: click.Context) -> None:
     """Stop the daemon server."""
     from ember.adapters.factory import DaemonFactory
 
@@ -1836,12 +1883,12 @@ def stop() -> None:
     lifecycle = daemon_factory.create_daemon_lifecycle()
 
     if not lifecycle.is_running():
-        click.echo("Daemon is not running")
+        _echo(ctx, "Daemon is not running")
         return
 
-    click.echo("Stopping daemon...")
+    _echo(ctx, "Stopping daemon...")
     if lifecycle.stop():
-        click.echo("✓ Daemon stopped successfully")
+        _echo(ctx, "✓ Daemon stopped successfully")
     else:
         raise EmberCliError(
             "Failed to stop daemon",
@@ -1865,10 +1912,10 @@ def restart(ctx: click.Context) -> None:
         idle_timeout=config.model.daemon_timeout,
         model_name=config.index.model,
     )
-    click.echo("Restarting daemon...")
+    _echo(ctx, "Restarting daemon...")
 
     if lifecycle.restart():
-        click.echo("✓ Daemon restarted successfully")
+        _echo(ctx, "✓ Daemon restarted successfully")
     else:
         raise EmberCliError(
             "Failed to restart daemon",
@@ -1877,14 +1924,20 @@ def restart(ctx: click.Context) -> None:
 
 
 @daemon.command(name="status")
+@click.pass_context
 @handle_cli_errors("daemon status")
-def daemon_status() -> None:
+def daemon_status(ctx: click.Context) -> None:
     """Show daemon status."""
     from ember.adapters.factory import DaemonFactory
+
+    quiet = ctx.obj.get("quiet", False)
 
     daemon_factory = DaemonFactory()
     lifecycle = daemon_factory.create_daemon_lifecycle()
     status = lifecycle.status()
+
+    if quiet:
+        return
 
     # Display status
     if status["running"]:

--- a/tests/integration/test_cli_commands.py
+++ b/tests/integration/test_cli_commands.py
@@ -222,19 +222,18 @@ class TestSyncCommand:
         assert_output_contains(result, "mutually exclusive")
 
     def test_sync_quiet_mode(self, runner: CliRunner, git_repo_isolated: Path, monkeypatch) -> None:
-        """Test that --quiet mode suppresses progress output."""
+        """Test that --quiet mode suppresses all informational output."""
         monkeypatch.chdir(git_repo_isolated)
         # Init first
         runner.invoke(cli, ["init"], catch_exceptions=False)
 
-        # Sync in quiet mode
+        # Sync in quiet mode - should produce no output
         result = runner.invoke(cli, ["--quiet", "sync"], catch_exceptions=False)
 
         assert_command_success(result, context="quiet sync")
-        # Output should be minimal (quiet mode shows summary but not progress)
-        lines = [line for line in result.output.strip().split('\n') if line]
-        # Should have at most a few lines (success message and stats)
-        assert len(lines) <= 5
+        assert result.output.strip() == "", (
+            f"Expected no output in quiet sync, got: {result.output!r}"
+        )
 
 
 class TestFindCommand:
@@ -951,6 +950,170 @@ class TestVerboseQuietFlags:
 
         # Semantic check: quiet mode should have less output
         assert len(result_quiet.output) < len(result_normal.output)
+
+
+class TestQuietModeConsistency:
+    """Tests for consistent --quiet mode support across all commands (Issue #433).
+
+    Verifies that --quiet suppresses informational output but NOT errors
+    or primary command output (e.g., search results, cat content).
+    """
+
+    def test_sync_quiet_suppresses_all_informational_output(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that 'ember --quiet sync' produces no output on success."""
+        monkeypatch.chdir(git_repo_isolated)
+        runner.invoke(cli, ["init"], catch_exceptions=False)
+
+        # First sync in quiet mode - should produce no output
+        result = runner.invoke(cli, ["--quiet", "sync"], catch_exceptions=False)
+        assert_command_success(result, context="quiet sync first run")
+        assert result.output.strip() == "", (
+            f"Expected no output in quiet mode, got: {result.output!r}"
+        )
+
+    def test_sync_quiet_suppresses_no_changes_message(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that 'ember --quiet sync' suppresses 'No changes detected' message."""
+        monkeypatch.chdir(git_repo_isolated)
+        runner.invoke(cli, ["init"], catch_exceptions=False)
+        # First sync
+        runner.invoke(cli, ["--quiet", "sync"], catch_exceptions=False)
+
+        # Second sync (no changes) in quiet mode
+        result = runner.invoke(cli, ["--quiet", "sync"], catch_exceptions=False)
+        assert_command_success(result, context="quiet sync no changes")
+        assert result.output.strip() == "", (
+            f"Expected no output in quiet mode for no-changes case, got: {result.output!r}"
+        )
+
+    def test_sync_quiet_still_shows_errors(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that 'ember --quiet sync' still shows errors."""
+        monkeypatch.chdir(git_repo_isolated)
+        # Don't init - sync should fail with error
+        result = runner.invoke(cli, ["--quiet", "sync"])
+        assert_command_failed(result, context="quiet sync without init")
+        # Error should still be shown
+        assert_error_message(result)
+
+    def test_find_quiet_still_shows_results(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that 'ember --quiet find' still shows search results (primary output)."""
+        monkeypatch.chdir(git_repo_isolated)
+        runner.invoke(cli, ["init"], catch_exceptions=False)
+        runner.invoke(cli, ["sync"], catch_exceptions=False)
+
+        # Find in quiet mode - results ARE the primary output, should still show
+        result = runner.invoke(
+            cli, ["--quiet", "find", "hello", "--json"],
+            catch_exceptions=False,
+        )
+        assert_command_success(result, context="quiet find")
+        # JSON results should still be present
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+
+    def test_find_quiet_suppresses_cache_warning(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that cache write warnings are suppressed in quiet mode."""
+        monkeypatch.chdir(git_repo_isolated)
+        runner.invoke(cli, ["init"], catch_exceptions=False)
+        runner.invoke(cli, ["sync"], catch_exceptions=False)
+
+        # Search in quiet mode - any cache warning should be suppressed
+        result = runner.invoke(
+            cli, ["--quiet", "find", "hello"],
+            catch_exceptions=False,
+        )
+        assert_command_success(result, context="quiet find with cache issue")
+        # No "Warning:" text should appear in quiet mode
+        assert "Warning: Could not cache" not in result.output
+
+    def test_status_quiet_suppresses_output(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that 'ember --quiet status' produces no output."""
+        monkeypatch.chdir(git_repo_isolated)
+        runner.invoke(cli, ["init"], catch_exceptions=False)
+        runner.invoke(cli, ["sync"], catch_exceptions=False)
+
+        result = runner.invoke(cli, ["--quiet", "status"], catch_exceptions=False)
+        assert_command_success(result, context="quiet status")
+        assert result.output.strip() == "", (
+            f"Expected no output in quiet mode for status, got: {result.output!r}"
+        )
+
+    def test_status_quiet_still_shows_errors(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that 'ember --quiet status' still shows errors."""
+        monkeypatch.chdir(git_repo_isolated)
+        # Don't init - status should fail
+        result = runner.invoke(cli, ["--quiet", "status"])
+        assert_command_failed(result, context="quiet status without init")
+        assert_error_message(result)
+
+    def test_cat_quiet_still_shows_content(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that 'ember --quiet cat' still shows chunk content (primary output)."""
+        monkeypatch.chdir(git_repo_isolated)
+        runner.invoke(cli, ["init"], catch_exceptions=False)
+        runner.invoke(cli, ["sync"], catch_exceptions=False)
+        search_result = runner.invoke(cli, ["find", "hello"], catch_exceptions=False)
+
+        if "No results" in search_result.output or search_result.output.strip() == "":
+            pytest.skip("Search returned no results")
+
+        # Cat in quiet mode - content is primary output, should still show
+        result = runner.invoke(cli, ["--quiet", "cat", "1"], catch_exceptions=False)
+        assert_command_success(result, context="quiet cat")
+        assert len(result.output) > 0, "Cat should still show content in quiet mode"
+
+    def test_init_quiet_still_shows_summary(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that 'ember --quiet init' shows summary but suppresses details."""
+        monkeypatch.chdir(git_repo_isolated)
+
+        result_quiet = runner.invoke(cli, ["--quiet", "init"], catch_exceptions=False)
+        assert_command_success(result_quiet, context="quiet init")
+        # Should have summary line (Initialized/Reinitialized)
+        assert_output_matches(result_quiet, r"[Ii]nitialized", context="init summary")
+
+        # Create second repo to compare output length
+        git_repo_2 = git_repo_isolated.parent / "test_repo_cmp"
+        git_repo_2.mkdir()
+        init_git_repo(git_repo_2)
+        monkeypatch.chdir(git_repo_2)
+        result_normal = runner.invoke(cli, ["init"], catch_exceptions=False)
+
+        # Quiet should have less output
+        assert len(result_quiet.output) < len(result_normal.output)
+
+    def test_sync_quiet_mode_with_reindex(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that 'ember --quiet sync --reindex' produces no output."""
+        monkeypatch.chdir(git_repo_isolated)
+        runner.invoke(cli, ["init"], catch_exceptions=False)
+        runner.invoke(cli, ["sync"], catch_exceptions=False)
+
+        # Reindex in quiet mode
+        result = runner.invoke(
+            cli, ["--quiet", "sync", "--reindex"],
+            catch_exceptions=False,
+        )
+        assert_command_success(result, context="quiet sync --reindex")
+        assert result.output.strip() == "", (
+            f"Expected no output in quiet reindex, got: {result.output!r}"
+        )
 
 
 class TestErrorHandling:


### PR DESCRIPTION
## Summary
- Fixes #433: `--quiet` flag was not consistently respected across commands
- Added `_echo()` and `_secho()` helpers that check the quiet flag before printing informational messages
- Applied consistent quiet mode suppression to all CLI commands:
  - **sync**: Suppresses completion messages, quick-check "no changes" messages, and progress bar
  - **status**: Suppresses all informational output (errors still display)
  - **find**: Suppresses cache warnings and degraded-result warnings
  - **daemon** (start/stop/restart/status): All respect quiet mode
  - **config edit**: Suppresses informational messages
- Primary output (search results, cat content, JSON output) is **never** suppressed
- Errors always display regardless of quiet mode
- Added 10 new integration tests for quiet mode consistency across commands

## Test plan
- [x] All 1589 existing tests pass
- [x] 10 new quiet mode tests verify each command respects `--quiet`
- [x] Lint passes (`ruff check .`)
- [x] Verified errors still display in quiet mode
- [x] Verified primary output (find results, cat content) not suppressed