### PR TITLE
refactor: adopt pytest.mark.parametrize across test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Adopted `pytest.mark.parametrize` across 5 test files** (#434)
+  - Replaced repetitive test methods with parametrized tests in model registry, entities, time formatting, sync error hints, and config validation tests
+  - Net reduction in test LOC while increasing test case count (305 -> 335 individual test invocations across refactored files)
+  - Improved test readability with descriptive `pytest.param` IDs
+
 ### Added
 - **`--json` output flag for `status`, `config show`, and `daemon status` commands** (#442)
   - `ember status --json` outputs `{"files": N, "chunks": N, "model": "...", "stale": bool, "last_sync": "ISO8601"}`

--- a/tests/unit/adapters/test_model_registry.py
+++ b/tests/unit/adapters/test_model_registry.py
@@ -22,71 +22,93 @@ from ember.adapters.local_models.registry import (
 class TestBuildEmbedderKwargs:
     """Tests for _build_embedder_kwargs helper function."""
 
-    def test_batch_size_always_included(self):
-        """Test that batch_size is always in kwargs."""
-        result = _build_embedder_kwargs(batch_size=32, device=None, max_seq_length=None)
-        assert result == {"batch_size": 32}
-
-    def test_device_included_when_not_none(self):
-        """Test that device is included when provided."""
-        result = _build_embedder_kwargs(batch_size=32, device="cuda", max_seq_length=None)
-        assert result == {"batch_size": 32, "device": "cuda"}
-
-    def test_max_seq_length_included_when_not_none(self):
-        """Test that max_seq_length is included when provided."""
-        result = _build_embedder_kwargs(batch_size=32, device=None, max_seq_length=512)
-        assert result == {"batch_size": 32, "max_seq_length": 512}
-
-    def test_all_params_included_when_provided(self):
-        """Test that all params are included when provided."""
-        result = _build_embedder_kwargs(batch_size=64, device="mps", max_seq_length=256)
-        assert result == {"batch_size": 64, "device": "mps", "max_seq_length": 256}
-
-    def test_device_cpu(self):
-        """Test that device=cpu works correctly."""
-        result = _build_embedder_kwargs(batch_size=32, device="cpu", max_seq_length=None)
-        assert result == {"batch_size": 32, "device": "cpu"}
+    @pytest.mark.parametrize(
+        "batch_size, device, max_seq_length, expected",
+        [
+            pytest.param(32, None, None, {"batch_size": 32}, id="batch-only"),
+            pytest.param(
+                32, "cuda", None, {"batch_size": 32, "device": "cuda"}, id="with-cuda"
+            ),
+            pytest.param(
+                32, None, 512, {"batch_size": 32, "max_seq_length": 512}, id="with-seq-len"
+            ),
+            pytest.param(
+                64,
+                "mps",
+                256,
+                {"batch_size": 64, "device": "mps", "max_seq_length": 256},
+                id="all-params",
+            ),
+            pytest.param(
+                32, "cpu", None, {"batch_size": 32, "device": "cpu"}, id="with-cpu"
+            ),
+        ],
+    )
+    def test_build_embedder_kwargs(self, batch_size, device, max_seq_length, expected):
+        """Test _build_embedder_kwargs returns correct kwargs for given inputs."""
+        result = _build_embedder_kwargs(
+            batch_size=batch_size, device=device, max_seq_length=max_seq_length
+        )
+        assert result == expected
 
 
 class TestResolveModelName:
     """Tests for resolve_model_name function."""
 
-    def test_resolve_preset_jina_code_v2(self):
-        """Test resolving jina-code-v2 preset."""
-        assert resolve_model_name("jina-code-v2") == "jinaai/jina-embeddings-v2-base-code"
-
-    def test_resolve_preset_minilm(self):
-        """Test resolving minilm preset."""
-        assert resolve_model_name("minilm") == "sentence-transformers/all-MiniLM-L6-v2"
-
-    def test_resolve_preset_bge_small(self):
-        """Test resolving bge-small preset."""
-        assert resolve_model_name("bge-small") == "BAAI/bge-small-en-v1.5"
-
-    def test_resolve_preset_case_insensitive(self):
-        """Test that preset names are case-insensitive."""
-        assert resolve_model_name("MINILM") == "sentence-transformers/all-MiniLM-L6-v2"
-        assert resolve_model_name("MiniLM") == "sentence-transformers/all-MiniLM-L6-v2"
-        assert resolve_model_name("BGE-SMALL") == "BAAI/bge-small-en-v1.5"
-
-    def test_resolve_legacy_default_name(self):
-        """Test resolving legacy 'local-default-code-embed' name."""
-        assert (
-            resolve_model_name("local-default-code-embed")
-            == "jinaai/jina-embeddings-v2-base-code"
-        )
-
-    def test_resolve_full_huggingface_id(self):
-        """Test resolving full HuggingFace model ID."""
-        assert (
-            resolve_model_name("jinaai/jina-embeddings-v2-base-code")
-            == "jinaai/jina-embeddings-v2-base-code"
-        )
-        assert (
-            resolve_model_name("sentence-transformers/all-MiniLM-L6-v2")
-            == "sentence-transformers/all-MiniLM-L6-v2"
-        )
-        assert resolve_model_name("BAAI/bge-small-en-v1.5") == "BAAI/bge-small-en-v1.5"
+    @pytest.mark.parametrize(
+        "input_name, expected_id",
+        [
+            pytest.param(
+                "jina-code-v2",
+                "jinaai/jina-embeddings-v2-base-code",
+                id="preset-jina",
+            ),
+            pytest.param(
+                "minilm",
+                "sentence-transformers/all-MiniLM-L6-v2",
+                id="preset-minilm",
+            ),
+            pytest.param(
+                "bge-small", "BAAI/bge-small-en-v1.5", id="preset-bge"
+            ),
+            pytest.param(
+                "MINILM",
+                "sentence-transformers/all-MiniLM-L6-v2",
+                id="case-insensitive-upper",
+            ),
+            pytest.param(
+                "MiniLM",
+                "sentence-transformers/all-MiniLM-L6-v2",
+                id="case-insensitive-mixed",
+            ),
+            pytest.param(
+                "BGE-SMALL", "BAAI/bge-small-en-v1.5", id="case-insensitive-bge"
+            ),
+            pytest.param(
+                "local-default-code-embed",
+                "jinaai/jina-embeddings-v2-base-code",
+                id="legacy-name",
+            ),
+            pytest.param(
+                "jinaai/jina-embeddings-v2-base-code",
+                "jinaai/jina-embeddings-v2-base-code",
+                id="full-hf-id-jina",
+            ),
+            pytest.param(
+                "sentence-transformers/all-MiniLM-L6-v2",
+                "sentence-transformers/all-MiniLM-L6-v2",
+                id="full-hf-id-minilm",
+            ),
+            pytest.param(
+                "BAAI/bge-small-en-v1.5",
+                "BAAI/bge-small-en-v1.5",
+                id="full-hf-id-bge",
+            ),
+        ],
+    )
+    def test_resolve_model_name(self, input_name, expected_id):
+        """Test resolving various model name formats to full HuggingFace IDs."""
+        assert resolve_model_name(input_name) == expected_id
 
     def test_resolve_unknown_model_raises_error(self):
         """Test that unknown model names raise ValueError."""
@@ -203,37 +225,52 @@ class TestCreateEmbedder:
 class TestGetModelInfo:
     """Tests for get_model_info function."""
 
-    def test_get_jina_info(self):
-        """Test getting info for Jina model."""
-        info = get_model_info("jina-code-v2")
-        assert info["name"] == "jinaai/jina-embeddings-v2-base-code"
-        assert info["dim"] == 768
-        assert info["params"] == "161M"
-        assert info["preset"] == "jina-code-v2"
-
-    def test_get_minilm_info(self):
-        """Test getting info for MiniLM model."""
-        info = get_model_info("minilm")
-        assert info["name"] == "sentence-transformers/all-MiniLM-L6-v2"
-        assert info["dim"] == 384
-        assert info["params"] == "22M"
-        assert info["preset"] == "minilm"
-
-    def test_get_bge_info(self):
-        """Test getting info for BGE-small model."""
-        info = get_model_info("bge-small")
-        assert info["name"] == "BAAI/bge-small-en-v1.5"
-        assert info["dim"] == 384
-        assert info["params"] == "33M"
-        assert info["preset"] == "bge-small"
-
-    def test_get_info_by_huggingface_id(self):
-        """Test getting info using full HuggingFace ID."""
-        info = get_model_info("jinaai/jina-embeddings-v2-base-code")
-        assert info["name"] == "jinaai/jina-embeddings-v2-base-code"
-        assert info["dim"] == 768
-        # Preset should be None when using full ID
-        assert info["preset"] is None
+    @pytest.mark.parametrize(
+        "input_name, expected_name, expected_dim, expected_params, expected_preset",
+        [
+            pytest.param(
+                "jina-code-v2",
+                "jinaai/jina-embeddings-v2-base-code",
+                768,
+                "161M",
+                "jina-code-v2",
+                id="jina-preset",
+            ),
+            pytest.param(
+                "minilm",
+                "sentence-transformers/all-MiniLM-L6-v2",
+                384,
+                "22M",
+                "minilm",
+                id="minilm-preset",
+            ),
+            pytest.param(
+                "bge-small",
+                "BAAI/bge-small-en-v1.5",
+                384,
+                "33M",
+                "bge-small",
+                id="bge-preset",
+            ),
+            pytest.param(
+                "jinaai/jina-embeddings-v2-base-code",
+                "jinaai/jina-embeddings-v2-base-code",
+                768,
+                "161M",
+                None,
+                id="full-hf-id",
+            ),
+        ],
+    )
+    def test_get_model_info(
+        self, input_name, expected_name, expected_dim, expected_params, expected_preset
+    ):
+        """Test getting model info by preset name or full HuggingFace ID."""
+        info = get_model_info(input_name)
+        assert info["name"] == expected_name
+        assert info["dim"] == expected_dim
+        assert info["params"] == expected_params
+        assert info["preset"] == expected_preset
 
     def test_get_info_unknown_model_raises_error(self):
         """Test that unknown model names raise ValueError."""
@@ -406,45 +443,30 @@ class TestIsModelCached:
 
             assert result is False
 
-    def test_resolves_preset_to_full_model_id(self):
-        """Test that preset names are resolved to full model IDs."""
+    @pytest.mark.parametrize(
+        "preset, expected_model_id",
+        [
+            pytest.param(
+                "minilm", "sentence-transformers/all-MiniLM-L6-v2", id="minilm"
+            ),
+            pytest.param(
+                "jina-code-v2",
+                "jinaai/jina-embeddings-v2-base-code",
+                id="jina",
+            ),
+            pytest.param("bge-small", "BAAI/bge-small-en-v1.5", id="bge"),
+        ],
+    )
+    def test_resolves_preset_to_full_model_id(self, preset, expected_model_id):
+        """Test that preset names are resolved to full model IDs for cache check."""
         with patch(
             "ember.adapters.local_models.registry.try_to_load_from_cache"
         ) as mock_cache:
             mock_cache.return_value = "/path/to/cached/config.json"
 
-            is_model_cached("minilm")
+            is_model_cached(preset)
 
-            # Should resolve "minilm" to full model ID
-            mock_cache.assert_called_once_with(
-                "sentence-transformers/all-MiniLM-L6-v2", "config.json"
-            )
-
-    def test_resolves_jina_preset(self):
-        """Test that jina-code-v2 preset is resolved correctly."""
-        with patch(
-            "ember.adapters.local_models.registry.try_to_load_from_cache"
-        ) as mock_cache:
-            mock_cache.return_value = "/path/to/cached/config.json"
-
-            is_model_cached("jina-code-v2")
-
-            mock_cache.assert_called_once_with(
-                "jinaai/jina-embeddings-v2-base-code", "config.json"
-            )
-
-    def test_resolves_bge_preset(self):
-        """Test that bge-small preset is resolved correctly."""
-        with patch(
-            "ember.adapters.local_models.registry.try_to_load_from_cache"
-        ) as mock_cache:
-            mock_cache.return_value = "/path/to/cached/config.json"
-
-            is_model_cached("bge-small")
-
-            mock_cache.assert_called_once_with(
-                "BAAI/bge-small-en-v1.5", "config.json"
-            )
+            mock_cache.assert_called_once_with(expected_model_id, "config.json")
 
     def test_falls_back_to_directory_check_on_import_error(self, tmp_path):
         """Test falls back to directory check when huggingface_hub fails to import."""

--- a/tests/unit/domain/test_config.py
+++ b/tests/unit/domain/test_config.py
@@ -33,43 +33,43 @@ class TestIndexConfigValidation:
         assert config.line_stride == 150
         assert config.overlap_lines == 20
 
-    def test_index_config_line_window_zero_raises_error(self):
-        """Test that line_window=0 raises ValueError."""
-        with pytest.raises(ValueError, match="line_window must be positive"):
-            IndexConfig(line_window=0)
-
-    def test_index_config_line_window_negative_raises_error(self):
-        """Test that negative line_window raises ValueError."""
-        with pytest.raises(ValueError, match="line_window must be positive"):
-            IndexConfig(line_window=-10)
-
-    def test_index_config_line_stride_zero_raises_error(self):
-        """Test that line_stride=0 raises ValueError."""
-        with pytest.raises(ValueError, match="line_stride must be positive"):
-            IndexConfig(line_stride=0)
-
-    def test_index_config_line_stride_negative_raises_error(self):
-        """Test that negative line_stride raises ValueError."""
-        with pytest.raises(ValueError, match="line_stride must be positive"):
-            IndexConfig(line_stride=-5)
-
-    def test_index_config_overlap_lines_negative_raises_error(self):
-        """Test that negative overlap_lines raises ValueError."""
-        with pytest.raises(ValueError, match="overlap_lines cannot be negative"):
-            IndexConfig(overlap_lines=-1)
+    @pytest.mark.parametrize(
+        "field, value, error_match",
+        [
+            pytest.param("line_window", 0, "line_window must be positive", id="window-zero"),
+            pytest.param(
+                "line_window", -10, "line_window must be positive", id="window-negative"
+            ),
+            pytest.param("line_stride", 0, "line_stride must be positive", id="stride-zero"),
+            pytest.param(
+                "line_stride", -5, "line_stride must be positive", id="stride-negative"
+            ),
+            pytest.param(
+                "overlap_lines",
+                -1,
+                "overlap_lines cannot be negative",
+                id="overlap-negative",
+            ),
+        ],
+    )
+    def test_index_config_invalid_single_field(self, field, value, error_match):
+        """Test that invalid single-field values raise ValueError."""
+        with pytest.raises(ValueError, match=error_match):
+            IndexConfig(**{field: value})
 
     def test_index_config_overlap_lines_zero_valid(self):
         """Test that overlap_lines=0 is valid (no overlap)."""
         config = IndexConfig(overlap_lines=0)
         assert config.overlap_lines == 0
 
-    def test_index_config_overlap_greater_than_window_raises_error(self):
+    @pytest.mark.parametrize(
+        "overlap",
+        [pytest.param(100, id="overlap-equals-window"), pytest.param(150, id="overlap-exceeds-window")],
+    )
+    def test_index_config_overlap_greater_than_or_equal_window_raises_error(self, overlap):
         """Test that overlap_lines >= line_window raises ValueError."""
         with pytest.raises(ValueError, match="overlap_lines.*must be less than.*line_window"):
-            IndexConfig(line_window=100, overlap_lines=100)
-
-        with pytest.raises(ValueError, match="overlap_lines.*must be less than.*line_window"):
-            IndexConfig(line_window=100, overlap_lines=150)
+            IndexConfig(line_window=100, overlap_lines=overlap)
 
     def test_index_config_stride_exceeds_window_raises_error(self):
         """Test that line_stride > line_window raises ValueError."""
@@ -166,54 +166,48 @@ class TestSearchConfigValidation:
         assert config.retrieval_pool_multiplier == 10
         assert config.min_retrieval_pool == 200
 
-    def test_search_config_topk_zero_raises_error(self):
-        """Test that topk=0 raises ValueError."""
-        with pytest.raises(ValueError, match="topk must be positive"):
-            SearchConfig(topk=0)
-
-    def test_search_config_topk_negative_raises_error(self):
-        """Test that negative topk raises ValueError."""
-        with pytest.raises(ValueError, match="topk must be positive"):
-            SearchConfig(topk=-5)
+    @pytest.mark.parametrize(
+        "field, value, error_match",
+        [
+            pytest.param("topk", 0, "topk must be positive", id="topk-zero"),
+            pytest.param("topk", -5, "topk must be positive", id="topk-negative"),
+            pytest.param("rrf_k", 0, "rrf_k must be positive", id="rrf-k-zero"),
+            pytest.param("rrf_k", -10, "rrf_k must be positive", id="rrf-k-negative"),
+            pytest.param(
+                "retrieval_pool_multiplier",
+                0,
+                "retrieval_pool_multiplier must be positive",
+                id="pool-multiplier-zero",
+            ),
+            pytest.param(
+                "retrieval_pool_multiplier",
+                -1,
+                "retrieval_pool_multiplier must be positive",
+                id="pool-multiplier-negative",
+            ),
+            pytest.param(
+                "min_retrieval_pool",
+                0,
+                "min_retrieval_pool must be positive",
+                id="min-pool-zero",
+            ),
+            pytest.param(
+                "min_retrieval_pool",
+                -50,
+                "min_retrieval_pool must be positive",
+                id="min-pool-negative",
+            ),
+        ],
+    )
+    def test_search_config_invalid_field(self, field, value, error_match):
+        """Test that invalid numeric fields raise ValueError."""
+        with pytest.raises(ValueError, match=error_match):
+            SearchConfig(**{field: value})
 
     def test_search_config_topk_one_valid(self):
         """Test that topk=1 is valid."""
         config = SearchConfig(topk=1)
         assert config.topk == 1
-
-    def test_search_config_rrf_k_zero_raises_error(self):
-        """Test that rrf_k=0 raises ValueError."""
-        with pytest.raises(ValueError, match="rrf_k must be positive"):
-            SearchConfig(rrf_k=0)
-
-    def test_search_config_rrf_k_negative_raises_error(self):
-        """Test that negative rrf_k raises ValueError."""
-        with pytest.raises(ValueError, match="rrf_k must be positive"):
-            SearchConfig(rrf_k=-10)
-
-    def test_search_config_retrieval_pool_multiplier_zero_raises_error(self):
-        """Test that retrieval_pool_multiplier=0 raises ValueError."""
-        with pytest.raises(
-            ValueError, match="retrieval_pool_multiplier must be positive"
-        ):
-            SearchConfig(retrieval_pool_multiplier=0)
-
-    def test_search_config_retrieval_pool_multiplier_negative_raises_error(self):
-        """Test that negative retrieval_pool_multiplier raises ValueError."""
-        with pytest.raises(
-            ValueError, match="retrieval_pool_multiplier must be positive"
-        ):
-            SearchConfig(retrieval_pool_multiplier=-1)
-
-    def test_search_config_min_retrieval_pool_zero_raises_error(self):
-        """Test that min_retrieval_pool=0 raises ValueError."""
-        with pytest.raises(ValueError, match="min_retrieval_pool must be positive"):
-            SearchConfig(min_retrieval_pool=0)
-
-    def test_search_config_min_retrieval_pool_negative_raises_error(self):
-        """Test that negative min_retrieval_pool raises ValueError."""
-        with pytest.raises(ValueError, match="min_retrieval_pool must be positive"):
-            SearchConfig(min_retrieval_pool=-50)
 
 
 # =============================================================================
@@ -234,15 +228,14 @@ class TestRedactionConfigValidation:
         config = RedactionConfig(max_file_mb=10)
         assert config.max_file_mb == 10
 
-    def test_redaction_config_max_file_mb_zero_raises_error(self):
-        """Test that max_file_mb=0 raises ValueError."""
+    @pytest.mark.parametrize(
+        "value",
+        [pytest.param(0, id="zero"), pytest.param(-1, id="negative")],
+    )
+    def test_redaction_config_max_file_mb_invalid(self, value):
+        """Test that non-positive max_file_mb raises ValueError."""
         with pytest.raises(ValueError, match="max_file_mb must be positive"):
-            RedactionConfig(max_file_mb=0)
-
-    def test_redaction_config_max_file_mb_negative_raises_error(self):
-        """Test that negative max_file_mb raises ValueError."""
-        with pytest.raises(ValueError, match="max_file_mb must be positive"):
-            RedactionConfig(max_file_mb=-1)
+            RedactionConfig(max_file_mb=value)
 
     def test_redaction_config_valid_regex_patterns(self):
         """Test that valid regex patterns are accepted."""
@@ -306,25 +299,36 @@ class TestModelConfigValidation:
         assert config.daemon_timeout == 600
         assert config.daemon_startup_timeout == 10
 
-    def test_model_config_daemon_timeout_zero_raises_error(self):
-        """Test that daemon_timeout=0 raises ValueError."""
-        with pytest.raises(ValueError, match="daemon_timeout must be positive"):
-            ModelConfig(daemon_timeout=0)
-
-    def test_model_config_daemon_timeout_negative_raises_error(self):
-        """Test that negative daemon_timeout raises ValueError."""
-        with pytest.raises(ValueError, match="daemon_timeout must be positive"):
-            ModelConfig(daemon_timeout=-100)
-
-    def test_model_config_daemon_startup_timeout_zero_raises_error(self):
-        """Test that daemon_startup_timeout=0 raises ValueError."""
-        with pytest.raises(ValueError, match="daemon_startup_timeout must be positive"):
-            ModelConfig(daemon_startup_timeout=0)
-
-    def test_model_config_daemon_startup_timeout_negative_raises_error(self):
-        """Test that negative daemon_startup_timeout raises ValueError."""
-        with pytest.raises(ValueError, match="daemon_startup_timeout must be positive"):
-            ModelConfig(daemon_startup_timeout=-1)
+    @pytest.mark.parametrize(
+        "field, value, error_match",
+        [
+            pytest.param(
+                "daemon_timeout", 0, "daemon_timeout must be positive", id="timeout-zero"
+            ),
+            pytest.param(
+                "daemon_timeout",
+                -100,
+                "daemon_timeout must be positive",
+                id="timeout-negative",
+            ),
+            pytest.param(
+                "daemon_startup_timeout",
+                0,
+                "daemon_startup_timeout must be positive",
+                id="startup-timeout-zero",
+            ),
+            pytest.param(
+                "daemon_startup_timeout",
+                -1,
+                "daemon_startup_timeout must be positive",
+                id="startup-timeout-negative",
+            ),
+        ],
+    )
+    def test_model_config_invalid_timeout(self, field, value, error_match):
+        """Test that non-positive timeout values raise ValueError."""
+        with pytest.raises(ValueError, match=error_match):
+            ModelConfig(**{field: value})
 
 
 # =============================================================================
@@ -351,21 +355,32 @@ class TestDisplayConfigValidation:
         assert config.color_scheme == "always"
         assert config.theme == "monokai"
 
-    def test_display_config_valid_pygments_themes(self):
+    @pytest.mark.parametrize(
+        "theme",
+        [
+            pytest.param("ansi", id="ansi"),
+            pytest.param("monokai", id="monokai"),
+            pytest.param("github-dark", id="github-dark"),
+            pytest.param("dracula", id="dracula"),
+            pytest.param("solarized-dark", id="solarized-dark"),
+        ],
+    )
+    def test_display_config_valid_pygments_themes(self, theme):
         """Test that common Pygments themes are accepted."""
-        for theme in ["ansi", "monokai", "github-dark", "dracula", "solarized-dark"]:
-            config = DisplayConfig(theme=theme)
-            assert config.theme == theme
+        config = DisplayConfig(theme=theme)
+        assert config.theme == theme
 
-    def test_display_config_invalid_theme_raises_error(self):
-        """Test that invalid theme raises ValueError."""
-        with pytest.raises(ValueError, match="Unknown theme 'invalid-theme'"):
-            DisplayConfig(theme="invalid-theme")
-
-    def test_display_config_empty_theme_raises_error(self):
-        """Test that empty theme raises ValueError."""
-        with pytest.raises(ValueError, match="Unknown theme ''"):
-            DisplayConfig(theme="")
+    @pytest.mark.parametrize(
+        "theme, expected_in_error",
+        [
+            pytest.param("invalid-theme", "invalid-theme", id="invalid"),
+            pytest.param("", "", id="empty"),
+        ],
+    )
+    def test_display_config_invalid_theme_raises_error(self, theme, expected_in_error):
+        """Test that invalid/empty theme raises ValueError."""
+        with pytest.raises(ValueError, match=f"Unknown theme '{expected_in_error}'"):
+            DisplayConfig(theme=theme)
 
 
 # =============================================================================

--- a/tests/unit/domain/test_entities.py
+++ b/tests/unit/domain/test_entities.py
@@ -68,47 +68,43 @@ class TestQueryValidation:
         query = Query(text="search term")
         assert query.topk == 20
 
-    def test_query_empty_text_raises_error(self):
-        """Test that empty query text raises ValueError."""
-        with pytest.raises(ValueError, match="Query text cannot be empty"):
-            Query(text="")
+    @pytest.mark.parametrize(
+        "text, topk, error_match",
+        [
+            pytest.param("", 10, "Query text cannot be empty", id="empty-text"),
+            pytest.param("   ", 10, "Query text cannot be empty", id="whitespace-text"),
+            pytest.param("search", 0, "topk must be positive", id="topk-zero"),
+            pytest.param("search", -5, "topk must be positive", id="topk-negative"),
+        ],
+    )
+    def test_query_invalid_creation(self, text, topk, error_match):
+        """Test that invalid Query parameters raise ValueError."""
+        with pytest.raises(ValueError, match=error_match):
+            Query(text=text, topk=topk)
 
-    def test_query_whitespace_only_text_raises_error(self):
-        """Test that whitespace-only query text raises ValueError."""
-        with pytest.raises(ValueError, match="Query text cannot be empty"):
-            Query(text="   ")
-
-    def test_query_topk_zero_raises_error(self):
-        """Test that topk=0 raises ValueError."""
-        with pytest.raises(ValueError, match="topk must be positive"):
-            Query(text="search", topk=0)
-
-    def test_query_topk_negative_raises_error(self):
-        """Test that negative topk raises ValueError."""
-        with pytest.raises(ValueError, match="topk must be positive"):
-            Query(text="search", topk=-5)
-
-    def test_query_topk_positive_valid(self):
+    @pytest.mark.parametrize("topk", [1, 100])
+    def test_query_topk_positive_valid(self, topk):
         """Test that positive topk values are valid."""
-        query = Query(text="search", topk=1)
-        assert query.topk == 1
-
-        query = Query(text="search", topk=100)
-        assert query.topk == 100
+        query = Query(text="search", topk=topk)
+        assert query.topk == topk
 
 
 class TestQueryImmutability:
     """Tests for Query immutability (frozen dataclass)."""
 
-    def test_query_is_frozen(self):
+    @pytest.mark.parametrize(
+        "attr, value",
+        [
+            pytest.param("text", "new text", id="text"),
+            pytest.param("topk", 20, id="topk"),
+            pytest.param("path_filter", PathFilter("*.py"), id="path-filter"),
+        ],
+    )
+    def test_query_is_frozen(self, attr, value):
         """Test that Query instances cannot be modified after creation."""
         query = Query(text="search term", topk=10)
         with pytest.raises(AttributeError):
-            query.text = "new text"
-        with pytest.raises(AttributeError):
-            query.topk = 20
-        with pytest.raises(AttributeError):
-            query.path_filter = PathFilter("*.py")
+            setattr(query, attr, value)
 
     def test_query_hashable(self):
         """Test that frozen Query is hashable."""
@@ -254,71 +250,26 @@ class TestChunkValidation:
         assert chunk.start_line == 1
         assert chunk.end_line == 10
 
-    def test_chunk_start_line_zero_raises_error(self):
-        """Test that start_line=0 raises ValueError (1-indexed)."""
-        with pytest.raises(ValueError, match="Line numbers must be >= 1"):
+    @pytest.mark.parametrize(
+        "start, end, error_match",
+        [
+            pytest.param(0, 10, "Line numbers must be >= 1", id="start-zero"),
+            pytest.param(1, 0, "Line numbers must be >= 1", id="end-zero"),
+            pytest.param(-1, 10, "Line numbers must be >= 1", id="start-negative"),
+            pytest.param(20, 10, "start_line.*>.*end_line", id="start-gt-end"),
+        ],
+    )
+    def test_chunk_invalid_line_numbers(self, start, end, error_match):
+        """Test that invalid line number combinations raise ValueError."""
+        with pytest.raises(ValueError, match=error_match):
             Chunk(
                 id="test_id",
                 project_id="proj",
                 path=Path("file.py"),
                 lang="py",
                 symbol="func",
-                start_line=0,
-                end_line=10,
-                content="code",
-                content_hash=self.VALID_CONTENT_HASH,
-                file_hash=self.VALID_FILE_HASH,
-                tree_sha=self.VALID_TREE_SHA,
-                rev="HEAD",
-            )
-
-    def test_chunk_end_line_zero_raises_error(self):
-        """Test that end_line=0 raises ValueError (1-indexed)."""
-        with pytest.raises(ValueError, match="Line numbers must be >= 1"):
-            Chunk(
-                id="test_id",
-                project_id="proj",
-                path=Path("file.py"),
-                lang="py",
-                symbol="func",
-                start_line=1,
-                end_line=0,
-                content="code",
-                content_hash=self.VALID_CONTENT_HASH,
-                file_hash=self.VALID_FILE_HASH,
-                tree_sha=self.VALID_TREE_SHA,
-                rev="HEAD",
-            )
-
-    def test_chunk_negative_line_numbers_raises_error(self):
-        """Test that negative line numbers raise ValueError."""
-        with pytest.raises(ValueError, match="Line numbers must be >= 1"):
-            Chunk(
-                id="test_id",
-                project_id="proj",
-                path=Path("file.py"),
-                lang="py",
-                symbol="func",
-                start_line=-1,
-                end_line=10,
-                content="code",
-                content_hash=self.VALID_CONTENT_HASH,
-                file_hash=self.VALID_FILE_HASH,
-                tree_sha=self.VALID_TREE_SHA,
-                rev="HEAD",
-            )
-
-    def test_chunk_start_greater_than_end_raises_error(self):
-        """Test that start_line > end_line raises ValueError."""
-        with pytest.raises(ValueError, match="start_line.*>.*end_line"):
-            Chunk(
-                id="test_id",
-                project_id="proj",
-                path=Path("file.py"),
-                lang="py",
-                symbol="func",
-                start_line=20,
-                end_line=10,
+                start_line=start,
+                end_line=end,
                 content="code",
                 content_hash=self.VALID_CONTENT_HASH,
                 file_hash=self.VALID_FILE_HASH,
@@ -437,17 +388,18 @@ class TestSearchResultSet:
 class TestSyncMode:
     """Tests for SyncMode enum."""
 
-    def test_sync_mode_values(self):
-        """Test SyncMode enum has expected values."""
-        assert SyncMode.NONE == "none"
-        assert SyncMode.WORKTREE == "worktree"
-        assert SyncMode.STAGED == "staged"
-
-    def test_sync_mode_from_string(self):
-        """Test creating SyncMode from string value."""
-        assert SyncMode("none") == SyncMode.NONE
-        assert SyncMode("worktree") == SyncMode.WORKTREE
-        assert SyncMode("staged") == SyncMode.STAGED
+    @pytest.mark.parametrize(
+        "member, string_value",
+        [
+            pytest.param(SyncMode.NONE, "none", id="none"),
+            pytest.param(SyncMode.WORKTREE, "worktree", id="worktree"),
+            pytest.param(SyncMode.STAGED, "staged", id="staged"),
+        ],
+    )
+    def test_sync_mode_values_and_from_string(self, member, string_value):
+        """Test SyncMode enum values and creation from string."""
+        assert member == string_value
+        assert SyncMode(string_value) == member
 
     def test_sync_mode_invalid_string_raises_error(self):
         """Test that invalid string raises ValueError."""
@@ -462,19 +414,24 @@ class TestSyncMode:
         # .value gives the underlying string
         assert mode.value == "worktree"
 
-    def test_sync_mode_is_commit_sha(self):
-        """Test is_commit_sha method for known modes."""
-        assert not SyncMode.is_commit_sha("none")
-        assert not SyncMode.is_commit_sha("worktree")
-        assert not SyncMode.is_commit_sha("staged")
-        # Valid commit SHAs
-        assert SyncMode.is_commit_sha("abc123def456789012345678901234567890abcd")
-        assert SyncMode.is_commit_sha("a" * 40)
-        # Short SHAs (7-39 chars) are also valid
-        assert SyncMode.is_commit_sha("abc1234")
-        # Invalid SHAs
-        assert not SyncMode.is_commit_sha("abc")  # Too short
-        assert not SyncMode.is_commit_sha("xyz123!")  # Invalid chars
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            pytest.param("none", False, id="mode-none"),
+            pytest.param("worktree", False, id="mode-worktree"),
+            pytest.param("staged", False, id="mode-staged"),
+            pytest.param(
+                "abc123def456789012345678901234567890abcd", True, id="full-sha"
+            ),
+            pytest.param("a" * 40, True, id="40-char-sha"),
+            pytest.param("abc1234", True, id="short-sha-7"),
+            pytest.param("abc", False, id="too-short"),
+            pytest.param("xyz123!", False, id="invalid-chars"),
+        ],
+    )
+    def test_sync_mode_is_commit_sha(self, value, expected):
+        """Test is_commit_sha correctly identifies commit SHAs vs mode strings."""
+        assert SyncMode.is_commit_sha(value) == expected
 
 
 # =============================================================================
@@ -644,70 +601,93 @@ class TestChunkHashValidation:
         defaults.update(kwargs)
         return Chunk(**defaults)
 
-    def test_chunk_valid_blake3_hash_content(self):
-        """Test that valid blake3 content_hash is accepted."""
-        chunk = self._make_chunk(content_hash="a" * 64)
-        assert chunk.content_hash == "a" * 64
+    @pytest.mark.parametrize(
+        "field, value",
+        [
+            pytest.param("content_hash", "a" * 64, id="valid-content-hash"),
+            pytest.param("file_hash", "b" * 64, id="valid-file-hash"),
+        ],
+    )
+    def test_chunk_valid_blake3_hash(self, field, value):
+        """Test that valid blake3 hashes are accepted."""
+        chunk = self._make_chunk(**{field: value})
+        assert getattr(chunk, field) == value
 
-    def test_chunk_valid_blake3_hash_file(self):
-        """Test that valid blake3 file_hash is accepted."""
-        chunk = self._make_chunk(file_hash="b" * 64)
-        assert chunk.file_hash == "b" * 64
+    @pytest.mark.parametrize(
+        "field, value, error_match",
+        [
+            pytest.param(
+                "content_hash",
+                "not-a-valid-hash",
+                "Invalid blake3 hash.*content_hash",
+                id="content-bad-format",
+            ),
+            pytest.param(
+                "content_hash",
+                "abc123",
+                "Invalid blake3 hash.*content_hash",
+                id="content-too-short",
+            ),
+            pytest.param(
+                "content_hash",
+                "",
+                "Invalid blake3 hash.*content_hash",
+                id="content-empty",
+            ),
+            pytest.param(
+                "content_hash",
+                "A" * 64,
+                "Invalid blake3 hash.*content_hash",
+                id="content-uppercase",
+            ),
+            pytest.param(
+                "file_hash",
+                "xyz-invalid-hash",
+                "Invalid blake3 hash.*file_hash",
+                id="file-bad-format",
+            ),
+            pytest.param(
+                "file_hash",
+                "a" * 63,
+                "Invalid blake3 hash.*file_hash",
+                id="file-too-short",
+            ),
+            pytest.param(
+                "file_hash",
+                "",
+                "Invalid blake3 hash.*file_hash",
+                id="file-empty",
+            ),
+        ],
+    )
+    def test_chunk_invalid_blake3_hash(self, field, value, error_match):
+        """Test that invalid blake3 hashes raise ValueError."""
+        with pytest.raises(ValueError, match=error_match):
+            self._make_chunk(**{field: value})
 
-    def test_chunk_invalid_content_hash_format_raises_error(self):
-        """Test that content_hash with non-hex chars raises ValueError."""
-        with pytest.raises(ValueError, match="Invalid blake3 hash.*content_hash"):
-            self._make_chunk(content_hash="not-a-valid-hash")
+    @pytest.mark.parametrize(
+        "tree_sha",
+        [
+            pytest.param("a" * 40, id="valid-40-char"),
+            pytest.param("", id="empty-worktree-mode"),
+        ],
+    )
+    def test_chunk_valid_tree_sha(self, tree_sha):
+        """Test that valid git tree SHA values are accepted."""
+        chunk = self._make_chunk(tree_sha=tree_sha)
+        assert chunk.tree_sha == tree_sha
 
-    def test_chunk_invalid_content_hash_length_raises_error(self):
-        """Test that content_hash with wrong length raises ValueError."""
-        with pytest.raises(ValueError, match="Invalid blake3 hash.*content_hash"):
-            self._make_chunk(content_hash="abc123")  # Too short
-
-    def test_chunk_invalid_file_hash_format_raises_error(self):
-        """Test that file_hash with non-hex chars raises ValueError."""
-        with pytest.raises(ValueError, match="Invalid blake3 hash.*file_hash"):
-            self._make_chunk(file_hash="xyz-invalid-hash")
-
-    def test_chunk_invalid_file_hash_length_raises_error(self):
-        """Test that file_hash with wrong length raises ValueError."""
-        with pytest.raises(ValueError, match="Invalid blake3 hash.*file_hash"):
-            self._make_chunk(file_hash="a" * 63)  # One char too short
-
-    def test_chunk_empty_content_hash_raises_error(self):
-        """Test that empty content_hash raises ValueError."""
-        with pytest.raises(ValueError, match="Invalid blake3 hash.*content_hash"):
-            self._make_chunk(content_hash="")
-
-    def test_chunk_empty_file_hash_raises_error(self):
-        """Test that empty file_hash raises ValueError."""
-        with pytest.raises(ValueError, match="Invalid blake3 hash.*file_hash"):
-            self._make_chunk(file_hash="")
-
-    def test_chunk_content_hash_uppercase_rejected(self):
-        """Test that uppercase hex in content_hash is rejected."""
-        with pytest.raises(ValueError, match="Invalid blake3 hash.*content_hash"):
-            self._make_chunk(content_hash="A" * 64)
-
-    def test_chunk_valid_tree_sha_format(self):
-        """Test that valid git tree SHA is accepted."""
-        chunk = self._make_chunk(tree_sha="a" * 40)
-        assert chunk.tree_sha == "a" * 40
-
-    def test_chunk_empty_tree_sha_valid(self):
-        """Test that empty tree_sha is valid (worktree mode)."""
-        chunk = self._make_chunk(tree_sha="")
-        assert chunk.tree_sha == ""
-
-    def test_chunk_invalid_tree_sha_raises_error(self):
+    @pytest.mark.parametrize(
+        "tree_sha",
+        [
+            pytest.param("not-valid-sha", id="bad-format"),
+            pytest.param("a" * 39, id="wrong-length"),
+        ],
+    )
+    def test_chunk_invalid_tree_sha(self, tree_sha):
         """Test that invalid tree_sha format raises ValueError."""
         with pytest.raises(ValueError, match="Invalid git SHA.*tree_sha"):
-            self._make_chunk(tree_sha="not-valid-sha")
-
-    def test_chunk_tree_sha_wrong_length_raises_error(self):
-        """Test that tree_sha with wrong length raises ValueError."""
-        with pytest.raises(ValueError, match="Invalid git SHA.*tree_sha"):
-            self._make_chunk(tree_sha="a" * 39)  # One char too short
+            self._make_chunk(tree_sha=tree_sha)
 
 
 # =============================================================================
@@ -827,36 +807,45 @@ class TestSearchExplanationScoreValidation:
         assert explanation.bm25_score == 0.0
         assert explanation.vector_score == 1.0
 
-    def test_negative_fused_score_raises_error(self):
-        """Test that negative fused_score raises ValueError."""
-        with pytest.raises(ValueError, match="fused_score must be between"):
-            SearchExplanation(fused_score=-0.1)
-
-    def test_fused_score_above_one_raises_error(self):
-        """Test that fused_score > 1.0 raises ValueError."""
-        with pytest.raises(ValueError, match="fused_score must be between"):
-            SearchExplanation(fused_score=1.5)
-
-    def test_negative_bm25_score_raises_error(self):
-        """Test that negative bm25_score raises ValueError."""
-        with pytest.raises(ValueError, match="bm25_score must be non-negative"):
-            SearchExplanation(fused_score=0.5, bm25_score=-0.1)
+    @pytest.mark.parametrize(
+        "kwargs, error_match",
+        [
+            pytest.param(
+                {"fused_score": -0.1},
+                "fused_score must be between",
+                id="fused-negative",
+            ),
+            pytest.param(
+                {"fused_score": 1.5},
+                "fused_score must be between",
+                id="fused-above-one",
+            ),
+            pytest.param(
+                {"fused_score": 0.5, "bm25_score": -0.1},
+                "bm25_score must be non-negative",
+                id="bm25-negative",
+            ),
+            pytest.param(
+                {"fused_score": 0.5, "vector_score": -0.5},
+                "vector_score must be between",
+                id="vector-negative",
+            ),
+            pytest.param(
+                {"fused_score": 0.5, "vector_score": 2.0},
+                "vector_score must be between",
+                id="vector-above-one",
+            ),
+        ],
+    )
+    def test_invalid_scores_raise_error(self, kwargs, error_match):
+        """Test that out-of-range scores raise ValueError."""
+        with pytest.raises(ValueError, match=error_match):
+            SearchExplanation(**kwargs)
 
     def test_bm25_score_above_one_valid(self):
         """Test that bm25_score > 1.0 is valid (raw FTS5 scores are unbounded)."""
-        # BM25 scores from SQLite FTS5 are raw, unbounded positive values
         explanation = SearchExplanation(fused_score=0.5, bm25_score=10.378)
         assert explanation.bm25_score == 10.378
-
-    def test_negative_vector_score_raises_error(self):
-        """Test that negative vector_score raises ValueError."""
-        with pytest.raises(ValueError, match="vector_score must be between"):
-            SearchExplanation(fused_score=0.5, vector_score=-0.5)
-
-    def test_vector_score_above_one_raises_error(self):
-        """Test that vector_score > 1.0 raises ValueError."""
-        with pytest.raises(ValueError, match="vector_score must be between"):
-            SearchExplanation(fused_score=0.5, vector_score=2.0)
 
 
 # =============================================================================
@@ -1014,42 +1003,43 @@ class TestChunkValidatorsInIsolation:
     one of the success criteria for #352.
     """
 
-    def test_validate_line_numbers_valid(self):
+    @pytest.mark.parametrize(
+        "start, end",
+        [pytest.param(1, 10, id="normal"), pytest.param(5, 5, id="single-line")],
+    )
+    def test_validate_line_numbers_valid(self, start, end):
         """Test _validate_line_numbers accepts valid values."""
-        # Should not raise
-        Chunk._validate_line_numbers(1, 10)
-        Chunk._validate_line_numbers(5, 5)  # Single line
+        Chunk._validate_line_numbers(start, end)  # Should not raise
 
-    def test_validate_line_numbers_zero_start(self):
-        """Test _validate_line_numbers rejects zero start_line."""
-        with pytest.raises(ValueError, match="Line numbers must be >= 1"):
-            Chunk._validate_line_numbers(0, 10)
+    @pytest.mark.parametrize(
+        "start, end, error_match",
+        [
+            pytest.param(0, 10, "Line numbers must be >= 1", id="zero-start"),
+            pytest.param(1, 0, "Line numbers must be >= 1", id="zero-end"),
+            pytest.param(20, 10, "start_line.*>.*end_line", id="start-gt-end"),
+        ],
+    )
+    def test_validate_line_numbers_invalid(self, start, end, error_match):
+        """Test _validate_line_numbers rejects invalid values."""
+        with pytest.raises(ValueError, match=error_match):
+            Chunk._validate_line_numbers(start, end)
 
-    def test_validate_line_numbers_zero_end(self):
-        """Test _validate_line_numbers rejects zero end_line."""
-        with pytest.raises(ValueError, match="Line numbers must be >= 1"):
-            Chunk._validate_line_numbers(1, 0)
-
-    def test_validate_line_numbers_start_greater_than_end(self):
-        """Test _validate_line_numbers rejects start > end."""
-        with pytest.raises(ValueError, match="start_line.*>.*end_line"):
-            Chunk._validate_line_numbers(20, 10)
-
-    def test_validate_content_valid(self):
+    @pytest.mark.parametrize(
+        "content",
+        [pytest.param("code", id="simple"), pytest.param("  code  ", id="padded")],
+    )
+    def test_validate_content_valid(self, content):
         """Test _validate_content accepts non-empty content."""
-        # Should not raise
-        Chunk._validate_content("code")
-        Chunk._validate_content("  code  ")
+        Chunk._validate_content(content)  # Should not raise
 
-    def test_validate_content_empty(self):
-        """Test _validate_content rejects empty content."""
+    @pytest.mark.parametrize(
+        "content",
+        [pytest.param("", id="empty"), pytest.param("   \n\t  ", id="whitespace-only")],
+    )
+    def test_validate_content_invalid(self, content):
+        """Test _validate_content rejects empty/whitespace content."""
         with pytest.raises(ValueError, match="content cannot be empty"):
-            Chunk._validate_content("")
-
-    def test_validate_content_whitespace_only(self):
-        """Test _validate_content rejects whitespace-only content."""
-        with pytest.raises(ValueError, match="content cannot be empty"):
-            Chunk._validate_content("   \n\t  ")
+            Chunk._validate_content(content)
 
     def test_validate_blake3_hash_valid(self):
         """Test _validate_blake3_hash accepts valid hash."""
@@ -1090,37 +1080,36 @@ class TestQueryValidatorsInIsolation:
     These tests verify that validation logic is testable in isolation.
     """
 
-    def test_validate_text_valid(self):
+    @pytest.mark.parametrize(
+        "text",
+        [pytest.param("search term", id="normal"), pytest.param("  search  ", id="padded")],
+    )
+    def test_validate_text_valid(self, text):
         """Test _validate_text accepts non-empty text."""
-        # Should not raise
-        Query._validate_text("search term")
-        Query._validate_text("  search  ")
+        Query._validate_text(text)  # Should not raise
 
-    def test_validate_text_empty(self):
-        """Test _validate_text rejects empty text."""
+    @pytest.mark.parametrize(
+        "text",
+        [pytest.param("", id="empty"), pytest.param("   ", id="whitespace-only")],
+    )
+    def test_validate_text_invalid(self, text):
+        """Test _validate_text rejects empty/whitespace text."""
         with pytest.raises(ValueError, match="Query text cannot be empty"):
-            Query._validate_text("")
+            Query._validate_text(text)
 
-    def test_validate_text_whitespace_only(self):
-        """Test _validate_text rejects whitespace-only text."""
-        with pytest.raises(ValueError, match="Query text cannot be empty"):
-            Query._validate_text("   ")
-
-    def test_validate_topk_valid(self):
+    @pytest.mark.parametrize("topk", [1, 100])
+    def test_validate_topk_valid(self, topk):
         """Test _validate_topk accepts positive values."""
-        # Should not raise
-        Query._validate_topk(1)
-        Query._validate_topk(100)
+        Query._validate_topk(topk)  # Should not raise
 
-    def test_validate_topk_zero(self):
-        """Test _validate_topk rejects zero."""
+    @pytest.mark.parametrize(
+        "topk",
+        [pytest.param(0, id="zero"), pytest.param(-5, id="negative")],
+    )
+    def test_validate_topk_invalid(self, topk):
+        """Test _validate_topk rejects non-positive values."""
         with pytest.raises(ValueError, match="topk must be positive"):
-            Query._validate_topk(0)
-
-    def test_validate_topk_negative(self):
-        """Test _validate_topk rejects negative values."""
-        with pytest.raises(ValueError, match="topk must be positive"):
-            Query._validate_topk(-5)
+            Query._validate_topk(topk)
 
     # Note: _normalize_path_filter and _normalize_lang_filter methods were removed
     # in favor of the from_strings() factory method. See TestQueryFromStrings.
@@ -1177,38 +1166,27 @@ class TestSearchResultValidation:
         result_one = SearchResult(chunk=chunk, score=1.0, rank=1)
         assert result_one.score == 1.0
 
-    def test_negative_score_raises_error(self):
-        """Test that negative score raises ValueError."""
+    @pytest.mark.parametrize(
+        "score, rank, error_match",
+        [
+            pytest.param(-0.1, 1, "score must be 0.0-1.0", id="score-negative"),
+            pytest.param(1.5, 1, "score must be 0.0-1.0", id="score-above-one"),
+            pytest.param(0.5, 0, "rank must be positive", id="rank-zero"),
+            pytest.param(0.5, -1, "rank must be positive", id="rank-negative"),
+        ],
+    )
+    def test_invalid_score_or_rank(self, score, rank, error_match):
+        """Test that invalid score/rank values raise ValueError."""
         chunk = self._make_chunk()
-        with pytest.raises(ValueError, match="score must be 0.0-1.0"):
-            SearchResult(chunk=chunk, score=-0.1, rank=1)
+        with pytest.raises(ValueError, match=error_match):
+            SearchResult(chunk=chunk, score=score, rank=rank)
 
-    def test_score_above_one_raises_error(self):
-        """Test that score > 1.0 raises ValueError."""
-        chunk = self._make_chunk()
-        with pytest.raises(ValueError, match="score must be 0.0-1.0"):
-            SearchResult(chunk=chunk, score=1.5, rank=1)
-
-    def test_rank_positive_valid(self):
+    @pytest.mark.parametrize("rank", [1, 100])
+    def test_rank_positive_valid(self, rank):
         """Test that positive rank values are valid."""
         chunk = self._make_chunk()
-        result = SearchResult(chunk=chunk, score=0.5, rank=1)
-        assert result.rank == 1
-
-        result = SearchResult(chunk=chunk, score=0.5, rank=100)
-        assert result.rank == 100
-
-    def test_rank_zero_raises_error(self):
-        """Test that rank=0 raises ValueError (1-indexed)."""
-        chunk = self._make_chunk()
-        with pytest.raises(ValueError, match="rank must be positive"):
-            SearchResult(chunk=chunk, score=0.5, rank=0)
-
-    def test_rank_negative_raises_error(self):
-        """Test that negative rank raises ValueError."""
-        chunk = self._make_chunk()
-        with pytest.raises(ValueError, match="rank must be positive"):
-            SearchResult(chunk=chunk, score=0.5, rank=-1)
+        result = SearchResult(chunk=chunk, score=0.5, rank=rank)
+        assert result.rank == rank
 
     def test_multiple_invalid_values(self):
         """Test error with both invalid score and rank."""
@@ -1242,16 +1220,20 @@ class TestSearchResultImmutability:
             rev="HEAD",
         )
 
-    def test_search_result_is_frozen(self):
+    @pytest.mark.parametrize(
+        "attr, value",
+        [
+            pytest.param("score", 0.9, id="score"),
+            pytest.param("rank", 2, id="rank"),
+            pytest.param("preview", "new preview", id="preview"),
+        ],
+    )
+    def test_search_result_is_frozen(self, attr, value):
         """Test that SearchResult instances cannot be modified after creation."""
         chunk = self._make_chunk()
         result = SearchResult(chunk=chunk, score=0.5, rank=1)
         with pytest.raises(AttributeError):
-            result.score = 0.9
-        with pytest.raises(AttributeError):
-            result.rank = 2
-        with pytest.raises(AttributeError):
-            result.preview = "new preview"
+            setattr(result, attr, value)
 
     def test_search_result_hashable(self):
         """Test that frozen SearchResult is hashable."""
@@ -1271,35 +1253,30 @@ class TestSearchResultValidatorsInIsolation:
     These tests verify that validation logic is testable in isolation.
     """
 
-    def test_validate_score_valid(self):
+    @pytest.mark.parametrize("score", [0.0, 0.5, 1.0])
+    def test_validate_score_valid(self, score):
         """Test _validate_score accepts valid values."""
-        # Should not raise
-        SearchResult._validate_score(0.0)
-        SearchResult._validate_score(0.5)
-        SearchResult._validate_score(1.0)
+        SearchResult._validate_score(score)  # Should not raise
 
-    def test_validate_score_negative(self):
-        """Test _validate_score rejects negative values."""
+    @pytest.mark.parametrize(
+        "score",
+        [pytest.param(-0.1, id="negative"), pytest.param(1.01, id="above-one")],
+    )
+    def test_validate_score_invalid(self, score):
+        """Test _validate_score rejects out-of-range values."""
         with pytest.raises(ValueError, match="score must be 0.0-1.0"):
-            SearchResult._validate_score(-0.1)
+            SearchResult._validate_score(score)
 
-    def test_validate_score_above_one(self):
-        """Test _validate_score rejects values > 1.0."""
-        with pytest.raises(ValueError, match="score must be 0.0-1.0"):
-            SearchResult._validate_score(1.01)
-
-    def test_validate_rank_valid(self):
+    @pytest.mark.parametrize("rank", [1, 100])
+    def test_validate_rank_valid(self, rank):
         """Test _validate_rank accepts positive values."""
-        # Should not raise
-        SearchResult._validate_rank(1)
-        SearchResult._validate_rank(100)
+        SearchResult._validate_rank(rank)  # Should not raise
 
-    def test_validate_rank_zero(self):
-        """Test _validate_rank rejects zero."""
+    @pytest.mark.parametrize(
+        "rank",
+        [pytest.param(0, id="zero"), pytest.param(-5, id="negative")],
+    )
+    def test_validate_rank_invalid(self, rank):
+        """Test _validate_rank rejects non-positive values."""
         with pytest.raises(ValueError, match="rank must be positive"):
-            SearchResult._validate_rank(0)
-
-    def test_validate_rank_negative(self):
-        """Test _validate_rank rejects negative values."""
-        with pytest.raises(ValueError, match="rank must be positive"):
-            SearchResult._validate_rank(-5)
+            SearchResult._validate_rank(rank)

--- a/tests/unit/entrypoints/test_sync_error_hints.py
+++ b/tests/unit/entrypoints/test_sync_error_hints.py
@@ -171,86 +171,73 @@ class TestHandleCliErrorsDecorator:
 class TestGetTargetedSyncHint:
     """Tests for _get_targeted_sync_hint function."""
 
-    def test_database_corruption_hint_suggests_reindex(self) -> None:
-        """Database corruption error should suggest --reindex."""
+    @pytest.mark.parametrize(
+        "error_message, expected_keyword",
+        [
+            pytest.param(
+                "database disk image is malformed",
+                "reindex",
+                id="db-corruption",
+            ),
+            pytest.param(
+                "file is not a database",
+                "reindex",
+                id="not-a-database",
+            ),
+            pytest.param(
+                "Embedding model changed",
+                "init",
+                id="model-mismatch",
+            ),
+            pytest.param(
+                "Vector dimension mismatch: expected 768, got 384",
+                "init|reindex",
+                id="dimension-mismatch",
+            ),
+            pytest.param(
+                "Permission denied: /path/to/file",
+                "permission",
+                id="permission-denied",
+            ),
+            pytest.param(
+                "Access denied to file.db",
+                "permission",
+                id="access-denied",
+            ),
+            pytest.param(
+                "No space left on device",
+                "space|disk",
+                id="disk-full",
+            ),
+            pytest.param(
+                "database is locked",
+                "wait|retry",
+                id="db-locked",
+            ),
+            pytest.param(
+                "database table is busy",
+                "wait|retry",
+                id="db-busy",
+            ),
+            pytest.param(
+                "Some unknown error occurred",
+                "verbose",
+                id="generic-error",
+            ),
+        ],
+    )
+    def test_get_targeted_sync_hint(self, error_message, expected_keyword) -> None:
+        """Test that error messages produce hints containing expected keywords."""
         from ember.entrypoints.cli import _get_targeted_sync_hint
 
-        hint = _get_targeted_sync_hint("database disk image is malformed")
+        hint = _get_targeted_sync_hint(error_message)
+        hint_lower = hint.lower()
 
-        assert "reindex" in hint.lower()
-
-    def test_database_not_a_database_suggests_reindex(self) -> None:
-        """'not a database' error should suggest --reindex."""
-        from ember.entrypoints.cli import _get_targeted_sync_hint
-
-        hint = _get_targeted_sync_hint("file is not a database")
-
-        assert "reindex" in hint.lower()
-
-    def test_model_mismatch_in_response_suggests_init_force(self) -> None:
-        """Model mismatch in error response should suggest init --force."""
-        from ember.entrypoints.cli import _get_targeted_sync_hint
-
-        hint = _get_targeted_sync_hint("Embedding model changed")
-
-        assert "init" in hint.lower()
-
-    def test_model_dimension_mismatch_suggests_init_force(self) -> None:
-        """Model dimension mismatch should suggest init --force."""
-        from ember.entrypoints.cli import _get_targeted_sync_hint
-
-        hint = _get_targeted_sync_hint("Vector dimension mismatch: expected 768, got 384")
-
-        # Should suggest reindex since 'mismatch' is detected
-        assert "init" in hint.lower() or "reindex" in hint.lower()
-
-    def test_permission_error_in_response_suggests_check_permissions(self) -> None:
-        """Permission error in response should suggest checking permissions."""
-        from ember.entrypoints.cli import _get_targeted_sync_hint
-
-        hint = _get_targeted_sync_hint("Permission denied: /path/to/file")
-
-        assert "permission" in hint.lower()
-
-    def test_access_denied_in_response_suggests_check_permissions(self) -> None:
-        """Access denied error should suggest checking permissions."""
-        from ember.entrypoints.cli import _get_targeted_sync_hint
-
-        hint = _get_targeted_sync_hint("Access denied to file.db")
-
-        assert "permission" in hint.lower()
-
-    def test_disk_full_in_response_suggests_free_space(self) -> None:
-        """Disk full error in response should suggest freeing space."""
-        from ember.entrypoints.cli import _get_targeted_sync_hint
-
-        hint = _get_targeted_sync_hint("No space left on device")
-
-        assert "space" in hint.lower() or "disk" in hint.lower()
-
-    def test_database_locked_suggests_wait_retry(self) -> None:
-        """Database locked error should suggest waiting and retrying."""
-        from ember.entrypoints.cli import _get_targeted_sync_hint
-
-        hint = _get_targeted_sync_hint("database is locked")
-
-        assert "wait" in hint.lower() or "retry" in hint.lower()
-
-    def test_database_busy_suggests_wait_retry(self) -> None:
-        """Database busy error should suggest waiting and retrying."""
-        from ember.entrypoints.cli import _get_targeted_sync_hint
-
-        hint = _get_targeted_sync_hint("database table is busy")
-
-        assert "wait" in hint.lower() or "retry" in hint.lower()
-
-    def test_generic_error_suggests_verbose(self) -> None:
-        """Generic error in response should suggest --verbose."""
-        from ember.entrypoints.cli import _get_targeted_sync_hint
-
-        hint = _get_targeted_sync_hint("Some unknown error occurred")
-
-        assert "verbose" in hint.lower()
+        # expected_keyword can be "keyword1|keyword2" meaning either must match
+        keywords = expected_keyword.split("|")
+        assert any(
+            kw in hint_lower for kw in keywords
+        ), f"Expected one of {keywords} in hint: {hint!r}"
 
 
 class TestSyncCommandErrorIntegration:

--- a/tests/unit/test_time_formatting.py
+++ b/tests/unit/test_time_formatting.py
@@ -2,85 +2,36 @@
 
 from datetime import UTC, datetime
 
+import pytest
+
 from ember.core.status.time_format import format_time_ago
 
 
 class TestFormatTimeAgo:
     """Tests for format_time_ago function."""
 
-    def test_just_now_for_seconds(self) -> None:
-        """Test that recent timestamps show 'just now'."""
+    @pytest.mark.parametrize(
+        "seconds_ago, expected",
+        [
+            pytest.param(5, "just now", id="5-seconds"),
+            pytest.param(45, "just now", id="45-seconds"),
+            pytest.param(60, "1 min ago", id="1-minute"),
+            pytest.param(300, "5 min ago", id="5-minutes"),
+            pytest.param(3600, "1 hour ago", id="1-hour"),
+            pytest.param(7200, "2 hours ago", id="2-hours"),
+            pytest.param(86400, "1 day ago", id="1-day"),
+            pytest.param(172800, "2 days ago", id="2-days"),
+            pytest.param(7 * 86400, "1 week ago", id="1-week"),
+            pytest.param(14 * 86400, "2 weeks ago", id="2-weeks"),
+            pytest.param(30 * 86400, "1 month ago", id="1-month"),
+            pytest.param(60 * 86400, "2 months ago", id="2-months"),
+        ],
+    )
+    def test_format_time_ago(self, seconds_ago: int, expected: str) -> None:
+        """Test time formatting for various durations."""
         now = datetime.now(UTC)
-        # 5 seconds ago
-        timestamp = now.timestamp() - 5
-        assert format_time_ago(timestamp) == "just now"
-
-    def test_just_now_for_under_minute(self) -> None:
-        """Test that timestamps under 1 minute show 'just now'."""
-        now = datetime.now(UTC)
-        # 45 seconds ago
-        timestamp = now.timestamp() - 45
-        assert format_time_ago(timestamp) == "just now"
-
-    def test_one_minute_ago(self) -> None:
-        """Test that 1 minute shows singular form."""
-        now = datetime.now(UTC)
-        timestamp = now.timestamp() - 60
-        assert format_time_ago(timestamp) == "1 min ago"
-
-    def test_minutes_ago(self) -> None:
-        """Test that multiple minutes show plural form."""
-        now = datetime.now(UTC)
-        timestamp = now.timestamp() - 300  # 5 minutes
-        assert format_time_ago(timestamp) == "5 min ago"
-
-    def test_one_hour_ago(self) -> None:
-        """Test that 1 hour shows singular form."""
-        now = datetime.now(UTC)
-        timestamp = now.timestamp() - 3600  # 1 hour
-        assert format_time_ago(timestamp) == "1 hour ago"
-
-    def test_hours_ago(self) -> None:
-        """Test that multiple hours show plural form."""
-        now = datetime.now(UTC)
-        timestamp = now.timestamp() - 7200  # 2 hours
-        assert format_time_ago(timestamp) == "2 hours ago"
-
-    def test_one_day_ago(self) -> None:
-        """Test that 1 day shows singular form."""
-        now = datetime.now(UTC)
-        timestamp = now.timestamp() - 86400  # 1 day
-        assert format_time_ago(timestamp) == "1 day ago"
-
-    def test_days_ago(self) -> None:
-        """Test that multiple days show plural form."""
-        now = datetime.now(UTC)
-        timestamp = now.timestamp() - 172800  # 2 days
-        assert format_time_ago(timestamp) == "2 days ago"
-
-    def test_one_week_ago(self) -> None:
-        """Test that 7+ days switches to weeks."""
-        now = datetime.now(UTC)
-        timestamp = now.timestamp() - (7 * 86400)  # 7 days
-        assert format_time_ago(timestamp) == "1 week ago"
-
-    def test_weeks_ago(self) -> None:
-        """Test that multiple weeks show plural form."""
-        now = datetime.now(UTC)
-        timestamp = now.timestamp() - (14 * 86400)  # 14 days
-        assert format_time_ago(timestamp) == "2 weeks ago"
-
-    def test_one_month_ago(self) -> None:
-        """Test that 30+ days switches to months."""
-        now = datetime.now(UTC)
-        timestamp = now.timestamp() - (30 * 86400)  # 30 days
-        assert format_time_ago(timestamp) == "1 month ago"
-
-    def test_months_ago(self) -> None:
-        """Test that multiple months show plural form."""
-        now = datetime.now(UTC)
-        timestamp = now.timestamp() - (60 * 86400)  # 60 days
-        assert format_time_ago(timestamp) == "2 months ago"
+        timestamp = now.timestamp() - seconds_ago
+        assert format_time_ago(timestamp) == expected
 
     def test_none_returns_none(self) -> None:
         """Test that None input returns None."""


### PR DESCRIPTION
## Summary
Implements #434 - Adopts `pytest.mark.parametrize` across 5 high-duplication test files:

- **`test_model_registry.py`** - Parametrized model preset resolution (10 cases), embedder kwargs (5 cases), model info (4 cases), and cache preset resolution (3 cases)
- **`test_entities.py`** - Parametrized Query/Chunk/SearchResult validation, immutability, hash validation, score validation, line numbers, SyncMode, and isolated validators
- **`test_time_formatting.py`** - Collapsed 12 repetitive time-formatting tests into a single parametrized test with 12 cases
- **`test_sync_error_hints.py`** - Collapsed 10 `_get_targeted_sync_hint` tests into a single parametrized test with 10 cases
- **`test_config.py`** - Parametrized IndexConfig, SearchConfig, RedactionConfig, ModelConfig, and DisplayConfig validation tests

### Results
- **5 test files** now use `@pytest.mark.parametrize`
- **Net reduction of 48 LOC** (3218 -> 3170 across modified files)
- **Test cases increased** from 305 to 335 individual invocations (parametrize expands formerly-combined assertions)
- **All 1633 tests pass** (full suite)
- **Linter passes** (ruff check clean)

## Test plan
- [x] All 5 target files use `@pytest.mark.parametrize`
- [x] Net reduction in test LOC
- [x] No loss of test coverage (test cases increased)
- [x] All tests pass: `uv run pytest` (1633 passed)
- [x] Linter passes: `uv run ruff check .`