### PR TITLE
feat: add --json output flag to status, config show, and daemon status commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`--json` output flag for `status`, `config show`, and `daemon status` commands** (#442)
+  - `ember status --json` outputs `{"files": N, "chunks": N, "model": "...", "stale": bool, "last_sync": "ISO8601"}`
+  - `ember config show --json` outputs the full effective configuration as JSON
+  - `ember daemon status --json` outputs daemon status dict as JSON (running, pid, status, etc.)
+  - Enables programmatic integration with scripts, CI pipelines, and editor plugins
+  - Follows the same pattern as the existing `find --json` flag
+
 ### Fixed
 - **Consistent `--quiet` mode support across all CLI commands** (#433)
   - Added `_echo()` and `_secho()` helpers that check the quiet flag before printing

--- a/ember/entrypoints/cli.py
+++ b/ember/entrypoints/cli.py
@@ -1488,9 +1488,15 @@ cli.add_command(open_result, name="open")
     is_flag=True,
     help="Show full technical details including configuration parameters.",
 )
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    help="Output status as JSON for programmatic use.",
+)
 @click.pass_context
 @handle_cli_errors("status")
-def status(ctx: click.Context, detailed: bool) -> None:
+def status(ctx: click.Context, detailed: bool, json_output: bool) -> None:
     """Show ember index status.
 
     By default, shows essential information:
@@ -1499,6 +1505,7 @@ def status(ctx: click.Context, detailed: bool) -> None:
     - When last synced
 
     Use --detailed for full technical output including configuration parameters.
+    Use --json for machine-readable JSON output.
     """
     from ember.adapters.factory import RepositoryFactory
     from ember.core.status.status_usecase import StatusRequest, StatusUseCase
@@ -1530,6 +1537,29 @@ def status(ctx: click.Context, detailed: bool) -> None:
             f"Failed to get status: {response.error}",
             hint="Try 'ember sync' to refresh the index",
         )
+
+    # JSON output mode
+    if json_output:
+        import json
+
+        # Format last_sync as ISO 8601 string or None
+        last_sync_iso = None
+        if response.last_sync_time is not None:
+            from datetime import UTC, datetime
+
+            last_sync_iso = datetime.fromtimestamp(
+                response.last_sync_time, tz=UTC
+            ).isoformat()
+
+        data = {
+            "files": response.indexed_files,
+            "chunks": response.total_chunks,
+            "model": response.model_name,
+            "stale": response.is_stale,
+            "last_sync": last_sync_iso,
+        }
+        click.echo(json.dumps(data, indent=2))
+        return
 
     # In quiet mode, suppress all informational status output
     quiet = ctx.obj.get("quiet", False)
@@ -1666,19 +1696,47 @@ def _show_effective_config(
 @click.option(
     "--local", "-l", "show_local", is_flag=True, help="Show local config location"
 )
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    help="Output configuration as JSON for programmatic use.",
+)
 @click.pass_context
 @handle_cli_errors("config show")
 def config_show(
-    ctx: click.Context, show_global: bool, show_local: bool
+    ctx: click.Context, show_global: bool, show_local: bool, json_output: bool
 ) -> None:
     """Show configuration file locations and current settings.
 
     By default shows both locations. Use --global or --local to show specific one.
+    Use --json for machine-readable JSON output of the effective configuration.
     """
+    import dataclasses
+
     from ember.shared.config_io import get_global_config_path
 
     global_path = get_global_config_path()
     local_path = _get_local_config_path()
+
+    # JSON output mode - output effective config as JSON
+    if json_output:
+        import json
+
+        if local_path and local_path.parent.exists():
+            effective_config = _load_config(local_path.parent)
+        elif global_path.exists():
+            from ember.shared.config_io import load_config
+
+            effective_config = load_config(global_path)
+        else:
+            from ember.domain.config import EmberConfig as EmberConfigClass
+
+            effective_config = EmberConfigClass.default()
+
+        data = dataclasses.asdict(effective_config)
+        click.echo(json.dumps(data, indent=2))
+        return
 
     # Determine what to display - default is both
     include_global = show_global or not show_local
@@ -1924,17 +1982,33 @@ def restart(ctx: click.Context) -> None:
 
 
 @daemon.command(name="status")
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    help="Output daemon status as JSON for programmatic use.",
+)
 @click.pass_context
 @handle_cli_errors("daemon status")
-def daemon_status(ctx: click.Context) -> None:
-    """Show daemon status."""
-    from ember.adapters.factory import DaemonFactory
+def daemon_status(ctx: click.Context, json_output: bool) -> None:
+    """Show daemon status.
 
-    quiet = ctx.obj.get("quiet", False)
+    Use --json for machine-readable JSON output.
+    """
+    from ember.adapters.factory import DaemonFactory
 
     daemon_factory = DaemonFactory()
     lifecycle = daemon_factory.create_daemon_lifecycle()
     status = lifecycle.status()
+
+    # JSON output mode
+    if json_output:
+        import json
+
+        click.echo(json.dumps(status, indent=2))
+        return
+
+    quiet = ctx.obj.get("quiet", False)
 
     if quiet:
         return

--- a/tests/integration/test_cli_commands.py
+++ b/tests/integration/test_cli_commands.py
@@ -1206,3 +1206,206 @@ class TestGetEmberRepoRoot:
 
         assert repo_root == git_repo_isolated
         assert ember_dir == git_repo_isolated / ".ember"
+
+
+class TestJsonOutputFlag:
+    """Tests for --json output flag on status, config show, and daemon status commands (#442)."""
+
+    def test_status_json_outputs_valid_json(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that 'ember status --json' outputs valid JSON."""
+        monkeypatch.chdir(git_repo_isolated)
+        runner.invoke(cli, ["init"], catch_exceptions=False)
+        runner.invoke(cli, ["sync"], catch_exceptions=False)
+
+        result = runner.invoke(cli, ["status", "--json"], catch_exceptions=False)
+
+        assert_command_success(result, context="status --json")
+        data = json.loads(result.output)
+        assert isinstance(data, dict)
+
+    def test_status_json_contains_expected_fields(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that status --json includes files, chunks, model, stale, last_sync."""
+        monkeypatch.chdir(git_repo_isolated)
+        runner.invoke(cli, ["init"], catch_exceptions=False)
+        runner.invoke(cli, ["sync"], catch_exceptions=False)
+
+        result = runner.invoke(cli, ["status", "--json"], catch_exceptions=False)
+
+        assert_command_success(result, context="status --json fields")
+        data = json.loads(result.output)
+        assert "files" in data
+        assert "chunks" in data
+        assert "model" in data
+        assert "stale" in data
+        assert "last_sync" in data
+        assert isinstance(data["files"], int)
+        assert isinstance(data["chunks"], int)
+        assert isinstance(data["stale"], bool)
+
+    def test_status_json_reflects_stale_state(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that status --json shows stale=true after a change."""
+        monkeypatch.chdir(git_repo_isolated)
+        runner.invoke(cli, ["init"], catch_exceptions=False)
+        runner.invoke(cli, ["sync"], catch_exceptions=False)
+
+        # Modify file (creating staleness)
+        test_file = git_repo_isolated / "example.py"
+        test_file.write_text(test_file.read_text() + "\n# New comment\n")
+        git_add_and_commit(git_repo_isolated, message="Update")
+
+        result = runner.invoke(cli, ["status", "--json"], catch_exceptions=False)
+
+        assert_command_success(result, context="status --json stale")
+        data = json.loads(result.output)
+        assert data["stale"] is True
+
+    def test_status_json_without_sync(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that status --json works before any sync (never synced state)."""
+        monkeypatch.chdir(git_repo_isolated)
+        runner.invoke(cli, ["init"], catch_exceptions=False)
+
+        result = runner.invoke(cli, ["status", "--json"], catch_exceptions=False)
+
+        assert_command_success(result, context="status --json never synced")
+        data = json.loads(result.output)
+        assert data["files"] == 0
+        assert data["chunks"] == 0
+        assert data["last_sync"] is None
+
+    def test_status_json_is_pure_json(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that status --json does not include human-readable text."""
+        monkeypatch.chdir(git_repo_isolated)
+        runner.invoke(cli, ["init"], catch_exceptions=False)
+        runner.invoke(cli, ["sync"], catch_exceptions=False)
+
+        result = runner.invoke(cli, ["status", "--json"], catch_exceptions=False)
+
+        assert_command_success(result, context="status --json purity")
+        # Should only contain valid JSON, no extra lines
+        data = json.loads(result.output.strip())
+        assert isinstance(data, dict)
+        # Ensure no "Index is up to date" style text
+        assert "Index is" not in result.output
+
+    def test_config_show_json_outputs_valid_json(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that 'ember config show --json' outputs valid JSON."""
+        monkeypatch.chdir(git_repo_isolated)
+        runner.invoke(cli, ["init"], catch_exceptions=False)
+
+        result = runner.invoke(cli, ["config", "show", "--json"], catch_exceptions=False)
+
+        assert_command_success(result, context="config show --json")
+        data = json.loads(result.output)
+        assert isinstance(data, dict)
+
+    def test_config_show_json_contains_config_sections(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that config show --json includes index, search, model, display sections."""
+        monkeypatch.chdir(git_repo_isolated)
+        runner.invoke(cli, ["init"], catch_exceptions=False)
+
+        result = runner.invoke(cli, ["config", "show", "--json"], catch_exceptions=False)
+
+        assert_command_success(result, context="config show --json sections")
+        data = json.loads(result.output)
+        assert "index" in data
+        assert "search" in data
+        assert "model" in data
+        assert "display" in data
+        # Verify nested values
+        assert "model" in data["index"]  # index.model (embedding model name)
+        assert "topk" in data["search"]
+
+    def test_config_show_json_is_pure_json(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that config show --json does not include path status text."""
+        monkeypatch.chdir(git_repo_isolated)
+        runner.invoke(cli, ["init"], catch_exceptions=False)
+
+        result = runner.invoke(cli, ["config", "show", "--json"], catch_exceptions=False)
+
+        assert_command_success(result, context="config show --json purity")
+        data = json.loads(result.output.strip())
+        assert isinstance(data, dict)
+        # Ensure no "Global config:" style text
+        assert "Global config:" not in result.output
+
+    def test_daemon_status_json_outputs_valid_json(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that 'ember daemon status --json' outputs valid JSON."""
+        monkeypatch.chdir(git_repo_isolated)
+
+        result = runner.invoke(cli, ["daemon", "status", "--json"], catch_exceptions=False)
+
+        assert_command_success(result, context="daemon status --json")
+        data = json.loads(result.output)
+        assert isinstance(data, dict)
+
+    def test_daemon_status_json_contains_expected_fields(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that daemon status --json includes running, pid, status fields."""
+        monkeypatch.chdir(git_repo_isolated)
+
+        result = runner.invoke(cli, ["daemon", "status", "--json"], catch_exceptions=False)
+
+        assert_command_success(result, context="daemon status --json fields")
+        data = json.loads(result.output)
+        assert "running" in data
+        assert "pid" in data
+        assert "status" in data
+        assert isinstance(data["running"], bool)
+
+    def test_daemon_status_json_is_pure_json(
+        self, runner: CliRunner, git_repo_isolated: Path, monkeypatch
+    ) -> None:
+        """Test that daemon status --json does not include human-readable text."""
+        monkeypatch.chdir(git_repo_isolated)
+
+        result = runner.invoke(cli, ["daemon", "status", "--json"], catch_exceptions=False)
+
+        assert_command_success(result, context="daemon status --json purity")
+        data = json.loads(result.output.strip())
+        assert isinstance(data, dict)
+        # Ensure no styled symbols
+        assert "✓" not in result.output
+        assert "✗" not in result.output
+
+    def test_status_json_help_documented(
+        self, runner: CliRunner
+    ) -> None:
+        """Test that --json flag is documented in status --help."""
+        result = runner.invoke(cli, ["status", "--help"])
+        assert_command_success(result, context="status --help")
+        assert "--json" in result.output
+
+    def test_config_show_json_help_documented(
+        self, runner: CliRunner
+    ) -> None:
+        """Test that --json flag is documented in config show --help."""
+        result = runner.invoke(cli, ["config", "show", "--help"])
+        assert_command_success(result, context="config show --help")
+        assert "--json" in result.output
+
+    def test_daemon_status_json_help_documented(
+        self, runner: CliRunner
+    ) -> None:
+        """Test that --json flag is documented in daemon status --help."""
+        result = runner.invoke(cli, ["daemon", "status", "--help"])
+        assert_command_success(result, context="daemon status --help")
+        assert "--json" in result.output


### PR DESCRIPTION
## Summary
- Adds `--json` flag to `ember status`, `ember config show`, and `ember daemon status` commands (#442)
- `ember status --json` outputs `{"files": N, "chunks": N, "model": "...", "stale": bool, "last_sync": "ISO8601"}`
- `ember config show --json` outputs the full effective configuration as JSON using `dataclasses.asdict()`
- `ember daemon status --json` outputs the daemon status dict directly as JSON
- Follows the same pattern as the existing `find --json` flag

## Test plan
- [x] 14 new integration tests covering all three commands
- [x] Tests verify valid JSON output, expected fields, pure JSON (no human text mixed in)
- [x] Tests verify --help documents the --json flag
- [x] Tests cover edge cases: stale state, never-synced state
- [x] All 1603 tests pass (`uv run pytest`)
- [x] Linter passes (`uv run ruff check .`)
- [x] CHANGELOG.md updated